### PR TITLE
feat(codecheck): collapse same-issue hits under one header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-05-21
-Version: 3.1.2.9001
+Version: 3.1.2.9002
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 ## Bug fixes
 
 * Code check: `params(sim)[[currentModule(sim)]]$x` now resolves to the current module instead of being reported as an unresolved param accessor.
+* Code check: no longer a false `out_declared_unused` (or `in_declared_unused`) when the assignment lives in a function wrapped in `compiler::cmpfun()` / `Cache()` etc.; the enclosing function is now found through such wrapper calls.
 
 # SpaDES.core 3.1.2.9001
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Enhancements
 
 * Code check report: hits of the same issue (e.g. several `scale()`/`levels()` ambiguities, or several inputs with no default) are collapsed under one header with one line per location, instead of repeating the full message + suggestion per hit.
+* Code check report now tags each finding with its rule id (e.g. `[conflicting_fn_unqualified]`) so it can be copied into a `# nolint`/`codeChecksIgnore`; the group name (e.g. `globals`) is also accepted there. Rule catalogue documented in `?codeCheckModule`.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 ## Bug fixes
 
 * Code check: `params(sim)[[currentModule(sim)]]$x` now resolves to the current module instead of being reported as an unresolved param accessor.
-* Code check: no longer a false `out_declared_unused` (or `in_declared_unused`) when the assignment lives in a function wrapped in `compiler::cmpfun()` / `Cache()` etc.; the enclosing function is now found through such wrapper calls.
+* Code check: no longer a false `out_declared_unused` (or `in_declared_unused`) when the assignment lives in a function wrapped in `compiler::cmpfun()` / `Cache()` etc.; the enclosing function is now found through such wrapper calls. Anonymous callbacks (e.g. `lapply(x, function(i) sim[[i]])`) are not misattributed, so a dynamic `sim[[var]]` inside one is no longer reported as an unresolved accessor.
 
 # SpaDES.core 3.1.2.9001
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 
 ## Bug fixes
 
+* Code check: `in_no_default` no longer fires for an input that is handled via a `suppliedElsewhere("x", sim)` guard (whether followed by a default assignment or a `stop()`), nor for one asserted with `# nolint: vars` at a dynamic `.inputObjects()` assignment.
 * Code check: `params(sim)[[currentModule(sim)]]$x` now resolves to the current module instead of being reported as an unresolved param accessor.
 * Code check: no longer a false `out_declared_unused` (or `in_declared_unused`) when the assignment lives in a function wrapped in `compiler::cmpfun()` / `Cache()` etc.; the enclosing function is now found through such wrapper calls. Anonymous callbacks (e.g. `lapply(x, function(i) sim[[i]])`) are not misattributed, so a dynamic `sim[[var]]` inside one is no longer reported as an unresolved accessor.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 ## New features
 
 * Code check findings can now be silenced: an inline `# nolint` (or `# nolint: <rule_id>`) comment in the module source (developers), `options(spades.codeChecksIgnore = list(<rule_id> = c("obj", ...)))` (users), and `options(spades.moduleCodeChecks = list(disable = ...))` (now actually wired). See `?codeCheckModule`.
+* Code check: new `reqdPkgs` rules — `reqd_pkg_duplicate` (a package declared 2+ times, especially with conflicting source/version), `reqd_pkg_undeclared` (a `pkg::fn` whose package is not in `reqdPkgs`), and `reqd_pkg_no_source` (best-effort, info: bare calls with no apparent source among the declared packages, only when all are installed).
+* Code check: `# nolint: vars a, b` asserts that objects `a`, `b` are produced at a dynamic bulk-assign line (e.g. `list2env(someList, envir(sim))`) whose names can't be seen statically, so they aren't reported as `out_declared_unused`.
+* Code check: `paramCheckOtherMods(sim, "x")` marks `"x"` as a used parameter.
 
 ## Enhancements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Code check report: hits of the same issue (e.g. several `scale()`/`levels()` ambiguities, or several inputs with no default) are collapsed under one header with one line per location, instead of repeating the full message + suggestion per hit.
 
+## Bug fixes
+
+* Code check: `params(sim)[[currentModule(sim)]]$x` now resolves to the current module instead of being reported as an unresolved param accessor.
+
 # SpaDES.core 3.1.2.9001
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # SpaDES.core 3.1.2.9002
 
+## New features
+
+* Code check findings can now be silenced: an inline `# nolint` (or `# nolint: <rule_id>`) comment in the module source (developers), `options(spades.codeChecksIgnore = list(<rule_id> = c("obj", ...)))` (users), and `options(spades.moduleCodeChecks = list(disable = ...))` (now actually wired). See `?codeCheckModule`.
+
 ## Enhancements
 
 * Code check report: hits of the same issue (e.g. several `scale()`/`levels()` ambiguities, or several inputs with no default) are collapsed under one header with one line per location, instead of repeating the full message + suggestion per hit.

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Code check report: hits of the same issue (e.g. several `scale()`/`levels()` ambiguities, or several inputs with no default) are collapsed under one header with one line per location, instead of repeating the full message + suggestion per hit.
 * Code check report now tags each finding with its rule id (e.g. `[conflicting_fn_unqualified]`) so it can be copied into a `# nolint`/`codeChecksIgnore`; the group name (e.g. `globals`) is also accepted there. Rule catalogue documented in `?codeCheckModule`.
+* Code check: `unresolved_accessor` now explains that dynamic `get()`/`mget()`-family and `sim[[<var>]]` access cannot be checked statically and prompts the developer to add `# nolint: unresolved_accessor` if intentional.
+* Code check: every suggestion now ends with how to acknowledge the finding (`otherwise add # nolint: <rule_id>`) instead of a vague "otherwise ignore".
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# SpaDES.core 3.1.2.9002
+
+## Enhancements
+
+* Code check report: hits of the same issue (e.g. several `scale()`/`levels()` ambiguities, or several inputs with no default) are collapsed under one header with one line per location, instead of repeating the full message + suggestion per hit.
+
 # SpaDES.core 3.1.2.9001
 
 ## New features

--- a/R/codecheck-api.R
+++ b/R/codecheck-api.R
@@ -25,6 +25,27 @@
 #' `options(spades.codeCheckEngine = "v2")` (the default). The legacy v1
 #' checker is still available via `options(spades.codeCheckEngine = "v1")`.
 #'
+#' @section Silencing findings:
+#' Individual findings can be suppressed three ways (all honoured both here and
+#' during `simInit()`):
+#' \itemize{
+#'   \item **Inline `# nolint` (module developer).** Put a `# nolint` comment on
+#'     the offending source line to silence every rule there, or
+#'     `# nolint: <rule_id>[, <rule_id>]` to silence only specific rules. For a
+#'     metadata finding such as `in_no_default`, place it anywhere within the
+#'     `expectsInput()` / `createsOutput()` / `defineParameter()` declaration,
+#'     e.g. `expectsInput("cloudFolderID", "character", desc = "...") # nolint: in_no_default`.
+#'     This travels with the module and documents the intent.
+#'   \item **`options(spades.codeChecksIgnore = ...)` (module user).** A named
+#'     list keyed by rule id whose values are object names to ignore, e.g.
+#'     `options(spades.codeChecksIgnore = list(in_no_default = c("cloudFolderID", "ecoregionRst")))`.
+#'     Lets someone running another author's module quiet specific findings
+#'     without editing its source.
+#'   \item **`options(spades.moduleCodeChecks = list(disable = ...))`.** Disable
+#'     whole rules by id (or restrict with `enable = ...`); see
+#'     `names(SpaDES.core:::.CC_RULES)` for the catalogue.
+#' }
+#'
 #' `codeCheckModule()` checks a single module. `codeCheckModules()` is the
 #' vectorized form: it runs `codeCheckModule()` on each path in `paths` and
 #' returns a list of findings named by module. When `paths` is not supplied it

--- a/R/codecheck-api.R
+++ b/R/codecheck-api.R
@@ -151,6 +151,8 @@ codeCheckModules <- function(paths = dir(getOption("spades.modulePath"), full.na
     otherModuleParams = .cc_otherModuleParams(sim, m),
     moduleEnv = modEnv,
     codetoolsOpts = .cc_codetoolsOpts(),
+    reqdPkgs = .cc_reqdPkgsFromDep(dep, file = if (file.exists(mainFile)) mainFile else NA_character_),
+    mainFile = if (file.exists(mainFile)) mainFile else NA_character_,
     files = files
   )
 
@@ -225,8 +227,45 @@ codeCheckModules <- function(paths = dir(getOption("spades.modulePath"), full.na
     inputs  = .cc_namesOfArg(doc, "expectsInput", "objectName"),
     outputs = .cc_namesOfArg(doc, "createsOutput", "objectName"),
     params  = .cc_namesOfArg(doc, "defineParameter", "name"),
-    otherModuleParams = list()
+    otherModuleParams = list(),
+    reqdPkgs = .cc_reqdPkgsFromSource(doc, file = mainFile),
+    mainFile = mainFile
   )
+}
+
+## Harvest the `reqdPkgs` list from a `defineModule()` block. Returns a
+## data.frame(spec, pkg, file, line): `spec` is the raw entry (e.g.
+## "PredictiveEcology/SpaDES.core@branch (>= 3.0.4)"), `pkg` the bare package
+## name via Require::extractPkgName(). Empty data.frame if none found.
+.cc_reqdPkgsFromSource <- function(doc, file = NA_character_) {
+  empty <- data.frame(spec = character(), pkg = character(),
+                      file = character(), line = integer(),
+                      stringsAsFactors = FALSE)
+  valExpr <- xml2::xml_find_first(
+    doc, "//SYMBOL_SUB[text()='reqdPkgs']/following-sibling::expr[1]")
+  if (length(valExpr) == 0) return(empty)
+  strs <- xml2::xml_find_all(valExpr, ".//STR_CONST")
+  if (length(strs) == 0) return(empty)
+  spec <- gsub('^["\']|["\']$', "", xml2::xml_text(strs))
+  pkg <- tryCatch(Require::extractPkgName(spec), error = function(e) spec)
+  data.frame(spec = spec, pkg = pkg, file = file %||% NA_character_,
+             line = as.integer(xml2::xml_attr(strs, "line1")),
+             stringsAsFactors = FALSE)
+}
+
+## Same as .cc_reqdPkgsFromSource() but from an already-parsed module
+## dependency object (simInit path). `dep@reqdPkgs` is an unevaluated list of
+## strings; line numbers aren't available, so `line` is NA.
+.cc_reqdPkgsFromDep <- function(dep, file = NA_character_) {
+  empty <- data.frame(spec = character(), pkg = character(),
+                      file = character(), line = integer(),
+                      stringsAsFactors = FALSE)
+  spec <- tryCatch(unlist(eval(dep@reqdPkgs)), error = function(e) NULL)
+  spec <- spec[nzchar(spec)]
+  if (length(spec) == 0) return(empty)
+  pkg <- tryCatch(Require::extractPkgName(spec), error = function(e) spec)
+  data.frame(spec = spec, pkg = pkg, file = file %||% NA_character_,
+             line = NA_integer_, stringsAsFactors = FALSE)
 }
 
 ## Find first positional or named arg `argName` of every `fnName(...)` call

--- a/R/codecheck-api.R
+++ b/R/codecheck-api.R
@@ -74,6 +74,12 @@
 #'     not be resolved statically).
 #'   \item **codetools** — `codetools` (findings relayed from
 #'     `codetools::checkUsageEnv`).
+#'   \item **reqdPkgs** — `reqd_pkg_duplicate` (a package declared more than
+#'     once in `reqdPkgs`, especially with conflicting source/version),
+#'     `reqd_pkg_undeclared` (a `pkg::fn` whose `pkg` is not in `reqdPkgs`),
+#'     `reqd_pkg_no_source` (best-effort, info: bare calls with no apparent
+#'     source among the declared packages — only when all declared packages are
+#'     installed).
 #' }
 #'
 #' `codeCheckModule()` checks a single module. `codeCheckModules()` is the

--- a/R/codecheck-api.R
+++ b/R/codecheck-api.R
@@ -26,24 +26,49 @@
 #' checker is still available via `options(spades.codeCheckEngine = "v1")`.
 #'
 #' @section Silencing findings:
-#' Individual findings can be suppressed three ways (all honoured both here and
-#' during `simInit()`):
+#' Each finding in the printed report is tagged with its **rule id** in
+#' brackets, e.g. `[conflicting_fn_unqualified]`; that id (or the `• <group>`
+#' name it is printed under) is what you reference to silence it. Findings can
+#' be suppressed three ways (all honoured both here and during `simInit()`):
 #' \itemize{
 #'   \item **Inline `# nolint` (module developer).** Put a `# nolint` comment on
 #'     the offending source line to silence every rule there, or
-#'     `# nolint: <rule_id>[, <rule_id>]` to silence only specific rules. For a
+#'     `# nolint: <rule_id>[, <rule_id>]` to silence only specific rules (a
+#'     group name such as `globals` is accepted in place of a rule id). For a
 #'     metadata finding such as `in_no_default`, place it anywhere within the
 #'     `expectsInput()` / `createsOutput()` / `defineParameter()` declaration,
 #'     e.g. `expectsInput("cloudFolderID", "character", desc = "...") # nolint: in_no_default`.
 #'     This travels with the module and documents the intent.
 #'   \item **`options(spades.codeChecksIgnore = ...)` (module user).** A named
-#'     list keyed by rule id whose values are object names to ignore, e.g.
+#'     list keyed by rule id (or group name) whose values are object names to
+#'     ignore, e.g.
 #'     `options(spades.codeChecksIgnore = list(in_no_default = c("cloudFolderID", "ecoregionRst")))`.
 #'     Lets someone running another author's module quiet specific findings
 #'     without editing its source.
 #'   \item **`options(spades.moduleCodeChecks = list(disable = ...))`.** Disable
-#'     whole rules by id (or restrict with `enable = ...`); see
-#'     `names(SpaDES.core:::.CC_RULES)` for the catalogue.
+#'     whole rules by id (or restrict with `enable = ...`).
+#' }
+#'
+#' @section Rule catalogue:
+#' The rule ids (printed in brackets in the report), grouped by the bucket they
+#' appear under:
+#' \itemize{
+#'   \item **inputObjects** — `in_declared_unused` (declared input never used),
+#'     `in_used_undeclared` (`sim$x` read but not in `inputObjects`),
+#'     `in_no_default` (declared input has no default in `.inputObjects()`).
+#'   \item **outputObjects** — `out_declared_unused` (declared output never
+#'     assigned), `out_used_undeclared` (`sim$x <-` but not in `outputObjects`).
+#'   \item **parameters** — `param_declared_unused`, `param_used_undeclared`,
+#'     `param_used_other_module`.
+#'   \item **module functions** — `must_return_sim` (a `doEvent.*` must return
+#'     `sim`), `must_assign_to_sim`, `module_named_object` (`sim$<module>`
+#'     collides with the module name), `clashing_module_fn`.
+#'   \item **globals** — `conflicting_fn_unqualified` (a bare function name
+#'     collides with a `raster::` namesake; qualify it, e.g. `raster::scale`).
+#'   \item **unresolved** — `unresolved_accessor` (an accessor whose name could
+#'     not be resolved statically).
+#'   \item **codetools** — `codetools` (findings relayed from
+#'     `codetools::checkUsageEnv`).
 #' }
 #'
 #' `codeCheckModule()` checks a single module. `codeCheckModules()` is the

--- a/R/codecheck-api.R
+++ b/R/codecheck-api.R
@@ -49,6 +49,11 @@
 #'     whole rules by id (or restrict with `enable = ...`).
 #' }
 #'
+#' A related developer hint is `# nolint: vars a, b`: placed on a dynamic
+#' bulk-assign line whose names can't be seen statically (e.g.
+#' `list2env(someList, envir(sim))`), it asserts that objects `a`, `b` are
+#' produced there, so they aren't reported as `out_declared_unused`.
+#'
 #' @section Rule catalogue:
 #' The rule ids (printed in brackets in the report), grouped by the bucket they
 #' appear under:

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -114,14 +114,32 @@
     "ancestor::expr[FUNCTION][1]")
   if (length(ancs) == 0) return(NA_character_)
   fnExpr <- ancs[[length(ancs)]]
