### PR TITLE
fixes invalid extent

### DIFF
--- a/R/module-define.R
+++ b/R/module-define.R
@@ -243,6 +243,8 @@ setMethod(
           ext(x$spatialExtent)
         }
       }
+    } else {
+      x$spatialExtent
     }
 
     x$timeframe <- if (is.null(x$timeframe) || any(is.na(x$timeframe))) {


### PR DESCRIPTION

With the development version of terra I get an error with SpaDES.core

```
library(SpaDES.core)
opts <- options("spades.moduleCodeChecks" = FALSE,
                "spades.useRequire" = FALSE)

path <- getSampleModules(tempdir())
sampleModules <- dir(path)
x <- moduleMetadata(sampleModules[3], path = path)
#Assuming sim is a module name
x$spatialExtent
Error: external pointer is not valid
```

With this fix that becomes 

```
x$spatialExtent
#SpatExtent : 0, 0, 0, 0 (xmin, xmax, ymin, ymax)
```

The reason that this was not detected earlier is that as.vector() still worked on the invalid pointer --- I am not quite sure why; I assume it is the class prototype extent which otherwise looks fine.
 
The problem still shows with 

```
new(".moduleDeps")
An object of class ".moduleDeps"
Slot "name":
character(0)

Slot "description":
character(0)

Slot "keywords":
character(0)

Slot "childModules":
character(0)

Slot "authors":
person()

Slot "version":
[1] ‘0.0.0’

Slot "spatialExtent":
Error: external pointer is not valid
```

I do not know why. Perhaps it is better to not initialize spatialExtent and set it after creation of an object?
