### PR TITLE
Drop NLMR dependency package-wide

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -124,7 +124,6 @@ jobs:
           cache-version: 2
           extra-packages: |
             any::rcmdcheck
-            NLMR=?ignore
           needs: check
 
       # Fallback: when setup-r-dependencies fails (most often a transient
@@ -148,11 +147,6 @@ jobs:
             install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
             pak::local_install_dev_deps(ask = FALSE, dependencies = TRUE)
             pak::pkg_install(c("any::rcmdcheck"), ask = FALSE)
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("ropensci/NLMR")
-        shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,13 +36,7 @@ jobs:
           extra-packages: |
             any::pkgdown
             local::.
-            NLMR=?ignore
           needs: website
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("ropensci/NLMR")
-        shell: Rscript {0}
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -56,12 +56,6 @@ jobs:
           cache-version: 2
           extra-packages: |
             any::covr
-            NLMR=?ignore
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("ropensci/NLMR")
-        shell: Rscript {0}
 
       - id: covr
         name: Test coverage

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -39,12 +39,6 @@ jobs:
           extra-packages: |
             any::cffr
             any::V8
-            NLMR=?ignore
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("ropensci/NLMR")
-        shell: Rscript {0}
 
       - name: Update CITATION.cff
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,9 +8,7 @@ Description: Provides the core framework for a discrete event system to
     Includes conditional scheduling, restart after interruption, packaging of
     reusable modules, tools for developing arbitrary automated workflows,
     automated interweaving of modules of different temporal resolution,