-  ## The function definition expr is typically the RHS of a top-level
-  ## `name <- function(...) {...}` assignment. The LHS SYMBOL is two siblings
-  ## back: <expr><SYMBOL>name</SYMBOL></expr><LEFT_ASSIGN>...<expr>function...
-  parent <- xml2::xml_parent(fnExpr)
-  if (xml2::xml_name(parent) != "expr") return(NA_character_)
-  lhs <- xml2::xml_find_first(parent, "expr[1]/SYMBOL")
-  if (length(lhs) == 0 || is.na(xml2::xml_text(lhs))) return(NA_character_)
-  xml2::xml_text(lhs)
+  ## The function-def expr is usually the RHS of a `name <- function(...) {...}`
+  ## assignment, but it may be wrapped in one or more calls, e.g.
+  ## `name <- compiler::cmpfun(function(...) {...})` or `Cache(function(...))`.
+  ## Walk up through such wrappers to the binding assignment. Stop (returning
+  ## NA) if we reach another function boundary first -- an anonymous function in
+  ## an outer function body must not be misattributed to that outer function.
+  cur <- fnExpr
+  repeat {
+    parent <- xml2::xml_parent(cur)
+    if (length(parent) == 0 || xml2::xml_name(parent) != "expr") {
+      return(NA_character_)
+    }
+    knames <- xml2::xml_name(xml2::xml_children(parent))
+    if (any(knames %in% c("LEFT_ASSIGN", "EQ_ASSIGN"))) {
+      lhs <- xml2::xml_find_first(parent, "expr[1]/SYMBOL")
+      if (length(lhs) > 0 && !is.na(xml2::xml_text(lhs))) return(xml2::xml_text(lhs))
+      return(NA_character_)
+    }
+    if (any(knames == "RIGHT_ASSIGN")) {
+      rhs <- xml2::xml_find_first(parent, "expr[last()]/SYMBOL")
+      if (length(rhs) > 0 && !is.na(xml2::xml_text(rhs))) return(xml2::xml_text(rhs))
+      return(NA_character_)
+    }
+    if (any(knames == "FUNCTION")) return(NA_character_)
+    cur <- parent
+  }
 }
 
 ## Is `node` (an expr) the LHS of an assignment? An expr is an LHS iff its

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -561,5 +561,62 @@
     uses[[length(uses) + 1]] <- .cc_collect_assignToSim(p)
     uses[[length(uses) + 1]] <- .cc_collect_globalsConflicts(p)
   }
-  do.call(rbind, uses)
+  out <- do.call(rbind, uses)
+  ## Attach suppression context so rules can honour inline `# nolint` markers.
+  ## (Carried as attributes; read by .cc_runRules before `out` is subset.)
+  attr(out, "nolint")    <- do.call(rbind, lapply(parses, .cc_collectNolint))
+  attr(out, "declLines") <- do.call(rbind, lapply(parses, .cc_collectDeclLines))
+  out
+}
+
+## Collect inline `# nolint` directives from the source comments. A bare
+## `# nolint` suppresses every rule on that line; `# nolint: id1, id2`
+## suppresses only the listed rule ids. Returns a data.frame(file, line,
+## rules) where `rules` is a list-column (NA = blanket), or NULL if none.
+.cc_collectNolint <- function(parsed) {
+  doc <- parsed$doc; file <- parsed$file
+  comments <- xml2::xml_find_all(doc, "//COMMENT")
+  out <- list()
+  for (cm in comments) {
+    txt <- xml2::xml_text(cm)
+    m <- regmatches(txt, regexec("#+\\s*nolint\\b\\s*(?::\\s*(.*))?$", txt,
+                                 ignore.case = TRUE))[[1]]
+    if (length(m) == 0) next
+    rulesStr <- if (length(m) >= 2) trimws(m[2]) else ""
+    rules <- if (nzchar(rulesStr)) {
+      trimws(strsplit(rulesStr, "[,[:space:]]+")[[1]])
+    } else NA_character_
+    out[[length(out) + 1]] <- data.frame(
+      file = file %||% NA_character_,
+      line = as.integer(xml2::xml_attr(cm, "line1")),
+      rules = I(list(rules)), stringsAsFactors = FALSE)
+  }
+  if (length(out) == 0) return(NULL)
+  do.call(rbind, out)
+}
+
+## Record the source line span of each metadata declaration
+## (expectsInput/createsOutput/defineParameter), keyed by object name, so a
+## `# nolint` placed anywhere within a (possibly multi-line) declaration can
+## suppress the corresponding metadata-only finding. Returns NULL if none.
+.cc_collectDeclLines <- function(parsed) {
+  doc <- parsed$doc; file <- parsed$file
+  spec <- list(expectsInput = "objectName", createsOutput = "objectName",
+               defineParameter = "name")
+  out <- list()
+  for (fnName in names(spec)) {
+    calls <- xml2::xml_find_all(
+      doc, sprintf("//expr[expr/SYMBOL_FUNCTION_CALL[text()='%s']]", fnName))
+    for (cal in calls) {
+      val <- .cc_argValueStr(cal, spec[[fnName]])
+      if (is.na(val)) next
+      out[[length(out) + 1]] <- data.frame(
+        name = val, file = file %||% NA_character_,
+        line1 = as.integer(xml2::xml_attr(cal, "line1")),
+        line2 = as.integer(xml2::xml_attr(cal, "line2")),
+        stringsAsFactors = FALSE)
+    }
+  }
+  if (length(out) == 0) return(NULL)
+  do.call(rbind, out)
 }

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -591,6 +591,7 @@
     uses[[length(uses) + 1]] <- .cc_collect_returnSim(p)
     uses[[length(uses) + 1]] <- .cc_collect_assignToSim(p)
     uses[[length(uses) + 1]] <- .cc_collect_globalsConflicts(p)
+    uses[[length(uses) + 1]] <- .cc_collect_localAndBulk(p)
   }
   out <- do.call(rbind, uses)
   ## Attach suppression context so rules can honour inline `# nolint` markers.
@@ -598,6 +599,44 @@
   attr(out, "nolint")    <- do.call(rbind, lapply(parses, .cc_collectNolint))
   attr(out, "declLines") <- do.call(rbind, lapply(parses, .cc_collectDeclLines))
   out
+}
+
+## Collect bare-symbol local assignments (`name <- ...`, `name = ...`,
+## `... -> name`) and detect a bulk write into `envir(sim)` via
+## `list2env(<x>, envir(sim))`. The local assignments let `out_declared_unused`
+## recognise outputs that are computed as a same-named local and then pushed to
+## the sim env in bulk (a common idiom). The bulk-write marker (kind
+## "sim_bulk_assign") gates that behaviour. Both are `resolved = TRUE` so they
+## are ignored by the unresolved-accessor rule.
+.cc_collect_localAndBulk <- function(parsed) {
+  doc <- parsed$doc; file <- parsed$file
+  out <- list()
+  emit <- function(kind, name, node, extra = NA_character_) {
+    pos <- .cc_pos(node)
+    .cc_use(kind, name = name, fn = .cc_enclosingFn(node), file = file,
+            line = pos$line, col = pos$col, resolved = TRUE, extra = extra)
+  }
+  ## `name <- ...` / `name = ...` (LHS is a single bare SYMBOL)
+  for (n in xml2::xml_find_all(
+    doc, "//expr[(LEFT_ASSIGN or EQ_ASSIGN) and expr[1][SYMBOL and count(*)=1]]")) {
+    sym <- xml2::xml_find_first(n, "expr[1]/SYMBOL")
+    if (length(sym) > 0) out[[length(out) + 1]] <- emit("local_assign", xml2::xml_text(sym), n)
+  }
+  ## `... -> name` (RHS is a single bare SYMBOL)
+  for (n in xml2::xml_find_all(
+    doc, "//expr[RIGHT_ASSIGN and expr[last()][SYMBOL and count(*)=1]]")) {
+    sym <- xml2::xml_find_first(n, "expr[last()]/SYMBOL")
+    if (length(sym) > 0) out[[length(out) + 1]] <- emit("local_assign", xml2::xml_text(sym), n)
+  }
+  ## `list2env(<x>, envir(sim))` -- a bulk write into the sim environment
+  for (n in xml2::xml_find_all(
+    doc,
+    paste0("//expr[expr/SYMBOL_FUNCTION_CALL[text()='list2env'] and ",
+           ".//expr[expr/SYMBOL_FUNCTION_CALL[text()='envir'] and expr/SYMBOL[text()='sim']]]"))) {
+    out[[length(out) + 1]] <- emit("sim_bulk_assign", NA_character_, n, extra = "list2env()")
+  }
+  if (length(out) == 0) return(.cc_emptyUses())
+  do.call(rbind, out)
 }
 
 ## Collect inline `# nolint` directives from the source comments. A bare

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -126,7 +126,8 @@
     if (length(parent) == 0 || xml2::xml_name(parent) != "expr") {
       return(NA_character_)
     }
-    knames <- xml2::xml_name(xml2::xml_children(parent))
+    kids <- xml2::xml_children(parent)
+    knames <- xml2::xml_name(kids)
     if (any(knames %in% c("LEFT_ASSIGN", "EQ_ASSIGN"))) {
       lhs <- xml2::xml_find_first(parent, "expr[1]/SYMBOL")
       if (length(lhs) > 0 && !is.na(xml2::xml_text(lhs))) return(xml2::xml_text(lhs))
@@ -137,7 +138,19 @@
       if (length(rhs) > 0 && !is.na(xml2::xml_text(rhs))) return(xml2::xml_text(rhs))
       return(NA_character_)
     }
