### PR TITLE
Children repo

### DIFF
--- a/R/module-repository.R
+++ b/R/module-repository.R
@@ -328,7 +328,7 @@ setMethod(
     if (!is.null(children)) {
       if (all(nzchar(children) & !is.na(children))) {
         tmp <- lapply(children, function(x) {
-          f <- if (is.null(childVersions[[x]])) {
+          f <- if (!is.null(childVersions[[x]])) {
             downloadModule(x, path = path, data = data, version = childVersions[[x]],
                            quickCheck = quickCheck, overwrite = overwrite)
           } else {

--- a/R/module-repository.R
+++ b/R/module-repository.R
@@ -329,10 +329,10 @@ setMethod(
       if (all(nzchar(children) & !is.na(children))) {
         tmp <- lapply(children, function(x) {
           f <- if (!is.null(childVersions[[x]])) {
-            downloadModule(x, path = path, data = data, version = childVersions[[x]],
+            downloadModule(x, path = path, repo = repo, data = data, version = childVersions[[x]],
                            quickCheck = quickCheck, overwrite = overwrite)
           } else {
-            downloadModule(x, path = path, data = data, quickCheck = quickCheck,
+            downloadModule(x, path = path,  repo = repo, data = data, quickCheck = quickCheck,
                            overwrite = overwrite)
           }
           files2 <<- append(files2, f[[1]])


### PR DESCRIPTION
downloadModule was getting children from the default repo, even when the parent was downloaded from a user-defined repo. This was causing a mismatch between children file versions (not true module versions) when they differed between the repos.

also, child versions were not being taken into account when they existed (typo?)