-    and tools for visualizing and understanding the within-project dependencies. 
-    The suggested package 'NLMR' can be installed from the repository 
-    (<https://PredictiveEcology.r-universe.dev>).
+    and tools for visualizing and understanding the within-project dependencies.
 URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
@@ -69,7 +67,6 @@ Suggests:
     lme4,
     logging,
     magrittr,
-    NLMR (>= 1.1.1),
     pkgload,
     png,
     RColorBrewer (>= 1.1-2),
@@ -84,7 +81,6 @@ Suggests:
     testthat (>= 1.0.2),
     withr
 Remotes:
-    ropensci/NLMR,
     PredictiveEcology/reproducible@development,
     PredictiveEcology/SpaDES.tools@spreadSpeed
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,15 @@
   per-layer `smooth` argument to control autocorrelation length. `NLMR`
   removed from `reqdPkgs`; bumped `SpaDES.tools` requirement to `>= 2.1.1.9001`.
   Step toward closing #334.
+* `NLMR` dependency fully removed from the package: dropped from `Suggests`
+  and `Remotes` in `DESCRIPTION`, removed from vignettes
+  (`i-introduction.Rmd`, `ii-modules.Rmd`, `iii-cache.Rmd`) and their
+  `vignette_pkgs` lists, removed from test helpers (`helper-initTests.R`'s
+  `sampleModReqdPkgs`) and from the `skip_if_not_installed("NLMR")` /
+  `skip_on_cran()` guards in `test-simulation.R` and
+  `test-module-deps-methods.R`. Mentions in `README.md` and `cran-comments.md`
+  removed. All neutral-landscape generation is now via
+  `SpaDES.tools::neutralLandscapeMap()`. Closes #334.
 * New module parameter `.useCacheArgs`: optional named list (keyed by event name) of extra arguments spliced into the per-event `reproducible::Cache()` call. Lets a developer pin a fixed `cacheId` so a pre-seeded cloud folder (`useCloud = TRUE`, `cloudFolderID = ...`) can short-circuit a deterministic event to a download. Falls through to existing defaults when absent. The `newModule()` template emits a commented-out opt-in example.
 * `Plots` now has `useCache` argument, which allows plotting to be cached; this is only relevant when `types` is file type, e.g., `"png"`
 * `restartSpades` now has default `numEvents = 1L` instead of `Inf`

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ and enable the user to include additional functionality by running user-built mo
 Includes conditional scheduling, restart after interruption, packaging of
 reusable modules, tools for developing arbitrary automated workflows,
 automated interweaving of modules of different temporal resolution,
-and tools for visualizing and understanding the within-project dependencies. 
-The suggested package `NLMR` can be installed from the repository 
-(<https://PredictiveEcology.r-universe.dev>).
+and tools for visualizing and understanding the within-project dependencies.
 
 **Website:** [https://SpaDES-core.PredictiveEcology.org](https://SpaDES-core.PredictiveEcology.org)
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -27,20 +27,7 @@ This also has many enhancemenets and addresses many minor bugfixes.
 
 ## R CMD check results
 
-There are no errors, or warnings in any of the above.
-
-There is one NOTE:
-
-1. The `NLMR` package in Suggests is optionally installed from our R-universe repository
-  (until the maintainers of that package are able to get it back on CRAN).
-  Instructions for installation are provided in the README, DESCRIPTION, and via a message to the user.
-  We believe this should satisfy the CRAN policy requirement regarding additional dependencies.
-
-        Suggests or Enhances not in mainstream repositories:
-          NLMR
-        Availability using Additional_repositories specification:
-          NLMR         yes   https://predictiveecology.r-universe.dev/
-
+There are no errors, warnings, or notes in any of the above.
 
 ## Downstream dependencies
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -18,7 +18,6 @@ Landis
 Matloff
 MiB
 Modularity
-NLMR
 Namespaced
 Namespacing
 NetLogo

--- a/inst/sampleModules/randomLandscapes/randomLandscapes.R
+++ b/inst/sampleModules/randomLandscapes/randomLandscapes.R
@@ -107,7 +107,7 @@ Init <- function(sim) {
   template <- rast(nrows = ny, ncols = nx, xmin = -nx / 2, xmax = nx / 2, ymin = -ny / 2, ymax = ny / 2)
 
   ## Make dummy maps for testing of models.
-  ## Uses the built-in 'gaussian' generator (no NLMR required).
+  ## Uses the built-in 'gaussian' generator in SpaDES.tools::neutralLandscapeMap.
   ## `smooth` controls spatial autocorrelation: larger = smoother.
   DEM <- SpaDES.tools::neutralLandscapeMap(template, smooth = 5L)
   DEM[] <- round(values(DEM), 1) * 300

--- a/tests/testthat/helper-initTests.R
+++ b/tests/testthat/helper-initTests.R
@@ -71,8 +71,7 @@ testInit <- function(libraries = character(), ask = FALSE, verbose,
   return(invisible(out))
 }
 
-sampleModReqdPkgs <- c("NLMR", # Only randomLandscapes
-                       "terra", "SpaDES.tools", "RColorBrewer", # randomLandscapes & fireSpread
+sampleModReqdPkgs <- c("terra", "SpaDES.tools", "RColorBrewer", # randomLandscapes & fireSpread
                        "sf", "CircStats") # caribouMovement
 
 testCode <- '

--- a/tests/testthat/test-module-deps-methods.R
+++ b/tests/testthat/test-module-deps-methods.R
@@ -114,18 +114,8 @@ test_that("defineModule correctly handles different inputs", {
 })
 
 test_that("depsEdgeList and depsGraph work", {
-  skip_on_cran() # requires installation of NLMR, from a Git Repo
   testInit(sampleModReqdPkgs)
 
-  origRepos <- getOption("repos")
-  # print(origRepos)
-  if (any(unname(origRepos) == "@CRAN@")) {
-    suppressMessages(utils::chooseCRANmirror(ind = 1))
-    on.exit({
-      options(repos = origRepos)
-      print(getOption("repos"))
-    } , add = TRUE)
-  }
   times <- list(start = 0.0, end = 10)
   npb <- "nPixelsBurned"
   params <- list(

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -303,8 +303,6 @@ test_that("spades calls - diff't signatures", {
 })
 
 test_that("simInit with R subfolder scripts", {
-  skip_if_not_installed("NLMR")
-
   testInit()
 
   newModule("child1", ".", open = FALSE)

--- a/vignettes/i-introduction.Rmd
+++ b/vignettes/i-introduction.Rmd
@@ -22,7 +22,7 @@ editor_options:
 
 ```{r setup, include=FALSE}
 # List the vignette-only packages this file *uses*:
-vignette_pkgs <- c("SpaDES.tools", "NLMR")
+vignette_pkgs <- c("SpaDES.tools")
 
 # Helper that checks availability without attaching:
 has_pkgs <- function(pkgs) all(vapply(pkgs, requireNamespace, quietly = TRUE, FUN.VALUE = logical(1)))
@@ -149,11 +149,10 @@ This demo loads three sample modules provided with the packages: 1) `randomLands
 These sample modules, respectively, highlight several keys features of the package: 1) the import, update, and plotting of raster map layers; 2) the computational speed of modeling spatial spread processes; and 3) the implementation of an agent-based (a.k.a., individual-based) model.
 
 ```{r SpaDES-demo, eval=FALSE, echo=TRUE}
-## NOTE: Suggested packages SpaDES.tools and NLMR packages must be installed
+## NOTE: Suggested package SpaDES.tools must be installed
 #install.packages("SpaDES.tools")
-#install.packages("NLMR", repos = "https://predictiveecology.r-universe.dev/")
 
-knitr::opts_chunk$set(eval = requireNamespace("SpaDES.tools") && !requireNamespace("NLMR"))
+knitr::opts_chunk$set(eval = requireNamespace("SpaDES.tools"))
 
 library(SpaDES.core)
 

--- a/vignettes/ii-modules.Rmd
+++ b/vignettes/ii-modules.Rmd
@@ -21,7 +21,7 @@ editor_options:
 
 ```{r setup, include=FALSE}
 # Packages used in this vignette
-vignette_pkgs <- c("DiagrammeR", "NLMR", "SpaDES.tools", "knitr", "CircStats")
+vignette_pkgs <- c("DiagrammeR", "SpaDES.tools", "knitr", "CircStats")
 
 # Check availability without attaching
 hasSuggests <- function(pkgs) all(vapply(pkgs, requireNamespace, quietly = TRUE, FUN.VALUE = logical(1)))
@@ -397,9 +397,8 @@ Note that modules need not be inter-dependent on one another: module B may depen
 To view the dependencies for a simulation:
 
 ```{r module-object-diagrams, echo=TRUE, message=FALSE, fig.width=7}
-## NOTE: Suggested packages SpaDES.tools and NLMR packages must be installed
+## NOTE: Suggested package SpaDES.tools must be installed
 #install.packages("SpaDES.tools")
-#install.packages("NLMR", repos = "https://predictiveecology.r-universe.dev/")
 
 library(SpaDES.core)
 

--- a/vignettes/iii-cache.Rmd
+++ b/vignettes/iii-cache.Rmd
@@ -19,7 +19,7 @@ editor_options:
 
 ```{r setup, include=FALSE}
 # Packages used in this vignette
-vignette_pkgs <- c("knitr", "NLMR", "RColorBrewer", "SpaDES.tools")
+vignette_pkgs <- c("knitr", "RColorBrewer", "SpaDES.tools")
 
 # Check availability without attaching
 has_pkgs <- function(pkgs) all(vapply(pkgs, requireNamespace, quietly = TRUE, FUN.VALUE = logical(1)))


### PR DESCRIPTION
## Summary

- Removes the `NLMR` package as a Suggests/Remotes dependency now that `SpaDES.tools::neutralLandscapeMap()` (built-in `gaussian` generator) covers all neutral-landscape use cases.
- Strips `NLMR` from `DESCRIPTION` (Suggests + Remotes + Description text), `README.md`, `cran-comments.md` (the resulting CRAN NOTE block), all three vignettes (`i-introduction.Rmd`, `ii-modules.Rmd`, `iii-cache.Rmd`) and their `vignette_pkgs` lists, test helpers (`sampleModReqdPkgs` in `helper-initTests.R`), the `skip_if_not_installed("NLMR")` and `skip_on_cran()` guards in `test-simulation.R` and `test-module-deps-methods.R`, the sample-module comment in `randomLandscapes.R`, `inst/WORDLIST`, and the `NLMR=?ignore` / `pak::pkg_install("ropensci/NLMR")` blocks in all four GitHub workflows.
- Adds a NEWS.md bullet documenting the full removal.

## Test plan

- [x] `R CMD check` passes locally (no more NLMR-related NOTE)
- [x] CI: `R-CMD-check`, `test-coverage`, `pkgdown`, `update-citation-cff` workflows all green without the NLMR install step
- [x] Vignettes knit when `SpaDES.tools` is installed but `NLMR` is not
- [x] `tests/testthat/test-module-deps-methods.R::depsEdgeList and depsGraph work` runs on CRAN-like envs (no longer skipped)
- [x] `tests/testthat/test-simulation.R::simInit with R subfolder scripts` runs without NLMR installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)