+    ## Don't ascend into a function's formals, and only ascend through a
+    ## call/grouping that wraps `cur` as the *first* thing inside its parens
+    ## (e.g. cmpfun(function(){}) or Cache(function(){})). A function that is a
+    ## later argument (e.g. lapply(x, function(){})) is an anonymous callback
+    ## and must not be attributed to whatever the surrounding expression binds.
     if (any(knames == "FUNCTION")) return(NA_character_)
+    parenIdx <- which(knames == "OP-LEFT-PAREN")
+    if (length(parenIdx) == 0) return(NA_character_)
+    afterParen <- which(knames == "expr" & seq_along(knames) > parenIdx[1])
+    if (length(afterParen) == 0 ||
+        !identical(xml2::xml_path(kids[[afterParen[1]]]), xml2::xml_path(cur))) {
+      return(NA_character_)
+    }
     cur <- parent
   }
 }

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -346,6 +346,25 @@
     )
   }
 
+  ## paramCheckOtherMods(sim, "x") -- treats "x" as a used parameter. The
+  ## function deliberately reads a parameter that may be defined in other
+  ## modules, so it is recorded as a use (no module attribution) and exempted
+  ## from the "used but not declared here" rule via its extra tag.
+  pcomNodes <- xml2::xml_find_all(
+    doc, "//expr[expr/SYMBOL_FUNCTION_CALL[text()='paramCheckOtherMods']]"
+  )
+  for (n in pcomNodes) {
+    nameNode <- xml2::xml_find_first(n, ".//STR_CONST[1]")
+    if (length(nameNode) == 0 || is.na(xml2::xml_text(nameNode))) next
+    pos <- .cc_pos(n)
+    out[[length(out) + 1]] <- .cc_use(
+      "param", name = gsub('^["\']|["\']$', "", xml2::xml_text(nameNode)),
+      fn = .cc_enclosingFn(n), file = file,
+      line = pos$line, col = pos$col, resolved = TRUE,
+      module = currentModule, extra = "paramCheckOtherMods()"
+    )
+  }
+
   if (length(out) == 0) return(.cc_emptyUses())
   do.call(rbind, out)
 }

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -631,6 +631,7 @@
     uses[[length(uses) + 1]] <- .cc_collect_globalsConflicts(p)
     uses[[length(uses) + 1]] <- .cc_collect_localAndBulk(p)
     uses[[length(uses) + 1]] <- .cc_collect_nsCalls(p)
+    uses[[length(uses) + 1]] <- .cc_collect_declaredVars(p)
   }
   out <- do.call(rbind, uses)
   ## Attach suppression context so rules can honour inline `# nolint` markers.
@@ -678,6 +679,31 @@
   do.call(rbind, out)
 }
 
+## Collect developer assertions of the form `# nolint: vars a, b, c`, used on a
+## dynamic bulk-assign line (e.g. list2env(<computedList>, envir(sim))) whose
+## element names cannot be seen statically. Each named object is recorded as a
+## "declared_var" use so out_declared_unused treats it as produced.
+.cc_collect_declaredVars <- function(parsed) {
+  doc <- parsed$doc; file <- parsed$file
+  out <- list()
+  for (cm in xml2::xml_find_all(doc, "//COMMENT")) {
+    m <- regmatches(xml2::xml_text(cm),
+                    regexec("#+\\s*nolint\\s*:\\s*vars\\b\\s*(.*)$",
+                            xml2::xml_text(cm), ignore.case = TRUE))[[1]]
+    if (length(m) < 2 || !nzchar(trimws(m[2]))) next
+    vars <- trimws(strsplit(trimws(m[2]), "[,[:space:]]+")[[1]])
+    vars <- vars[nzchar(vars)]
+    pos <- .cc_pos(cm)
+    for (v in vars) {
+      out[[length(out) + 1]] <- .cc_use(
+        "declared_var", name = v, fn = NA_character_, file = file,
+        line = pos$line, col = NA_integer_, resolved = TRUE, extra = "nolint:vars")
+    }
+  }
+  if (length(out) == 0) return(.cc_emptyUses())
+  do.call(rbind, out)
+}
+
 ## Collect inline `# nolint` directives from the source comments. A bare
 ## `# nolint` suppresses every rule on that line; `# nolint: id1, id2`
 ## suppresses only the listed rule ids. Returns a data.frame(file, line,
@@ -695,6 +721,9 @@
     rules <- if (nzchar(rulesStr)) {
       trimws(strsplit(rulesStr, "[,[:space:]]+")[[1]])
     } else NA_character_
+    ## `# nolint: vars a, b` is a declared-vars assertion, not a rule
+    ## suppression (handled by .cc_collect_declaredVars); skip it here
+    if (!all(is.na(rules)) && identical(tolower(rules[1]), "vars")) next
     out[[length(out) + 1]] <- data.frame(
       file = file %||% NA_character_,
       line = as.integer(xml2::xml_attr(cm, "line1")),

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -333,6 +333,12 @@
     inner, "OP-DOLLAR | LBB")) > 0
   if (innerHasAccessor) {
     modName <- .cc_chainTail(inner)
+    if (!is.null(modName) && isTRUE(modName$current)) {
+      ## params(sim)[[currentModule(sim)]]$x -- the key resolves to the
+      ## current module, so treat it like the no-module form below
+      return(list(module = NULL, param = outerName$name,
+                  resolved = outerName$resolved))
+    }
     list(module = modName$name,
          param = outerName$name,
          resolved = outerName$resolved && (is.null(modName) || modName$resolved))
@@ -354,10 +360,17 @@
     if (length(sym) == 0) return(NULL)
     return(list(name = xml2::xml_text(sym), resolved = TRUE))
   } else if (opName == "LBB") {
-    str <- xml2::xml_find_first(expr, "expr[2]/STR_CONST")
+    key <- xml2::xml_find_first(expr, "expr[2]")
+    str <- xml2::xml_find_first(key, "STR_CONST")
     if (length(str) > 0 && !is.na(xml2::xml_text(str))) {
       return(list(name = gsub('^["\']|["\']$', "", xml2::xml_text(str)),
                   resolved = TRUE))
+    }
+    ## params(sim)[[currentModule(sim)]] -- key is a call to currentModule(),
+    ## i.e. the current module; resolvable even though it isn't a literal
+    fnCall <- xml2::xml_find_first(key, ".//SYMBOL_FUNCTION_CALL")
+    if (length(fnCall) > 0 && identical(xml2::xml_text(fnCall), "currentModule")) {
+      return(list(name = NA_character_, resolved = TRUE, current = TRUE))
     }
     return(list(name = NA_character_, resolved = FALSE))
   }

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -581,6 +581,30 @@
   do.call(rbind, out)
 }
 
+## Bare (unqualified) function calls -- every `fn(...)` that is not `pkg::fn`.
+## Deduplicated by name (first occurrence keeps a position), since the
+## consumer (reqd_pkg_no_source) only needs the set of called names.
+.cc_collect_bareCalls <- function(parsed) {
+  doc <- parsed$doc; file <- parsed$file
+  calls <- xml2::xml_find_all(doc, "//SYMBOL_FUNCTION_CALL")
+  if (length(calls) == 0) return(.cc_emptyUses())
+  out <- list(); seen <- character()
+  for (cal in calls) {
+    ## skip namespaced calls (pkg::fn / pkg:::fn)
+    if (length(xml2::xml_find_first(
+      cal, "preceding-sibling::NS_GET | preceding-sibling::NS_GET_INT")) > 0) next
+    nm <- xml2::xml_text(cal)
+    if (nm %in% seen) next
+    seen <- c(seen, nm)
+    pos <- .cc_pos(cal)
+    out[[length(out) + 1]] <- .cc_use("bare_call", name = nm,
+                                      fn = .cc_enclosingFn(cal), file = file,
+                                      line = pos$line, col = pos$col, resolved = TRUE)
+  }
+  if (length(out) == 0) return(.cc_emptyUses())
+  do.call(rbind, out)
+}
+
 ## Conflicting/clashing function uses (raster::levels, quickPlot::Plot, etc.).
 ## These are flagged by name only -- we don't care about positions for the
 ## clashing-defined-fn check (handled via env name listing, not parsing).
@@ -632,6 +656,7 @@
     uses[[length(uses) + 1]] <- .cc_collect_localAndBulk(p)
     uses[[length(uses) + 1]] <- .cc_collect_nsCalls(p)
     uses[[length(uses) + 1]] <- .cc_collect_declaredVars(p)
+    uses[[length(uses) + 1]] <- .cc_collect_bareCalls(p)
   }
   out <- do.call(rbind, uses)
   ## Attach suppression context so rules can honour inline `# nolint` markers.

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -562,6 +562,25 @@
   do.call(rbind, out)
 }
 
+## Namespaced references: every `pkg::name` / `pkg:::name`. Emits one
+## use per occurrence with name = pkg (the SYMBOL_PACKAGE token) and
+## extra = the referenced symbol, so reqd_pkg_undeclared can see which
+## packages are used via `::`.
+.cc_collect_nsCalls <- function(parsed) {
+  doc <- parsed$doc; file <- parsed$file
+  pkgNodes <- xml2::xml_find_all(doc, "//SYMBOL_PACKAGE")
+  if (length(pkgNodes) == 0) return(.cc_emptyUses())
+  out <- lapply(pkgNodes, function(p) {
+    parent <- xml2::xml_parent(p)
+    fnNode <- xml2::xml_find_first(parent, "SYMBOL_FUNCTION_CALL | SYMBOL")
+    pos <- .cc_pos(p)
+    .cc_use("ns_call", name = xml2::xml_text(p), fn = .cc_enclosingFn(p),
+            file = file, line = pos$line, col = pos$col, resolved = TRUE,
+            extra = if (length(fnNode) > 0) xml2::xml_text(fnNode) else NA_character_)
+  })
+  do.call(rbind, out)
+}
+
 ## Conflicting/clashing function uses (raster::levels, quickPlot::Plot, etc.).
 ## These are flagged by name only -- we don't care about positions for the
 ## clashing-defined-fn check (handled via env name listing, not parsing).
@@ -611,6 +630,7 @@
     uses[[length(uses) + 1]] <- .cc_collect_assignToSim(p)
     uses[[length(uses) + 1]] <- .cc_collect_globalsConflicts(p)
     uses[[length(uses) + 1]] <- .cc_collect_localAndBulk(p)
+    uses[[length(uses) + 1]] <- .cc_collect_nsCalls(p)
   }
   out <- do.call(rbind, uses)
   ## Attach suppression context so rules can honour inline `# nolint` markers.

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -581,6 +581,36 @@
   do.call(rbind, out)
 }
 
+## `suppliedElsewhere("x", sim)` references. Captures the first argument when
+## it is a string literal or a bare symbol (the object name). Used by
+## in_no_default: requiring an input via suppliedElsewhere (e.g. then stop()ing
+## if absent) is a legitimate alternative to providing a default.
+.cc_collect_suppliedElsewhere <- function(parsed) {
+  doc <- parsed$doc; file <- parsed$file
+  calls <- xml2::xml_find_all(
+    doc, "//expr[expr/SYMBOL_FUNCTION_CALL[text()='suppliedElsewhere']]")
+  if (length(calls) == 0) return(.cc_emptyUses())
+  out <- list()
+  for (cal in calls) {
+    arg <- xml2::xml_find_first(cal, "expr[2]")     # first argument
+    if (length(arg) == 0) next
+    sc <- xml2::xml_find_first(arg, ".//STR_CONST")
+    name <- if (length(sc) > 0 && !is.na(xml2::xml_text(sc))) {
+      gsub('^["\']|["\']$', "", xml2::xml_text(sc))
+    } else {
+      sy <- xml2::xml_find_first(arg, ".//SYMBOL")
+      if (length(sy) > 0) xml2::xml_text(sy) else NA_character_
+    }
+    if (is.na(name)) next
+    pos <- .cc_pos(cal)
+    out[[length(out) + 1]] <- .cc_use("supplied_elsewhere", name = name,
+                                      fn = .cc_enclosingFn(cal), file = file,
+                                      line = pos$line, col = pos$col, resolved = TRUE)
+  }
+  if (length(out) == 0) return(.cc_emptyUses())
+  do.call(rbind, out)
+}
+
 ## Bare (unqualified) function calls -- every `fn(...)` that is not `pkg::fn`.
 ## Deduplicated by name (first occurrence keeps a position), since the
 ## consumer (reqd_pkg_no_source) only needs the set of called names.
@@ -657,6 +687,7 @@
     uses[[length(uses) + 1]] <- .cc_collect_nsCalls(p)
     uses[[length(uses) + 1]] <- .cc_collect_declaredVars(p)
     uses[[length(uses) + 1]] <- .cc_collect_bareCalls(p)
+    uses[[length(uses) + 1]] <- .cc_collect_suppliedElsewhere(p)
   }
   out <- do.call(rbind, uses)
   ## Attach suppression context so rules can honour inline `# nolint` markers.

