### PR TITLE
fix(paths): tolerate NULL reproducible.cachePath (development CI regression)

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -71,6 +71,22 @@ spPaths <- c(corePaths, tmpPaths)
 #' Paths # shows change
 #' }
 #'
+## reproducible (>= 3.1.1.9002) leaves options("reproducible.cachePath") unset
+## (NULL) until first use, so setup layers can detect "unset". SpaDES is such a
+## layer: resolve a default here -- mirroring reproducible's own temp-cache
+## fallback (file.path(reproducible.tempPath, "cache")) -- so checkPath() never
+## receives NULL.
+.cachePathOrDefault <- function() {
+  cp <- .getOption("reproducible.cachePath")
+  if (is.null(cp)) {
+    tempPath <- getOption("reproducible.tempPath",
+                          file.path(tempdir(), "reproducible"))
+    file.path(tempPath, "cache")
+  } else {
+    cp
+  }
+}
+
 .paths <- function() {
   if (!is.null(.getOption("spades.cachePath"))) {
     message(
@@ -81,7 +97,7 @@ spPaths <- c(corePaths, tmpPaths)
   }
 
   list(
-    cachePath = .getOption("reproducible.cachePath"), # nolint
+    cachePath = .cachePathOrDefault(), # nolint
     inputPath = getOption("spades.inputPath"), # nolint
     modulePath = getOption("spades.modulePath"), # nolint
     outputPath = getOption("spades.outputPath"), # nolint
@@ -118,7 +134,7 @@ setPaths <- function(cachePath, inputPath, modulePath, outputPath, rasterPath, s
     TP = FALSE
   )
   if (missing(cachePath)) {
-    cachePath <- .getOption("reproducible.cachePath") # nolint
+    cachePath <- .cachePathOrDefault() # nolint
     defaults$CP <- TRUE
   }
   if (missing(inputPath)) {


### PR DESCRIPTION
## Why development went red
`development` CI started failing on 2026-05-19 (between runs `ff70a345` green and `7528ad6b` red). The one SpaDES.core commit in that window was a test-teardown change — not the cause. The actual trigger is in **reproducible@development**, which SpaDES.core CI installs:

- reproducible commit `1fd4465a` (3.1.1.9002, "resolve reproducible.cachePath lazily on first use") changed `options("reproducible.cachePath")` to default to **`NULL`** instead of a session-tempdir path.

SpaDES.core read that option directly in `.paths()` and `setPaths()` and passed it straight to `checkPath()`, which errors on `NULL` ("Invalid path: cannot be NULL"). That breaks `simInit()` whenever `cachePath` isn't explicitly set — including the `ii-modules.Rmd` / `iii-cache.Rmd` vignettes, which is what fails the check.

## Fix
Add `.cachePathOrDefault()`: when `options("reproducible.cachePath")` is `NULL`, fall back to reproducible's own temp-cache location (`file.path(reproducible.tempPath, "cache")`); otherwise use the set value. Route both read sites (`.paths()`, `setPaths()`) through it.

Users who set `reproducible.cachePath` explicitly (e.g. via `SpaDES.project::setupProject()`) see no change — this only supplies a default when the option is unset, matching pre-3.1.1.9002 behavior.

## Test plan
- [x] Local repro: `simInit(paths = list(modulePath = …))` with `options(reproducible.cachePath = NULL)` previously errored; now resolves `sim@paths$cachePath` to the temp-cache dir.
- [ ] CI: vignettes build; full check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)