### PR TITLE
randomLandscapes sample module: drop NLMR dependency (#334)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,8 @@ Description: Provides the core framework for a discrete event system to
 URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
-Date: 2026-03-10
-Version: 3.0.4.9002
+Date: 2026-05-10
+Version: 3.0.4.9003
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # SpaDES.core (development version)
 
+* Sample module `randomLandscapes` (`inst/sampleModules/randomLandscapes`) no
+  longer requires `NLMR`. It now uses the new `type = "gaussian"` default of
+  `SpaDES.tools::neutralLandscapeMap()` (built-in, dependency-free) with a
+  per-layer `smooth` argument to control autocorrelation length. `NLMR`
+  removed from `reqdPkgs`; bumped `SpaDES.tools` requirement to `>= 2.1.1.9001`.
+  Step toward closing #334.
 * `Plots` now has `useCache` argument, which allows plotting to be cached; this is only relevant when `types` is file type, e.g., `"png"`
 * `restartSpades` now has default `numEvents = 1L` instead of `Inf`
 * if `options(spades.dotInputObjects = FALSE)`, then it will not do `.inputObjects` even 

--- a/inst/sampleModules/randomLandscapes/randomLandscapes.R
+++ b/inst/sampleModules/randomLandscapes/randomLandscapes.R
@@ -22,14 +22,14 @@ defineModule(sim, list(
     person(c("Eliot", "J", "B"), "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"))
   ),
-  version = list(randomLandscapes = "1.7.0"),
+  version = list(randomLandscapes = "1.7.1"),
   spatialExtent = terra::ext(rep(0, 4)),
   timeframe = as.POSIXlt(c(NA, NA)),
   timeunit = "year",
   citation = list(),
   documentation = list(),
-  reqdPkgs = list("ropensci/NLMR (>= 1.1.1)", "terra", "RColorBrewer", "reproducible (>= 2.0.2)",
-                  "SpaDES.tools (>= 2.0.0)"),
+  reqdPkgs = list("terra", "RColorBrewer", "reproducible (>= 2.0.2)",
+                  "SpaDES.tools (>= 2.1.1.9001)"),
   parameters = rbind(
     # defineParameter("inRAM", "logical", FALSE, TRUE, FALSE, "should the raster be stored in memory?"),
     defineParameter("nx", "numeric", 100L, 10L, 500L, "size of map (number of pixels) in the x dimension"),
@@ -106,31 +106,18 @@ Init <- function(sim) {
   ny <- Par$ny
   template <- rast(nrows = ny, ncols = nx, xmin = -nx / 2, xmax = nx / 2, ymin = -ny / 2, ymax = ny / 2)
 
-  ## Make dummy maps for testing of models
-  DEM <- SpaDES.tools::neutralLandscapeMap(template,
-                                           roughness = 0.3,
-                                           rand_dev = 10,
-                                           rescale = TRUE,
-                                           verbose = FALSE)
-
+  ## Make dummy maps for testing of models.
+  ## Uses the built-in 'gaussian' generator (no NLMR required).
+  ## `smooth` controls spatial autocorrelation: larger = smoother.
+  DEM <- SpaDES.tools::neutralLandscapeMap(template, smooth = 5L)
   DEM[] <- round(values(DEM), 1) * 300
   # terra::plot(DEM)
 
-  forestAge <- SpaDES.tools::neutralLandscapeMap(template,
-                                                 roughness = 0.7,
-                                                 rand_dev = 10,
-                                                 rescale = FALSE,
-                                                 verbose = FALSE)
-
+  forestAge <- SpaDES.tools::neutralLandscapeMap(template, smooth = 2L)
   forestAge[] <- round(values(forestAge), 1) * 10
   # terra::plot(forestAge)
 
-  percentPine <- SpaDES.tools::neutralLandscapeMap(template,
-                                                   roughness = 0.5,
-                                                   rand_dev = 10,
-                                                   rescale = TRUE,
-                                                   verbose = FALSE)
-
+  percentPine <- SpaDES.tools::neutralLandscapeMap(template, smooth = 3L)
   percentPine[] <- round(values(percentPine), 1)
   # terra::plot(percentPine)
 


### PR DESCRIPTION
## Summary

Removes \`NLMR\` from the bundled \`randomLandscapes\` sample module by switching to the new built-in \`type = "gaussian"\` generator added in [SpaDES.tools#104](https://github.com/PredictiveEcology/SpaDES.tools/pull/104).

Changes to \`inst/sampleModules/randomLandscapes/randomLandscapes.R\`:
- \`reqdPkgs\`: drops \`ropensci/NLMR (>= 1.1.1)\`; bumps \`SpaDES.tools\` minimum to \`>= 2.1.1.9001\` (the version that adds \`type = "gaussian"\`).
- The three \`neutralLandscapeMap()\` calls now use \`smooth = <N>\` to control spatial autocorrelation instead of the NLMR-specific \`roughness\`/\`rand_dev\`/\`rescale\`/\`verbose\` args. Per-layer values chosen to keep the demo visually similar: \`DEM\` smoother (smooth=5), \`forestAge\` less so (smooth=2), \`percentPine\` in between (smooth=3).
- Bumped module version to \`1.7.1\`.

## Why

\`NLMR\` is being deprecated / flagged for archive (ropensci/NLMR#116). This PR (together with [SpaDES.tools#104](https://github.com/PredictiveEcology/SpaDES.tools/pull/104)) closes the headline use of \`NLMR\` in the SpaDES stack: the \`randomLandscapes\` sample module that all the other sample modules and several vignettes depend on. Tracking issue: #334.

## Depends on

- [PredictiveEcology/SpaDES.tools#104](https://github.com/PredictiveEcology/SpaDES.tools/pull/104) (adds the \`"gaussian"\` type). **Must be merged first.**

## Test plan

- [x] End-to-end: \`simInit\` + \`spades\` on \`randomLandscapes\` with the new code produces all four expected landscape layers (\`DEM\`, \`forestAge\`, \`percentPine\`, \`habitatQuality\`) with sensible value ranges.
- [ ] Reviewer: visually compare a rendered \`randomLandscapes\` map to the old NLMR-based version.
- [ ] Follow-up: remove any remaining \`NLMR\` references in vignettes \`vignette_pkgs\` lists and in \`Suggests\` of \`DESCRIPTION\`.

## Out of scope for this PR

- The other two sample modules (\`fireSpread\`, \`caribouMovement\`) don't use \`NLMR\` directly — they depend on \`landscape\` produced by \`randomLandscapes\`, so they automatically pick up the change.
- Vignettes still mention \`NLMR\` in their \`vignette_pkgs\` lists; those can be cleaned in a small follow-up once both this PR and the SpaDES.tools one are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)