--- a/R/codecheck-report.R
+++ b/R/codecheck-report.R
@@ -16,25 +16,10 @@
     return(invisible(findings))
   }
 
-  ## group: which broad bucket does each rule belong to?
-  groups <- c(
-    out_declared_unused      = "outputObjects",
-    out_used_undeclared      = "outputObjects",
-    in_declared_unused       = "inputObjects",
-    in_used_undeclared       = "inputObjects",
-    in_no_default            = "inputObjects",
-    param_declared_unused    = "parameters",
-    param_used_undeclared    = "parameters",
-    param_used_other_module  = "parameters",
-    unresolved_accessor      = "unresolved",
-    must_return_sim          = "module functions",
-    must_assign_to_sim       = "module functions",
-    module_named_object      = "module functions",
-    conflicting_fn_unqualified = "globals",
-    clashing_module_fn       = "module functions",
-    codetools                = "codetools"
-  )
-  findings$group <- groups[findings$id] %||% "other"
+  ## group: which broad bucket does each rule belong to? (shared map, so the
+  ## report and `# nolint`/codeChecksIgnore suppression stay in sync)
+  findings$group <- unname(.CC_RULE_GROUPS[findings$id])
+  findings$group[is.na(findings$group)] <- "other"
 
   if (quiet) return(invisible(findings))
 
@@ -69,16 +54,19 @@
       idx <- which(key == k)
       r0 <- sub[idx[1], ]
       tag <- sevTag(r0$severity)
+      ## show the rule id so it can be copied into a `# nolint: <id>` marker
+      ## or options(spades.codeChecksIgnore = list(<id> = ...))
+      idTag <- cli::col_silver(paste0("[", r0$id, "]"))
       if (length(idx) == 1L) {
         msgLoc <- paste0(r0$message, loc(r0))
-        cli::cli_text("  {tag} {msgLoc}")
+        cli::cli_text("  {tag} {msgLoc} {idTag}")
         if (!is.na(r0$suggestion)) {
           cli::cli_text(cli::col_silver("        \u21aa  {r0$suggestion}"))
         }
       } else {
         ## one header for the shared issue, then one line per hit
         header <- gmsg[idx[1]]
-        cli::cli_text("  {tag} {header}")
+        cli::cli_text("  {tag} {header} {idTag}")
         for (j in idx) {
           r <- sub[j, ]
           nm <- if (!is.na(r$name)) paste0("`", r$name, "`") else ""

--- a/R/codecheck-report.R
+++ b/R/codecheck-report.R
@@ -41,23 +41,53 @@
   ## header per module
   cli::cli_rule(left = cli::col_cyan(module %||% findings$module[1]))
 
+  sevTag <- function(sev) switch(sev,
+                                 error   = cli::col_red("[error]"),
+                                 warning = cli::col_magenta("[warn] "),
+                                 note    = cli::col_blue("[note] "),
+                                 info    = cli::col_silver("[info] "))
+  loc <- function(r) if (!is.na(r$line)) {
+    sprintf(" (%s:%d:%d)", basename(r$file %||% file %||% ""), r$line, r$col)
+  } else ""
+  ## blank a finding's own name to a placeholder, so hits that differ only in
+  ## that name (e.g. `scale`/`levels`, or inputs `cloudFolderID`/`ecoregionRst`)
+  ## collapse under one header
+  generic <- function(text, name) {
+    if (is.na(text) || is.na(name) || !nzchar(name)) return(text)
+    gsub(name, "<name>", text, fixed = TRUE)
+  }
+
   for (g in unique(findings$group)) {
     sub <- findings[findings$group == g, , drop = FALSE]
     cli::cli_text(cli::col_yellow(paste0("\u2022 ", g)))
-    for (i in seq_len(nrow(sub))) {
-      r <- sub[i, ]
-      sevTag <- switch(r$severity,
-                       error   = cli::col_red("[error]"),
-                       warning = cli::col_magenta("[warn] "),
-                       note    = cli::col_blue("[note] "),
-                       info    = cli::col_silver("[info] "))
-      loc <- if (!is.na(r$line)) {
-        sprintf(" (%s:%d:%d)",
-                basename(r$file %||% file %||% ""), r$line, r$col)
-      } else ""
-      cli::cli_text("  {sevTag} {r$message}{loc}")
-      if (!is.na(r$suggestion)) {
-        cli::cli_text(cli::col_silver("        \u21aa  {r$suggestion}"))
+    gmsg <- vapply(seq_len(nrow(sub)),
+                   function(i) generic(sub$message[i], sub$name[i]), character(1))
+    gsug <- vapply(seq_len(nrow(sub)),
+                   function(i) generic(sub$suggestion[i], sub$name[i]), character(1))
+    key <- paste(sub$id, gmsg, gsug, sep = "\r")
+    for (k in unique(key)) {
+      idx <- which(key == k)
+      r0 <- sub[idx[1], ]
+      tag <- sevTag(r0$severity)
+      if (length(idx) == 1L) {
+        msgLoc <- paste0(r0$message, loc(r0))
+        cli::cli_text("  {tag} {msgLoc}")
+        if (!is.na(r0$suggestion)) {
+          cli::cli_text(cli::col_silver("        \u21aa  {r0$suggestion}"))
+        }
+      } else {
+        ## one header for the shared issue, then one line per hit
+        header <- gmsg[idx[1]]
+        cli::cli_text("  {tag} {header}")
+        for (j in idx) {
+          r <- sub[j, ]
+          nm <- if (!is.na(r$name)) paste0("`", r$name, "`") else ""
+          detail <- trimws(paste0(nm, loc(r)))
+          cli::cli_text(cli::col_silver("         {detail}"))
+        }
+        if (!is.na(gsug[idx[1]])) {
+          cli::cli_text(cli::col_silver("        \u21aa  {gsug[idx[1]]}"))
+        }
       }
     }
   }

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -35,7 +35,8 @@
   clashing_module_fn       = function(uses, meta) .ccr_clashing_fn(uses, meta),
   codetools                = function(uses, meta) .ccr_codetools(uses, meta),
   reqd_pkg_duplicate       = function(uses, meta) .ccr_reqd_pkg_duplicate(uses, meta),
-  reqd_pkg_undeclared      = function(uses, meta) .ccr_reqd_pkg_undeclared(uses, meta)
+  reqd_pkg_undeclared      = function(uses, meta) .ccr_reqd_pkg_undeclared(uses, meta),
+  reqd_pkg_no_source       = function(uses, meta) .ccr_reqd_pkg_no_source(uses, meta)
 )
 
 ## Base-priority packages that are always available and never declared in
@@ -64,7 +65,8 @@
   clashing_module_fn         = "module functions",
   codetools                  = "codetools",
   reqd_pkg_duplicate         = "reqdPkgs",
-  reqd_pkg_undeclared        = "reqdPkgs"
+  reqd_pkg_undeclared        = "reqdPkgs",
+  reqd_pkg_no_source         = "reqdPkgs"
 )
 
 ## Public entry: returns a Findings data.frame
@@ -548,4 +550,35 @@
                         p, eg),
       suggestion = sprintf("add '%s' to reqdPkgs", p))
   }))
+}
+
+## Quiet, best-effort: bare function calls that have no apparent source among
+## the declared reqdPkgs (their installed namespace exports), base packages,
+## SpaDES.core, or functions defined locally in the module. Only runs when
+## every declared (non-base) package is installed -- otherwise we can't tell
+## where bare calls come from, so we stay silent. Info-level.
+.ccr_reqd_pkg_no_source <- function(uses, meta) {
+  bare <- unique(uses$name[uses$kind == "bare_call" & !is.na(uses$name)])
+  if (length(bare) == 0) return(.cc_emptyFindings())
+  declared <- if (is.null(meta$reqdPkgs)) character() else unique(meta$reqdPkgs$pkg)
+  declared <- setdiff(declared, .CC_BASE_PKGS)
+  if (length(declared) &&
+      !all(vapply(declared, requireNamespace, logical(1), quietly = TRUE))) {
+    return(.cc_emptyFindings())   # incomplete export info -> stay quiet
+  }
+  ## exclude tcltk -- loading its namespace warns when there is no DISPLAY
+  exportPkgs <- setdiff(unique(c("SpaDES.core", .CC_BASE_PKGS, declared)), "tcltk")
+  exports <- suppressWarnings(unlist(lapply(exportPkgs, function(p)
+    tryCatch(getNamespaceExports(p), error = function(e) character()))))
+  ## locally-defined names (functions and other locals) and enclosing fn names
+  localNames <- unique(c(uses$name[uses$kind == "local_assign"], uses$fn))
+  localNames <- localNames[!is.na(localNames)]
+  noSource <- setdiff(bare, c(exports, localNames))
+  if (length(noSource) == 0) return(.cc_emptyFindings())
+  .cc_finding(
+    "reqd_pkg_no_source", "info", meta$module,
+    where = "reqdPkgs", file = meta$mainFile %||% NA_character_,
+    message = sprintf("within the named packages in reqdPkgs, there is no apparent source for the function(s): %s",
+                      paste(sort(noSource), collapse = ", ")),
+    suggestion = "declare the providing package in reqdPkgs, qualify the call as pkg::fn, or ignore if defined elsewhere")
 }

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -381,35 +381,27 @@
   ## are inherently un-checkable statically -- the developer must decide whether
   ## the access is intentional (add `# nolint: unresolved_accessor`) or a bug.
   getFamily <- c("get()", "mget()", "exists()", "assign()")
