### PR TITLE
codecheck: clarify in_no_default note wording

### DIFF
--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -81,11 +81,17 @@
 
 ## Build a generic finding for a "declared but unused" object (no source pos).
 .cc_declaredUnused <- function(id, severity, module, name, kind) {
+  message <- switch(
+    id,
+    in_no_default = sprintf("input '%s' has no fallback default in .inputObjects(); the simulation will fail unless it is supplied via simInit() or another module",
+                            name),
+    sprintf("'%s' is declared in metadata %s but is not %s in module code",
+            name, kind,
+            if (grepl("unused$", id)) "used" else "assigned")
+  )
   .cc_finding(id = id, severity = severity, module = module,
               where = "<metadata only>", name = name,
-              message = sprintf("'%s' is declared in metadata %s but is not %s in module code",
-                                name, kind,
-                                if (grepl("unused$", id)) "used" else "assigned"),
+              message = message,
               suggestion = switch(
                 id,
                 out_declared_unused   = sprintf("either remove '%s' from outputObjects, or add `sim$%s <- ...` in an event function",
@@ -94,7 +100,7 @@
                                                 name, name),
                 param_declared_unused = sprintf("either remove `defineParameter('%s', ...)` or add `Par$%s` (or P(sim)$%s) in module code",
                                                 name, name, name),
-                in_no_default         = sprintf("add `if (!suppliedElsewhere('%s', sim)) sim$%s <- <default>` to .inputObjects()",
+                in_no_default         = sprintf("if a default is appropriate, add `if (!suppliedElsewhere('%s', sim)) sim$%s <- <default>` to .inputObjects(); otherwise ignore",
                                                 name, name),
                 NA_character_
               ))


### PR DESCRIPTION
## Summary
- The `in_no_default` rule in `codeCheckModule()` was reusing the generic "declared but unused" message, which read *"is declared in metadata inputObjects but is not assigned in module code"*. That conflates `expectsInput` semantics (the module *consumes* the object) with `createsOutput` semantics (the module *assigns* `sim\$x <- ...`), so users reasonably read the note as a false positive when their module legitimately reads the input.
- The rule itself remains useful (it asks: does `.inputObjects()` provide a fallback default?). This PR gives it its own accurate message and softens the suggestion to make clear the note is safely ignorable when the input is meant to come from another module or `simInit()`.

### Before
```
[note]  'caribouLoc' is declared in metadata inputObjects but is not assigned in module code
↪ add ` if (!suppliedElsewhere('caribouLoc', sim)) sim\$caribouLoc <- <default>` to .inputObjects()
```

### After
```
[note]  input 'caribouLoc' has no fallback default in .inputObjects(); the simulation will fail unless it is supplied via simInit() or another module
↪ if a default is appropriate, add ` if (!suppliedElsewhere('caribouLoc', sim)) sim\$caribouLoc <- <default>` to .inputObjects(); otherwise ignore
```

## Test plan
- [x] Run `codeCheckModule()` against a module that declares `expectsInput()` without an `.inputObjects()` default and confirm the new wording.
- [x] Run existing `tests/testthat/test-codecheck.R` to ensure no test relied on the old message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)