### PR TITLE
Change to pass data.table v1.12.0 please

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -133,7 +133,7 @@ saveFiles <- function(sim) {
     # don't need to save exactly same thing more than once - use data.table here because distinct
     # from dplyr does not do as expected
     outputs(sim) <- data.table(outputs(sim)) %>%
-      unique(., by = c("objectName", "saveTime", "file", "fun", "package", "arguments")) %>%
+      unique(., by = c("objectName", "saveTime", "file", "fun", "package")) %>%
       data.frame()
   }
 


### PR DESCRIPTION
Hi Alex,

data.table v1.12.0 is about to go to CRAN and revdep checking shows one fail in SpaDES.core.  I've checked this PR passes.  The 6th column of `by=` here is `"arguments"` which is type `list` which isn't supported by sorting/grouping/unique in data.table.  It worked before because data.table didn't look at the type of the column until it needed to.  In this case, the first few columns of `by=` were enough to establish the uniqueness and the subsequent columns weren't used.  The new version of data.table works a bit differently and all the column types are now checked up-front.

The status before this PR was : 
```
Quitting from lines 637-677 (ii-modules.Rmd) 
Error: processing vignette 'ii-modules.Rmd' failed with diagnostics:
Column 6 of by= (5) is type 'list', not yet supported
Execution halted

* checking PDF version of manual ... OK
* DONE

Status: 1 WARNING
See
  ‘/home/mdowle/build/revdeplib/SpaDES.core.Rcheck/00check.log’
for details.
```

Please could you update SpaDES.core on CRAN.  Either in advance or after data.table is there is fine too.

Thanks, Matt