-  bad$access <- ifelse(bad$extra %in% getFamily, "getfam",
-                       ifelse(bad$kind %in% c("sim_get", "sim_assign"),
-                              "bracket", "other"))
-  ## Aggregate: one finding per (fn, access) showing all line numbers, so the
-  ## report doesn't spew one row per occurrence. Tests can still see the raw
-  ## Uses on .codeCheck if they want.
-  by <- split(bad, list(bad$fn, bad$access), drop = TRUE)
-  do.call(rbind, lapply(by, function(g) {
-    lines <- paste(g$line, collapse = ", ")
-    u <- g[1, ]
-    nolintHint <- paste0("cannot be checked statically (the object name is ",
-                         "computed at run time); if intentional, add ",
-                         "`# nolint: unresolved_accessor` on the line(s), ",
-                         "otherwise use a literal name (`sim$x`) or declare ",
-                         "the object in inputObjects/outputObjects")
+  access <- ifelse(bad$extra %in% getFamily, "getfam",
+                   ifelse(bad$kind %in% c("sim_get", "sim_assign"),
+                          "bracket", "other"))
+  nolintHint <- paste0("cannot be checked statically (the object name is ",
+                       "computed at run time); if intentional, add ",
+                       "`# nolint: unresolved_accessor` on the line(s), ",
+                       "otherwise use a literal name (`sim$x`) or declare ",
+                       "the object in inputObjects/outputObjects")
+  ## One finding per occurrence with a generic, location-free message, so the
+  ## report collapses same-kind accesses (across functions) into a single info
+  ## with one line per location.
+  do.call(rbind, lapply(seq_len(nrow(bad)), function(i) {
+    u <- bad[i, ]
     msgSug <- switch(
-      u$access,
-      getfam = list(
-        msg = sprintf("%d dynamic `get()`/`mget()`-family access(es) of `sim` in %s (lines %s)",
-                      nrow(g), u$fn, lines),
-        sug = nolintHint),
-      bracket = list(
-        msg = sprintf("%d dynamic `sim[[<var>]]` access(es) in %s (lines %s)",
-                      nrow(g), u$fn, lines),
-        sug = nolintHint),
-      list(
-        msg = sprintf("%d unresolved %s accessor(s) in %s (lines %s) \u2014 skipped",
-                      nrow(g), u$kind, u$fn, lines),
-        sug = "if these objects should be checked, declare them explicitly in inputObjects/outputObjects"))
+      access[i],
+      getfam  = list(msg = "dynamic `get()`/`mget()`-family access of `sim`",
+                     sug = nolintHint),
+      bracket = list(msg = "dynamic `sim[[<var>]]` access",
+                     sug = nolintHint),
+      list(msg = sprintf("unresolved %s accessor", u$kind),
+           sug = "if these objects should be checked, declare them explicitly in inputObjects/outputObjects"))
     .cc_findingFromUse("unresolved_accessor", "info", meta$module, u,
                        message = msgSug$msg, suggestion = msgSug$sug)
   }))

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -248,6 +248,10 @@
     assignedNames <- c(assignedNames,
                        uses$name[uses$kind == "local_assign" & !is.na(uses$name)])
   }
+  ## developer assertions via `# nolint: vars a, b` (e.g. on a list2env line
+  ## whose list element names can't be seen statically) -- treat as produced
+  assignedNames <- c(assignedNames,
+                     uses$name[uses$kind == "declared_var" & !is.na(uses$name)])
   missing <- setdiff(meta$outputs, assignedNames)
   if (length(missing) == 0) return(.cc_emptyFindings())
   do.call(rbind, lapply(missing, function(n)

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -326,6 +326,9 @@
   ## core machinery defines these implicitly; modules legitimately reference
   ## them without declaring in defineParameter()
   pUses <- pUses[!.cc_isInternalParam(pUses$name), , drop = FALSE]
+  ## paramCheckOtherMods(sim, "x") deliberately reads parameters owned by other
+  ## modules, so such uses must not be reported as "used but not declared here"
+  pUses <- pUses[is.na(pUses$extra) | pUses$extra != "paramCheckOtherMods()", , drop = FALSE]
   bad <- pUses[!(pUses$name %in% meta$params), , drop = FALSE]
   if (nrow(bad) == 0) return(.cc_emptyFindings())
   do.call(rbind, lapply(seq_len(nrow(bad)), function(i) {

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -34,8 +34,15 @@
   conflicting_fn_unqualified = function(uses, meta) .ccr_conflicting_fn(uses, meta),
   clashing_module_fn       = function(uses, meta) .ccr_clashing_fn(uses, meta),
   codetools                = function(uses, meta) .ccr_codetools(uses, meta),
-  reqd_pkg_duplicate       = function(uses, meta) .ccr_reqd_pkg_duplicate(uses, meta)
+  reqd_pkg_duplicate       = function(uses, meta) .ccr_reqd_pkg_duplicate(uses, meta),
+  reqd_pkg_undeclared      = function(uses, meta) .ccr_reqd_pkg_undeclared(uses, meta)
 )
+
+## Base-priority packages that are always available and never declared in
+## reqdPkgs.
+.CC_BASE_PKGS <- c("base", "compiler", "datasets", "graphics", "grDevices",
+                   "grid", "methods", "parallel", "splines", "stats", "stats4",
+                   "tcltk", "tools", "utils")
 
 ## Display bucket each rule id is reported under (the `• <group>` headers).
 ## Shared by the reporter and by `# nolint` / codeChecksIgnore suppression, so
@@ -56,7 +63,8 @@
   conflicting_fn_unqualified = "globals",
   clashing_module_fn         = "module functions",
   codetools                  = "codetools",
-  reqd_pkg_duplicate         = "reqdPkgs"
+  reqd_pkg_duplicate         = "reqdPkgs",
+  reqd_pkg_undeclared        = "reqdPkgs"
 )
 
 ## Public entry: returns a Findings data.frame
@@ -523,5 +531,25 @@
                         if (conflict) " with differing source/version" else "",
                         paste(specs, collapse = " | ")),
       suggestion = "keep a single declaration (the most specific source/version) and remove the rest")
+  }))
+}
+
+## A package referenced via `pkg::fn` but not present in reqdPkgs (and not a
+## base package). Likely a missing declaration.
+.ccr_reqd_pkg_undeclared <- function(uses, meta) {
+  ns <- uses[uses$kind == "ns_call" & !is.na(uses$name), , drop = FALSE]
+  if (nrow(ns) == 0) return(.cc_emptyFindings())
+  declared <- if (is.null(meta$reqdPkgs)) character() else unique(meta$reqdPkgs$pkg)
+  missing <- setdiff(unique(ns$name), c(declared, .CC_BASE_PKGS))
+  if (length(missing) == 0) return(.cc_emptyFindings())
+  do.call(rbind, lapply(missing, function(p) {
+    fns <- unique(stats::na.omit(ns$extra[ns$name == p]))
+    eg <- paste0(p, "::", utils::head(fns, 3), "()", collapse = ", ")
+    u <- ns[ns$name == p, , drop = FALSE][1, ]
+    .cc_findingFromUse(
+      "reqd_pkg_undeclared", "warning", meta$module, u,
+      message = sprintf("package '%s' is used via `::` (e.g. %s) but not declared in reqdPkgs",
+                        p, eg),
+      suggestion = sprintf("add '%s' to reqdPkgs", p))
   }))
 }

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -33,7 +33,8 @@
   module_named_object      = function(uses, meta) .ccr_module_named_object(uses, meta),
   conflicting_fn_unqualified = function(uses, meta) .ccr_conflicting_fn(uses, meta),
   clashing_module_fn       = function(uses, meta) .ccr_clashing_fn(uses, meta),
-  codetools                = function(uses, meta) .ccr_codetools(uses, meta)
+  codetools                = function(uses, meta) .ccr_codetools(uses, meta),
+  reqd_pkg_duplicate       = function(uses, meta) .ccr_reqd_pkg_duplicate(uses, meta)
 )
 
 ## Display bucket each rule id is reported under (the `• <group>` headers).
@@ -54,7 +55,8 @@
   module_named_object        = "module functions",
   conflicting_fn_unqualified = "globals",
   clashing_module_fn         = "module functions",
-  codetools                  = "codetools"
+  codetools                  = "codetools",
+  reqd_pkg_duplicate         = "reqdPkgs"
 )
 
 ## Public entry: returns a Findings data.frame
@@ -494,5 +496,32 @@
   do.call(rbind, lapply(msgs, function(m) {
     .cc_finding("codetools", "note", meta$module,
                 message = m, suggestion = NA_character_)
+  }))
+}
+
+## reqdPkgs rules ------------------------------------------------------------
+
+## A package declared more than once in reqdPkgs. Different source/version
+## specs for the same package (e.g. CRAN `SpaDES.core (>= 3.0.1)` plus
+## `PredictiveEcology/SpaDES.core@branch (>= 3.0.4)`) are a real conflict
+## (warning); exact repeats are a note.
+.ccr_reqd_pkg_duplicate <- function(uses, meta) {
+  rp <- meta$reqdPkgs
+  if (is.null(rp) || NROW(rp) == 0) return(.cc_emptyFindings())
+  dups <- unique(rp$pkg[duplicated(rp$pkg)])
+  if (length(dups) == 0) return(.cc_emptyFindings())
+  do.call(rbind, lapply(dups, function(p) {
+    entries <- rp[rp$pkg == p, , drop = FALSE]
+    specs <- unique(entries$spec)
+    conflict <- length(specs) > 1
+    .cc_finding(
+      "reqd_pkg_duplicate", if (conflict) "warning" else "note", meta$module,
+      where = "reqdPkgs", name = p,
+      file = entries$file[1], line = entries$line[1],
+      message = sprintf("package '%s' is declared %d times in reqdPkgs%s: %s",
+                        p, nrow(entries),
+                        if (conflict) " with differing source/version" else "",
+                        paste(specs, collapse = " | ")),
+      suggestion = "keep a single declaration (the most specific source/version) and remove the rest")
   }))
 }

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -45,6 +45,10 @@
                    "grid", "methods", "parallel", "splines", "stats", "stats4",
                    "tcltk", "tools", "utils")
 
+## "Call" tokens that are special syntax rather than package functions, so the
+## no-source check must never report them. `.` is data.table's `DT[, .(...)]`.
+.CC_NONFUNCTION_CALLS <- c(".")
+
 ## Display bucket each rule id is reported under (the `• <group>` headers).
 ## Shared by the reporter and by `# nolint` / codeChecksIgnore suppression, so
 ## either the rule id or its group name can be used to silence a finding.
@@ -565,8 +569,11 @@
 ## every declared (non-base) package is installed -- otherwise we can't tell
 ## where bare calls come from, so we stay silent. Info-level.
 .ccr_reqd_pkg_no_source <- function(uses, meta) {
-  bare <- unique(uses$name[uses$kind == "bare_call" & !is.na(uses$name)])
-  if (length(bare) == 0) return(.cc_emptyFindings())
+  bareUses <- uses[uses$kind == "bare_call" & !is.na(uses$name), , drop = FALSE]
+  ## `.` is data.table syntax (DT[, .(...)]) and similar non-functions, not a
+  ## package export -- never report it
+  bareUses <- bareUses[!bareUses$name %in% .CC_NONFUNCTION_CALLS, , drop = FALSE]
+  if (nrow(bareUses) == 0) return(.cc_emptyFindings())
   declared <- if (is.null(meta$reqdPkgs)) character() else unique(meta$reqdPkgs$pkg)
   declared <- setdiff(declared, .CC_BASE_PKGS)
   if (length(declared) &&
@@ -580,12 +587,15 @@
   ## locally-defined names (functions and other locals) and enclosing fn names
   localNames <- unique(c(uses$name[uses$kind == "local_assign"], uses$fn))
   localNames <- localNames[!is.na(localNames)]
-  noSource <- setdiff(bare, c(exports, localNames))
-  if (length(noSource) == 0) return(.cc_emptyFindings())
-  .cc_finding(
-    "reqd_pkg_no_source", "info", meta$module,
-    where = "reqdPkgs", file = meta$mainFile %||% NA_character_,
-    message = sprintf("within the named packages in reqdPkgs, there is no apparent source for the function(s): %s",
-                      paste(sort(noSource), collapse = ", ")),
-    suggestion = "declare the providing package in reqdPkgs, qualify the call as pkg::fn, or ignore if defined elsewhere")
+  noSource <- bareUses[!(bareUses$name %in% c(exports, localNames)), , drop = FALSE]
+  if (nrow(noSource) == 0) return(.cc_emptyFindings())
+  ## one finding per function (carrying its first source position) with a
+  ## generic message, so the report collapses them under one header with a
+  ## `fn (file:line)` line apiece.
+  do.call(rbind, lapply(seq_len(nrow(noSource)), function(i) {
+    .cc_findingFromUse(
+      "reqd_pkg_no_source", "info", meta$module, noSource[i, ],
+      message = "no apparent source among the packages named in reqdPkgs",
+      suggestion = "declare the providing package in reqdPkgs, qualify the call as pkg::fn, or ignore if defined elsewhere")
+  }))
 }

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -311,7 +311,14 @@
   if (length(meta$inputs) == 0) return(.cc_emptyFindings())
   initAssigns <- .cc_inDotInputObjects(uses)
   initAssigns <- initAssigns[initAssigns$kind == "sim_assign" & !is.na(initAssigns$name), , drop = FALSE]
-  missing <- setdiff(meta$inputs, initAssigns$name)
+  ## `# nolint: vars a, b` asserts a, b are assigned (e.g. a dynamic
+  ## sim[[namPlural]] <- ... in .inputObjects whose name can't be seen
+  ## statically); treat them as having a default.
+  declaredVars <- uses$name[uses$kind == "declared_var" & !is.na(uses$name)]
+  ## an input guarded by `suppliedElsewhere("x", sim)` (then assigned a default
+  ## OR stop()ped if absent) is intentionally handled -- not a missing default.
+  suppliedElsewhere <- uses$name[uses$kind == "supplied_elsewhere" & !is.na(uses$name)]
+  missing <- setdiff(meta$inputs, c(initAssigns$name, declaredVars, suppliedElsewhere))
   if (length(missing) == 0) return(.cc_emptyFindings())
   do.call(rbind, lapply(missing, function(n)
     .cc_declaredUnused("in_no_default", "note", meta$module, n, "inputObjects")))

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -80,7 +80,24 @@
   out <- out[lengths(out) > 0]
   if (length(out) == 0) return(.cc_emptyFindings())
   findings <- do.call(rbind, out)
+  findings <- .cc_appendNolintHint(findings)
   .cc_applySuppression(findings, uses)
+}
+
+## Every suggestion ends by telling the developer how to acknowledge the
+## finding: `otherwise add # nolint: <rule_id>`. Replaces the vaguer
+## "otherwise ignore" and is appended to suggestions that don't already mention
+## `nolint`, using each finding's own rule id.
+.cc_appendNolintHint <- function(findings) {
+  if (nrow(findings) == 0) return(findings)
+  findings$suggestion <- vapply(seq_len(nrow(findings)), function(i) {
+    s <- findings$suggestion[i]
+    if (is.na(s)) return(NA_character_)
+    if (grepl("nolint", s, fixed = TRUE)) return(s)   # already mentions it
+    s <- sub("[[:space:];,]*otherwise ignore\\.?[[:space:]]*$", "", s)
+    paste0(s, "; otherwise add `# nolint: ", findings$id[i], "`")
+  }, character(1))
+  findings
 }
 
 ## Drop findings silenced either by an inline `# nolint` marker (carried on
@@ -189,7 +206,7 @@
                                                 name, name),
                 param_declared_unused = sprintf("either remove `defineParameter('%s', ...)` or add `Par$%s` (or P(sim)$%s) in module code",
                                                 name, name, name),
-                in_no_default         = sprintf("if a default is appropriate, add `if (!suppliedElsewhere('%s', sim)) sim$%s <- <default>` to .inputObjects(); otherwise ignore",
+                in_no_default         = sprintf("if a default is appropriate, add `if (!suppliedElsewhere('%s', sim)) sim$%s <- <default>` to .inputObjects()",
                                                 name, name),
                 NA_character_
               ))
