### PR TITLE
Fix roxygen2 issue with all/all.equal ambiguity

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -303,7 +303,8 @@ setMethod(
 #'
 #' @return See [base::all.equal()]
 #'
-#' @export
+#' @method all.equal simList
+#' @exportS3Method all.equal simList
 #' @importFrom reproducible .wrap
 all.equal.simList <- function(target, current, ...) {
   attr(target, ".Cache")$newCache <- NULL


### PR DESCRIPTION
You are affected by https://github.com/r-lib/roxygen2/issues/1587. Came across your package while trying to find a solution, so sharing what I found.