@@ -332,17 +349,42 @@
 .ccr_unresolved_accessor <- function(uses, meta) {
   bad <- uses[!uses$resolved & !is.na(uses$fn), , drop = FALSE]
   if (nrow(bad) == 0) return(.cc_emptyFindings())
-  ## Aggregate: one finding per (fn, kind) showing all line numbers, so the
+  ## Classify the kind of dynamic access so the message can be specific. The
+  ## get-family (get/mget/exists/assign with a computed name) and `sim[[var]]`
+  ## are inherently un-checkable statically -- the developer must decide whether
+  ## the access is intentional (add `# nolint: unresolved_accessor`) or a bug.
+  getFamily <- c("get()", "mget()", "exists()", "assign()")
+  bad$access <- ifelse(bad$extra %in% getFamily, "getfam",
+                       ifelse(bad$kind %in% c("sim_get", "sim_assign"),
+                              "bracket", "other"))
+  ## Aggregate: one finding per (fn, access) showing all line numbers, so the
   ## report doesn't spew one row per occurrence. Tests can still see the raw
   ## Uses on .codeCheck if they want.
-  by <- split(bad, list(bad$fn, bad$kind), drop = TRUE)
+  by <- split(bad, list(bad$fn, bad$access), drop = TRUE)
   do.call(rbind, lapply(by, function(g) {
     lines <- paste(g$line, collapse = ", ")
     u <- g[1, ]
+    nolintHint <- paste0("cannot be checked statically (the object name is ",
+                         "computed at run time); if intentional, add ",
+                         "`# nolint: unresolved_accessor` on the line(s), ",
+                         "otherwise use a literal name (`sim$x`) or declare ",
+                         "the object in inputObjects/outputObjects")
+    msgSug <- switch(
+      u$access,
+      getfam = list(
+        msg = sprintf("%d dynamic `get()`/`mget()`-family access(es) of `sim` in %s (lines %s)",
+                      nrow(g), u$fn, lines),
+        sug = nolintHint),
+      bracket = list(
+        msg = sprintf("%d dynamic `sim[[<var>]]` access(es) in %s (lines %s)",
+                      nrow(g), u$fn, lines),
+        sug = nolintHint),
+      list(
+        msg = sprintf("%d unresolved %s accessor(s) in %s (lines %s) \u2014 skipped",
+                      nrow(g), u$kind, u$fn, lines),
+        sug = "if these objects should be checked, declare them explicitly in inputObjects/outputObjects"))
     .cc_findingFromUse("unresolved_accessor", "info", meta$module, u,
-                       message = sprintf("%d unresolved %s accessor(s) in %s (lines %s) \u2014 skipped",
-                                         nrow(g), u$kind, u$fn, lines),
-                       suggestion = "if these objects should be checked, declare them explicitly in inputObjects/outputObjects")
+                       message = msgSug$msg, suggestion = msgSug$sug)
   }))
 }
 

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -11,7 +11,10 @@
 ##               files = chr)
 ##
 ## Rules are dispatched by .cc_runRules(); each is enabled unless disabled via
-## options(spades.moduleCodeChecks = list(disable = c("rule_id", ...))).
+## options(spades.moduleCodeChecks = list(disable = c("rule_id", ...))). Per
+## finding, output is further filtered by .cc_applySuppression(): inline
+## `# nolint` markers in the module source, and
+## options(spades.codeChecksIgnore = list(<rule_id> = c("obj", ...))).
 
 ## Rule catalogue ------------------------------------------------------------
 
@@ -36,8 +39,15 @@
 ## Public entry: returns a Findings data.frame
 .cc_runRules <- function(uses, meta, enable = NULL, disable = NULL) {
   ids <- names(.CC_RULES)
-  if (!is.null(enable)) ids <- intersect(ids, enable)
-  if (!is.null(disable)) ids <- setdiff(ids, disable)
+  ## Honour rule enable/disable supplied via the option, in addition to the
+  ## function arguments: options(spades.moduleCodeChecks = list(disable = ...)).
+  opt <- getOption("spades.moduleCodeChecks")
+  if (is.list(opt)) {
+    enable  <- c(enable,  opt[["enable"]])
+    disable <- c(disable, opt[["disable"]])
+  }
+  if (length(enable))  ids <- intersect(ids, enable)
+  if (length(disable)) ids <- setdiff(ids, disable)
   out <- lapply(ids, function(id) {
     fn <- .CC_RULES[[id]]
     tryCatch(fn(uses, meta),
@@ -48,7 +58,59 @@
   })
   out <- out[lengths(out) > 0]
   if (length(out) == 0) return(.cc_emptyFindings())
-  do.call(rbind, out)
+  findings <- do.call(rbind, out)
+  .cc_applySuppression(findings, uses)
+}
+
+## Drop findings silenced either by an inline `# nolint` marker (carried on
+## `uses` as the "nolint"/"declLines" attributes) or by the user option
+## options(spades.codeChecksIgnore = list(<rule_id> = c("obj1", "obj2"))).
+.cc_applySuppression <- function(findings, uses) {
+  if (nrow(findings) == 0) return(findings)
+  nolint    <- attr(uses, "nolint")
+  declLines <- attr(uses, "declLines")
+  ignore    <- getOption("spades.codeChecksIgnore")
+
+  ## candidate (file, line) locations a `# nolint` could sit on to silence
+  ## finding `i`: its own source line, or — for metadata-only findings with no
+  ## line — every line of the matching declaration's span.
+  candLines <- function(i) {
+    if (!is.na(findings$line[i])) {
+      return(data.frame(file = findings$file[i], line = findings$line[i],
+                        stringsAsFactors = FALSE))
+    }
+    if (is.null(declLines) || is.na(findings$name[i])) return(NULL)
+    dl <- declLines[declLines$name == findings$name[i], , drop = FALSE]
+    if (nrow(dl) == 0) return(NULL)
+    do.call(rbind, Map(function(f, a, b)
+      data.frame(file = f, line = seq.int(a, b), stringsAsFactors = FALSE),
+      dl$file, dl$line1, dl$line2))
+  }
+
+  keep <- vapply(seq_len(nrow(findings)), function(i) {
+    fid <- findings$id[i]; fname <- findings$name[i]
+    ## user option: ignore named objects for a given rule
+    if (is.list(ignore) && !is.null(ignore[[fid]]) &&
+        !is.na(fname) && fname %in% ignore[[fid]]) {
+      return(FALSE)
+    }
+    ## inline `# nolint`
+    if (!is.null(nolint) && nrow(nolint)) {
+      cand <- candLines(i)
+      if (!is.null(cand) && nrow(cand)) {
+        for (j in seq_len(nrow(nolint))) {
+          sameFile <- (is.na(nolint$file[j]) & is.na(cand$file)) |
+            (!is.na(nolint$file[j]) & nolint$file[j] == cand$file)
+          if (any(sameFile & nolint$line[j] == cand$line)) {
+            r <- nolint$rules[[j]]
+            if (all(is.na(r)) || fid %in% r) return(FALSE)
+          }
+        }
+      }
+    }
+    TRUE
+  }, logical(1))
+  findings[keep, , drop = FALSE]
 }
 
 ## Helpers -------------------------------------------------------------------

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -36,6 +36,27 @@
   codetools                = function(uses, meta) .ccr_codetools(uses, meta)
 )
 
+## Display bucket each rule id is reported under (the `• <group>` headers).
+## Shared by the reporter and by `# nolint` / codeChecksIgnore suppression, so
+## either the rule id or its group name can be used to silence a finding.
+.CC_RULE_GROUPS <- c(
+  out_declared_unused        = "outputObjects",
+  out_used_undeclared        = "outputObjects",
+  in_declared_unused         = "inputObjects",
+  in_used_undeclared         = "inputObjects",
+  in_no_default              = "inputObjects",
+  param_declared_unused      = "parameters",
+  param_used_undeclared      = "parameters",
+  param_used_other_module    = "parameters",
+  unresolved_accessor        = "unresolved",
+  must_return_sim            = "module functions",
+  must_assign_to_sim         = "module functions",
+  module_named_object        = "module functions",
+  conflicting_fn_unqualified = "globals",
+  clashing_module_fn         = "module functions",
+  codetools                  = "codetools"
+)
+
 ## Public entry: returns a Findings data.frame
 .cc_runRules <- function(uses, meta, enable = NULL, disable = NULL) {
   ids <- names(.CC_RULES)
@@ -89,9 +110,11 @@
 
   keep <- vapply(seq_len(nrow(findings)), function(i) {
     fid <- findings$id[i]; fname <- findings$name[i]
-    ## user option: ignore named objects for a given rule
-    if (is.list(ignore) && !is.null(ignore[[fid]]) &&
-        !is.na(fname) && fname %in% ignore[[fid]]) {
+    ## a finding can be referenced by its rule id or by its group name
+    fkeys <- c(fid, .CC_RULE_GROUPS[[fid]])
+    ## user option: ignore named objects for a given rule (or group)
+    if (is.list(ignore) && !is.na(fname) &&
+        any(vapply(fkeys, function(k) fname %in% ignore[[k]], logical(1)))) {
       return(FALSE)
     }
     ## inline `# nolint`
@@ -103,7 +126,7 @@
             (!is.na(nolint$file[j]) & nolint$file[j] == cand$file)
           if (any(sameFile & nolint$line[j] == cand$line)) {
             r <- nolint$rules[[j]]
-            if (all(is.na(r)) || fid %in% r) return(FALSE)
+            if (all(is.na(r)) || any(fkeys %in% r)) return(FALSE)
           }
         }
       }

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -160,8 +160,12 @@
   uses[!is.na(uses$fn) & uses$fn == ".inputObjects", , drop = FALSE]
 }
 
+## Everything that is not provably inside .inputObjects(). A use whose
+## enclosing function could not be identified (fn = NA, e.g. a function wrapped
+## in compiler::cmpfun()/Cache()) is treated as outside, so an unrecognised
+## wrapper never produces a false "declared but unused" finding.
 .cc_outsideDotInputObjects <- function(uses) {
-  uses[!is.na(uses$fn) & uses$fn != ".inputObjects", , drop = FALSE]
+  uses[is.na(uses$fn) | uses$fn != ".inputObjects", , drop = FALSE]
 }
 
 ## Build a generic finding for a "declared but unused" object (no source pos).

--- a/R/codecheck-rules.R
+++ b/R/codecheck-rules.R
@@ -228,7 +228,17 @@
   if (length(meta$outputs) == 0) return(.cc_emptyFindings())
   outsideInit <- .cc_outsideDotInputObjects(uses)
   assigns <- outsideInit[outsideInit$kind == "sim_assign" & !is.na(outsideInit$name), , drop = FALSE]
-  missing <- setdiff(meta$outputs, assigns$name)
+  assignedNames <- assigns$name
+  ## A bulk write into envir(sim) -- e.g. list2env(mget(outputNames,
+  ## environment()), envir(sim)) -- assigns outputs by run-time name. In that
+  ## case treat an output that is computed as a same-named local variable as
+  ## produced. (mget() would error at run time if such a local were missing, so
+  ## this is reliable; outputs with no local assignment are still flagged.)
+  if (any(uses$kind == "sim_bulk_assign")) {
+    assignedNames <- c(assignedNames,
+                       uses$name[uses$kind == "local_assign" & !is.na(uses$name)])
+  }
+  missing <- setdiff(meta$outputs, assignedNames)
   if (length(missing) == 0) return(.cc_emptyFindings())
   do.call(rbind, lapply(missing, function(n)
     .cc_declaredUnused("out_declared_unused", "warning", meta$module, n, "outputObjects")))

--- a/man/codeCheckModule.Rd
+++ b/man/codeCheckModule.Rd
@@ -69,6 +69,11 @@ without editing its source.
 \item \strong{\code{options(spades.moduleCodeChecks = list(disable = ...))}.} Disable
 whole rules by id (or restrict with \code{enable = ...}).
 }
+
+A related developer hint is \verb{# nolint: vars a, b}: placed on a dynamic
+bulk-assign line whose names can't be seen statically (e.g.
+\code{list2env(someList, envir(sim))}), it asserts that objects \code{a}, \code{b} are
+produced there, so they aren't reported as \code{out_declared_unused}.
 }
 
 \section{Rule catalogue}{

--- a/man/codeCheckModule.Rd
+++ b/man/codeCheckModule.Rd
@@ -47,24 +47,51 @@ checker is still available via \code{options(spades.codeCheckEngine = "v1")}.
 }
 \section{Silencing findings}{
 
-Individual findings can be suppressed three ways (all honoured both here and
-during \code{simInit()}):
+Each finding in the printed report is tagged with its \strong{rule id} in
+brackets, e.g. \verb{[conflicting_fn_unqualified]}; that id (or the \verb{• <group>}
+name it is printed under) is what you reference to silence it. Findings can
+be suppressed three ways (all honoured both here and during \code{simInit()}):
 \itemize{
 \item \strong{Inline \verb{# nolint} (module developer).} Put a \verb{# nolint} comment on
 the offending source line to silence every rule there, or
-\verb{# nolint: <rule_id>[, <rule_id>]} to silence only specific rules. For a
+\verb{# nolint: <rule_id>[, <rule_id>]} to silence only specific rules (a
+group name such as \code{globals} is accepted in place of a rule id). For a
 metadata finding such as \code{in_no_default}, place it anywhere within the
 \code{expectsInput()} / \code{createsOutput()} / \code{defineParameter()} declaration,
 e.g. \code{expectsInput("cloudFolderID", "character", desc = "...") # nolint: in_no_default}.
 This travels with the module and documents the intent.
 \item \strong{\code{options(spades.codeChecksIgnore = ...)} (module user).} A named
-list keyed by rule id whose values are object names to ignore, e.g.
+list keyed by rule id (or group name) whose values are object names to
+ignore, e.g.
 \code{options(spades.codeChecksIgnore = list(in_no_default = c("cloudFolderID", "ecoregionRst")))}.
 Lets someone running another author's module quiet specific findings
 without editing its source.
 \item \strong{\code{options(spades.moduleCodeChecks = list(disable = ...))}.} Disable
-whole rules by id (or restrict with \code{enable = ...}); see
-\code{names(SpaDES.core:::.CC_RULES)} for the catalogue.
+whole rules by id (or restrict with \code{enable = ...}).
+}
+}
+
+\section{Rule catalogue}{
+
+The rule ids (printed in brackets in the report), grouped by the bucket they
+appear under:
+\itemize{
+\item \strong{inputObjects} — \code{in_declared_unused} (declared input never used),
+\code{in_used_undeclared} (\code{sim$x} read but not in \code{inputObjects}),
+\code{in_no_default} (declared input has no default in \code{.inputObjects()}).
+\item \strong{outputObjects} — \code{out_declared_unused} (declared output never
+assigned), \code{out_used_undeclared} (\verb{sim$x <-} but not in \code{outputObjects}).
+\item \strong{parameters} — \code{param_declared_unused}, \code{param_used_undeclared},
+\code{param_used_other_module}.
+\item \strong{module functions} — \code{must_return_sim} (a \verb{doEvent.*} must return
+\code{sim}), \code{must_assign_to_sim}, \code{module_named_object} (\verb{sim$<module>}
+collides with the module name), \code{clashing_module_fn}.
+\item \strong{globals} — \code{conflicting_fn_unqualified} (a bare function name
+collides with a \verb{raster::} namesake; qualify it, e.g. \code{raster::scale}).
+\item \strong{unresolved} — \code{unresolved_accessor} (an accessor whose name could
+not be resolved statically).
+\item \strong{codetools} — \code{codetools} (findings relayed from
+\code{codetools::checkUsageEnv}).
 }
 
 \code{codeCheckModule()} checks a single module. \code{codeCheckModules()} is the

--- a/man/codeCheckModule.Rd
+++ b/man/codeCheckModule.Rd
@@ -44,6 +44,28 @@ structured tibble of findings, optionally printed as grouped tables.
 This is the v2 implementation, selectable at \code{simInit()} time via
 \code{options(spades.codeCheckEngine = "v2")} (the default). The legacy v1
 checker is still available via \code{options(spades.codeCheckEngine = "v1")}.
+}
+\section{Silencing findings}{
+
+Individual findings can be suppressed three ways (all honoured both here and
+during \code{simInit()}):
+\itemize{
+\item \strong{Inline \verb{# nolint} (module developer).} Put a \verb{# nolint} comment on
+the offending source line to silence every rule there, or
+\verb{# nolint: <rule_id>[, <rule_id>]} to silence only specific rules. For a
+metadata finding such as \code{in_no_default}, place it anywhere within the
+\code{expectsInput()} / \code{createsOutput()} / \code{defineParameter()} declaration,
+e.g. \code{expectsInput("cloudFolderID", "character", desc = "...") # nolint: in_no_default}.
+This travels with the module and documents the intent.
+\item \strong{\code{options(spades.codeChecksIgnore = ...)} (module user).} A named
+list keyed by rule id whose values are object names to ignore, e.g.
+\code{options(spades.codeChecksIgnore = list(in_no_default = c("cloudFolderID", "ecoregionRst")))}.
+Lets someone running another author's module quiet specific findings
+without editing its source.
+\item \strong{\code{options(spades.moduleCodeChecks = list(disable = ...))}.} Disable
+whole rules by id (or restrict with \code{enable = ...}); see
+\code{names(SpaDES.core:::.CC_RULES)} for the catalogue.
+}
 
 \code{codeCheckModule()} checks a single module. \code{codeCheckModules()} is the
 vectorized form: it runs \code{codeCheckModule()} on each path in \code{paths} and
@@ -53,3 +75,4 @@ so \code{codeCheckModules()} with no arguments checks the whole project. It
 replaces the manual idiom
 \code{Map(codeCheckModule, dir(getOption("spades.modulePath"), full.names = TRUE))}.
 }
+

--- a/man/codeCheckModule.Rd
+++ b/man/codeCheckModule.Rd
@@ -97,6 +97,12 @@ collides with a \verb{raster::} namesake; qualify it, e.g. \code{raster::scale})
 not be resolved statically).
 \item \strong{codetools} — \code{codetools} (findings relayed from
 \code{codetools::checkUsageEnv}).
+\item \strong{reqdPkgs} — \code{reqd_pkg_duplicate} (a package declared more than
+once in \code{reqdPkgs}, especially with conflicting source/version),
+\code{reqd_pkg_undeclared} (a \code{pkg::fn} whose \code{pkg} is not in \code{reqdPkgs}),
+\code{reqd_pkg_no_source} (best-effort, info: bare calls with no apparent
+source among the declared packages — only when all declared packages are
+installed).
 }
 
 \code{codeCheckModule()} checks a single module. \code{codeCheckModules()} is the

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -344,6 +344,30 @@ Init <- function(sim) {
   expect_false("param_used_undeclared" %in% f$id)
 })
 
+test_that("reqd_pkg_duplicate flags a package declared twice (conflict)", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  skip_if_not_installed("Require")
+  src <- '
+defineModule(sim, list(
+  name = "m",
+  reqdPkgs = list("terra",
+                  "SpaDES.core (>= 3.0.1)",
+                  "PredictiveEcology/SpaDES.core@branch (>= 3.0.4)",
+                  "deldir"),
+  inputObjects = bindrows(),
+  outputObjects = bindrows()
+))
+'
+  tf <- withr::local_tempfile(fileext = ".R")
+  writeLines(src, tf)
+  f <- codeCheckModule(tf, print = FALSE)
+  dup <- f[f$id == "reqd_pkg_duplicate", , drop = FALSE]
+  expect_equal(dup$name, "SpaDES.core")
+  expect_equal(dup$severity, "warning")          # differing source/version -> conflict
+  expect_false(any(c("terra", "deldir") %in% dup$name))
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -396,6 +396,28 @@ Init <- function(sim) {
   expect_false("stats" %in% missing)             # base package
 })
 
+test_that("# nolint: vars asserts produced outputs for a dynamic bulk assign", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+Init <- function(sim) {
+  sppOuts <- sppHarmonize(sim$sppEquiv, P(sim)$sppEquivCol)
+  list2env(sppOuts, envir = envir(sim))  # nolint: vars sppEquiv, sppColorVect
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  expect_setequal(uses$name[uses$kind == "declared_var"], c("sppEquiv", "sppColorVect"))
+  meta <- list(module = "m", inputs = character(),
+               outputs = c("sppEquiv", "sppColorVect", "notProduced"),
+               params = character(), otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  unused <- f$name[f$id == "out_declared_unused"]
+  expect_false("sppEquiv" %in% unused)
+  expect_false("sppColorVect" %in% unused)
+  expect_true("notProduced" %in% unused)         # no assertion -> still flagged
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -273,6 +273,29 @@ Init <- function(sim) {
   expect_false("conflicting_fn_unqualified" %in% f$id)
 })
 
+test_that("suggestions end with a `# nolint: <rule_id>` acknowledgement", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+Init <- function(sim) {
+  a <- scale(1)
+  sim$undeclared <- 1
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  meta <- list(module = "m", inputs = character(), outputs = character(),
+               params = character(), otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  withSug <- f[!is.na(f$suggestion), , drop = FALSE]
+  expect_true(nrow(withSug) > 0)
+  ## each suggestion references nolint with the finding's own rule id
+  expect_true(all(mapply(function(s, id) grepl(paste0("# nolint: ", id), s, fixed = TRUE),
+                         withSug$suggestion, withSug$id)))
+  ## the old vague wording is gone
+  expect_false(any(grepl("otherwise ignore", f$suggestion, fixed = TRUE)))
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -84,6 +84,33 @@ Init <- function(sim) {
   expect_equal(sum(uses$kind == "sim_get" & !uses$resolved), 1L)
 })
 
+test_that("enclosing fn is found through wrapper calls (e.g. cmpfun)", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+SummaryBGM <- compiler::cmpfun(function(sim) {
+  sim$ANPPMap <- rasterizeReduced(x, sim$pixelGroupMap, "uniqueSumANPP")
+  sim
+})
+anon <- function(sim) {
+  lapply(1:2, function(z) sim$inner <- z)   # anonymous: not attributed
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  ## the assign wrapped in cmpfun() is attributed to its binding name
+  anpp <- uses[uses$name == "ANPPMap" & uses$kind == "sim_assign", , drop = FALSE]
+  expect_equal(anpp$fn, "SummaryBGM")
+  ## an assign declared as an output is therefore seen as "used"
+  meta <- list(module = "m", inputs = character(), outputs = "ANPPMap",
+               params = character(), otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  expect_false("ANPPMap" %in% f$name[f$id == "out_declared_unused"])
+  ## the anonymous lapply callback is not misattributed to the outer function
+  inner <- uses[uses$name == "inner" & uses$kind == "sim_assign", , drop = FALSE]
+  expect_true(is.na(inner$fn))
+})
+
 test_that("collector recognizes all parameter accessor forms", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -109,6 +109,27 @@ Init <- function(sim) {
   expect_equal(modByName[["epsilon"]], "other")
 })
 
+test_that("params(sim)[[currentModule(sim)]]$x resolves to the current module", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+Init <- function(sim) {
+  params(sim)[[currentModule(sim)]]$pixelGroupAgeClass <- P(sim)$successionTimestep
+  z <- params(sim)[[someVar]]$bar   # genuinely unresolved
+  return(invisible(sim))
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "thisMod")
+  pUses <- uses[uses$kind == "param", , drop = FALSE]
+  ## the currentModule(sim) key resolves to the current module
+  pgac <- pUses[pUses$name == "pixelGroupAgeClass", , drop = FALSE]
+  expect_equal(nrow(pgac), 1L)
+  expect_true(pgac$resolved)
+  expect_equal(pgac$module, "thisMod")
+  ## a non-literal, non-currentModule key is still unresolved
+  expect_true(any(uses$kind == "param" & !uses$resolved))
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -489,6 +489,37 @@ Init <- function(sim) {
   expect_false("reqd_pkg_no_source" %in% f$id)   # incomplete export info -> quiet
 })
 
+test_that("in_no_default honours # nolint: vars and suppliedElsewhere guards", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+.inputObjects <- function(sim) {
+  for (nam in objsHere) {
+    sim[[paste0(nam, "s")]] <- mget(x, envir(sim)) # nolint: vars cohortDatas
+  }
+  if (!suppliedElsewhere("historicalClimateRasters", sim)) {
+    stop("please supply it")
+  }
+  if (!suppliedElsewhere(standAgeMap, sim)) {
+    sim$standAgeMap <- makeDefault()
+  }
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  meta <- list(module = "m",
+               inputs = c("cohortDatas", "historicalClimateRasters",
+                          "standAgeMap", "propFlammables"),
+               outputs = character(), params = character(),
+               otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  flagged <- f$name[f$id == "in_no_default"]
+  expect_false("cohortDatas" %in% flagged)                # # nolint: vars
+  expect_false("historicalClimateRasters" %in% flagged)   # suppliedElsewhere + stop
+  expect_false("standAgeMap" %in% flagged)                # suppliedElsewhere + default
+  expect_true("propFlammables" %in% flagged)              # genuinely no default
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -465,9 +465,30 @@ Init <- function(sim) {
   writeLines(src, tf)
   f <- codeCheckModule(tf, print = FALSE)
   ns <- f[f$id == "reqd_pkg_no_source", , drop = FALSE]
-  expect_equal(nrow(ns), 1L)
-  expect_match(ns$message, "totallyMadeUpFn")
-  expect_false(grepl("\\brast\\b|myHelper|\\bpaste\\b", ns$message))
+  ## one finding per no-source function, carrying its name + source line
+  expect_equal(ns$name, "totallyMadeUpFn")
+  expect_true(all(!is.na(ns$line)))
+  expect_false(any(c("rast", "myHelper", "paste") %in% ns$name))
+})
+
+test_that("reqd_pkg_no_source ignores data.table `.` syntax", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  skip_if_not_installed("data.table")
+  src <- '
+defineModule(sim, list(
+  name = "m", reqdPkgs = list("data.table"),
+  inputObjects = bindrows(), outputObjects = bindrows()
+))
+Init <- function(sim) {
+  DT[, .(s = sum(x))]
+  sim
+}
+'
+  tf <- withr::local_tempfile(fileext = ".R")
+  writeLines(src, tf)
+  f <- codeCheckModule(tf, print = FALSE)
+  expect_false("." %in% f$name[f$id == "reqd_pkg_no_source"])
 })
 
 test_that("reqd_pkg_no_source stays quiet if a declared package is not installed", {

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -111,6 +111,25 @@ anon <- function(sim) {
   expect_true(is.na(inner$fn))
 })
 
+test_that("sim[[var]] in an anonymous lapply callback is not flagged unresolved", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  ## a dynamic accessor inside an anonymous callback (fn = NA) must not surface
+  ## as an unresolved_accessor finding (which requires a known enclosing fn)
+  src <- '
+Init <- function(sim) {
+  haveAllRasters <- all(!unlist(lapply(rasterNamesToCompare,
+                                       function(rn) is.null(sim[[rn]]))))
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  meta <- list(module = "m", inputs = character(), outputs = character(),
+               params = character(), otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  expect_false("unresolved_accessor" %in% f$id)
+})
+
 test_that("collector recognizes all parameter accessor forms", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -322,6 +322,28 @@ Init <- function(sim) {
   expect_true("neverProduced" %in% unused)
 })
 
+test_that("paramCheckOtherMods(sim, 'x') marks x a used parameter", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+Init <- function(sim) {
+  a <- SpaDES.core::paramCheckOtherMods(sim, "spreadFitFilename")
+  b <- paramCheckOtherMods(sim, "otherParam")
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  pc <- uses[uses$kind == "param" & uses$extra == "paramCheckOtherMods()", , drop = FALSE]
+  expect_setequal(pc$name, c("spreadFitFilename", "otherParam"))
+  ## a declared param read only via paramCheckOtherMods is "used"
+  meta <- list(module = "m", inputs = character(), outputs = character(),
+               params = "spreadFitFilename", otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  expect_false("spreadFitFilename" %in% f$name[f$id == "param_declared_unused"])
+  ## and is exempt from used-but-not-declared (it belongs to other modules)
+  expect_false("param_used_undeclared" %in% f$id)
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -443,6 +443,52 @@ helper <- function(sim) {
   expect_false(any(grepl("inputObjects|helper|lines", gf$message)))
 })
 
+test_that("reqd_pkg_no_source reports bare calls with no apparent source", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  skip_if_not_installed("terra")
+  src <- '
+defineModule(sim, list(
+  name = "m", reqdPkgs = list("terra"),
+  inputObjects = bindrows(), outputObjects = bindrows()
+))
+myHelper <- function(x) x + 1
+Init <- function(sim) {
+  a <- rast(2)                # terra export -> sourced
+  b <- myHelper(3)            # local -> sourced
+  d <- paste("x")             # base -> sourced
+  e <- totallyMadeUpFn(4)     # no apparent source
+  sim
+}
+'
+  tf <- withr::local_tempfile(fileext = ".R")
+  writeLines(src, tf)
+  f <- codeCheckModule(tf, print = FALSE)
+  ns <- f[f$id == "reqd_pkg_no_source", , drop = FALSE]
+  expect_equal(nrow(ns), 1L)
+  expect_match(ns$message, "totallyMadeUpFn")
+  expect_false(grepl("\\brast\\b|myHelper|\\bpaste\\b", ns$message))
+})
+
+test_that("reqd_pkg_no_source stays quiet if a declared package is not installed", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+defineModule(sim, list(
+  name = "m", reqdPkgs = list("aPackageThatIsNotInstalled12345"),
+  inputObjects = bindrows(), outputObjects = bindrows()
+))
+Init <- function(sim) {
+  e <- totallyMadeUpFn(4)
+  sim
+}
+'
+  tf <- withr::local_tempfile(fileext = ".R")
+  writeLines(src, tf)
+  f <- codeCheckModule(tf, print = FALSE)
+  expect_false("reqd_pkg_no_source" %in% f$id)   # incomplete export info -> quiet
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -418,6 +418,31 @@ Init <- function(sim) {
   expect_true("notProduced" %in% unused)         # no assertion -> still flagged
 })
 
+test_that("unresolved accessors share a generic message so the report collapses them", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+.inputObjects <- function(sim) {
+  d <- mget(names, envir(sim))
+  sim
+}
+helper <- function(sim) {
+  e <- get(nm, envir(sim))
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  meta <- list(module = "m", inputs = character(), outputs = character(),
+               params = character(), otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  gf <- f[f$id == "unresolved_accessor", , drop = FALSE]
+  ## two get-family occurrences in different functions, one finding each, but
+  ## with an identical (location-free) message so the report groups them
+  expect_equal(nrow(gf), 2L)
+  expect_equal(length(unique(gf$message)), 1L)
+  expect_false(any(grepl("inputObjects|helper|lines", gf$message)))
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -130,6 +130,82 @@ Init <- function(sim) {
   expect_true(any(uses$kind == "param" & !uses$resolved))
 })
 
+test_that("inline # nolint suppresses findings (line and declaration span)", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+defineModule(sim, list(
+  name = "nolintMod",
+  inputObjects = bindrows(
+    expectsInput("cloudFolderID", "character", desc = "x"), # nolint: in_no_default
+    expectsInput("ecoregionRst", "RasterLayer",
+                 desc = "multi-line"), # nolint
+    expectsInput("needsIt", "character", desc = "still flagged")
+  ),
+  outputObjects = bindrows()
+))
+.inputObjects <- function(sim) sim
+Init <- function(sim) {
+  a <- scale(1)            # nolint: conflicting_fn_unqualified
+  b <- levels(2)
+  sim
+}
+'
+  tf <- withr::local_tempfile(fileext = ".R")
+  writeLines(src, tf)
+  f <- codeCheckModule(tf, print = FALSE)
+  inNoDef <- f$name[f$id == "in_no_default"]
+  ## rule-specific nolint on the line, and blanket nolint within the
+  ## (multi-line) declaration span, both silence in_no_default
+  expect_false("cloudFolderID" %in% inNoDef)
+  expect_false("ecoregionRst" %in% inNoDef)
+  expect_true("needsIt" %in% inNoDef)
+  ## rule-specific nolint silences only that rule on that line
+  conf <- f$name[f$id == "conflicting_fn_unqualified"]
+  expect_false("scale" %in% conf)
+  expect_true("levels" %in% conf)
+})
+
+test_that("options(spades.codeChecksIgnore) suppresses by rule + object name", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+defineModule(sim, list(
+  name = "ignoreMod",
+  inputObjects = bindrows(
+    expectsInput("a", "character", desc = "x"),
+    expectsInput("b", "character", desc = "y")
+  ),
+  outputObjects = bindrows()
+))
+.inputObjects <- function(sim) sim
+'
+  tf <- withr::local_tempfile(fileext = ".R")
+  writeLines(src, tf)
+  withr::local_options(spades.codeChecksIgnore = list(in_no_default = "a"))
+  f <- codeCheckModule(tf, print = FALSE)
+  inNoDef <- f$name[f$id == "in_no_default"]
+  expect_false("a" %in% inNoDef)
+  expect_true("b" %in% inNoDef)
+})
+
+test_that("options(spades.moduleCodeChecks=list(disable=)) disables a whole rule", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+Init <- function(sim) {
+  a <- scale(1)
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  withr::local_options(spades.moduleCodeChecks = list(disable = "conflicting_fn_unqualified"))
+  meta <- list(module = "m", inputs = character(), outputs = character(),
+               params = character(), otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  expect_false("conflicting_fn_unqualified" %in% f$id)
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -166,6 +166,27 @@ Init <- function(sim) {
   expect_true("levels" %in% conf)
 })
 
+test_that("# nolint accepts a group name as well as a rule id", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+Init <- function(sim) {
+  a <- scale(1)                            # nolint: globals
+  b <- levels(2)                           # nolint: conflicting_fn_unqualified
+  d <- scale(3)
+  sim
+}
+'
+  tf <- withr::local_tempfile(fileext = ".R")
+  writeLines(src, tf)
+  f <- codeCheckModule(tf, print = FALSE)
+  conf <- f[f$id == "conflicting_fn_unqualified", , drop = FALSE]
+  ## the group-name and rule-id markers each silence their own line; the
+  ## un-marked scale(3) remains
+  expect_equal(nrow(conf), 1L)
+  expect_equal(conf$name, "scale")
+})
+
 test_that("options(spades.codeChecksIgnore) suppresses by rule + object name", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -368,6 +368,34 @@ defineModule(sim, list(
   expect_false(any(c("terra", "deldir") %in% dup$name))
 })
 
+test_that("reqd_pkg_undeclared flags pkg::fn whose pkg is not in reqdPkgs", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  skip_if_not_installed("Require")
+  src <- '
+defineModule(sim, list(
+  name = "m",
+  reqdPkgs = list("terra", "PredictiveEcology/reproducible@dev (>= 3.0.0)"),
+  inputObjects = bindrows(), outputObjects = bindrows()
+))
+Init <- function(sim) {
+  a <- terra::rast(1)
+  b <- reproducible::Cache(f)
+  d <- data.table::data.table()
+  e <- stats::lm(y ~ x)
+  sim
+}
+'
+  tf <- withr::local_tempfile(fileext = ".R")
+  writeLines(src, tf)
+  f <- codeCheckModule(tf, print = FALSE)
+  missing <- f$name[f$id == "reqd_pkg_undeclared"]
+  expect_true("data.table" %in% missing)        # used via :: but not declared
+  expect_false("terra" %in% missing)             # declared
+  expect_false("reproducible" %in% missing)      # declared via GitHub spec
+  expect_false("stats" %in% missing)             # base package
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-codecheck.R
+++ b/tests/testthat/test-codecheck.R
@@ -296,6 +296,32 @@ Init <- function(sim) {
   expect_false(any(grepl("otherwise ignore", f$suggestion, fixed = TRUE)))
 })
 
+test_that("list2env(..., envir(sim)) bulk write counts local assigns as outputs", {
+  skip_if_not_installed("xmlparsedata")
+  skip_if_not_installed("xml2")
+  src <- '
+Init <- function(sim) {
+  studyArea <- makeSA()
+  rasterToMatch <- makeRTM()
+  objsHere <- depends(sim)@dependencies[[currentModule(sim)]]@outputObjects$objectName
+  list2env(mget(objsHere, envir = environment()), envir = envir(sim))
+  sim
+}
+'
+  uses <- .cc_collectModule(text = src, currentModule = "m")
+  meta <- list(module = "m",
+               inputs = character(),
+               outputs = c("studyArea", "rasterToMatch", "neverProduced"),
+               params = character(), otherModuleParams = list(), moduleEnv = NULL)
+  f <- .cc_runRules(uses, meta)
+  unused <- f$name[f$id == "out_declared_unused"]
+  ## locally-assigned outputs are treated as produced via the bulk write
+  expect_false("studyArea" %in% unused)
+  expect_false("rasterToMatch" %in% unused)
+  ## an output that is neither sim$-assigned nor a local assignment is still flagged
+  expect_true("neverProduced" %in% unused)
+})
+
 test_that("LHS vs RHS distinction is correct", {
   skip_if_not_installed("xmlparsedata")
   skip_if_not_installed("xml2")


### PR DESCRIPTION
## Summary
The code-check report repeated the full message + suggestion for every hit of the same issue. This collapses them: hits that share a rule and the same message *after blanking the finding's own name* group under one header, with one line per location.

So instead of:
```
• globals
[warn]  `scale()` is ambiguous (collides with raster:: namesake) (Biomass_borealDataPrep.R:1012:24)
↪ use the qualified form, e.g., `raster::scale(...)` for the raster variant
[warn]  `scale()` is ambiguous (collides with raster:: namesake) (Biomass_borealDataPrep.R:1013:23)
↪ use the qualified form, e.g., `raster::scale(...)` for the raster variant
[warn]  `levels()` is ambiguous (collides with raster:: namesake) (...)
↪ ...
```
you get:
```
• globals
[warn]  `<name>()` is ambiguous (collides with raster:: namesake)
         `levels` (Biomass_borealDataPrep.R:926:19)
         `scale`  (Biomass_borealDataPrep.R:1012:24)
         `scale`  (Biomass_borealDataPrep.R:1013:23)
         ...
↪ use the qualified form, e.g., `raster::<name>(...)` for the raster variant
```

This also collapses non-identical-but-same-issue cases such as multiple inputs with no default (`cloudFolderID`, `ecoregionRst`), since the grouping key blanks the finding's `name`.

- Singletons render exactly as before.
- The returned findings `data.frame` is unchanged — only the printed report differs.
- `tests/testthat/test-codecheck.R` passes (it asserts on the data.frame, not captured text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)