### PR TITLE
fix(restart): carry `events` filter through to restartSpades (#354)

### DIFF
--- a/R/restart.R
+++ b/R/restart.R
@@ -307,7 +307,12 @@ restartSpades <- function(sim = NULL, module = NULL, numEvents = 1L, restart = T
     # an NFS-backed .so) when packages are touched again unnecessarily.
     opts <- options(spades.loadReqdPkgs = FALSE)
     on.exit(options(opts), add = TRUE)
-    sim <- spades(sim, ...)
+    ## reuse the `events` filter from the interrupted spades call (issue #354),
+    ## unless the user supplied a new one to restartSpades(...)
+    dots <- list(...)
+    if (!"events" %in% ...names() && !is.null(sim@.xData[["._spadesEvents"]]))
+      dots$events <- sim@.xData[["._spadesEvents"]]
+    sim <- do.call(spades, append(list(sim), dots))
   }
   # } else {
   #   message("There was no interrupted spades call; returning sim as is")

--- a/R/simulation-spades.R
+++ b/R/simulation-spades.R
@@ -979,6 +979,12 @@ setMethod(
       if (is.null(sim@.xData[["._startClockTime"]]))
         sim@.xData[["._startClockTime"]] <- Sys.time()
 
+      ## store the events filter so a subsequent restartSpades reuses the same
+      ## subset of events (issue #354). The sim env is the one saved on a crash,
+      ## so this persists into savedSimEnv()$.sim. Set unconditionally (incl. NULL)
+      ## so a later spades() call without `events` clears any stale filter.
+      sim@.xData[["._spadesEvents"]] <- events
+
       if (is.list(events)) {
         unspecifiedEvents <- setdiff(unlist(modules(sim, TRUE)), names(events))
         unspecifiedEvents <- setdiff(unspecifiedEvents, "progress")

--- a/tests/testthat/test-mod.R
+++ b/tests/testthat/test-mod.R
@@ -261,6 +261,113 @@ test_that("spades.recoveryMode = FALSE does not populate .recoverableObjs", {
   expect_null(saved$.recoverableObjs)
 })
 
+test_that("restartSpades reuses the `events` filter from the interrupted spades call (#354)", {
+  testInit(smcc = FALSE, debug = FALSE,
+           opts = list(reproducible.useMemoise = FALSE))
+  withr::local_options(reproducible.cachePath = tmpCache,
+                       spades.recoveryMode = TRUE,
+                       spades.saveSimOnExit = TRUE,
+                       ## boom crashes while this is TRUE; we flip it before restart
+                       spades.test354.crash = TRUE)
+
+  ## A one-module workflow with an extra `final` event that the `events` filter
+  ## deliberately excludes. The bug: restartSpades dropped the filter and ran it.
+  newModule(
+    name = "m354", path = tmpdir, open = FALSE, useGitHub = FALSE, unitTests = FALSE,
+    events = list(
+      init = {
+        sim$steps <- "init"
+        sim <- scheduleEvent(sim, start(sim), "m354", "advance")
+        sim <- scheduleEvent(sim, start(sim), "m354", "boom")
+        sim <- scheduleEvent(sim, start(sim), "m354", "final")
+      },
+      advance = {
+        sim$steps <- c(sim$steps, "advance")
+        sim <- scheduleEvent(sim, time(sim) + 1, "m354", "advance")
+      },
+      boom = {
+        if (isTRUE(getOption("spades.test354.crash"))) stop("intentional crash #354")
+        sim$steps <- c(sim$steps, "boom-fixed")
+        sim <- scheduleEvent(sim, time(sim) + 1, "m354", "boom")
+      },
+      final = {
+        sim$steps <- c(sim$steps, "final")
+        sim <- scheduleEvent(sim, time(sim) + 1, "m354", "final")
+      }
+    )
+  )
+
+  mySim <- simInit(modules = "m354", paths = list(modulePath = tmpdir),
+                   times = list(start = 0, end = 3))
+
+  ## first run: filter to init/advance/boom (no `final`); boom crashes
+  err <- try(spades(mySim, events = list(m354 = c("init", "advance", "boom")),
+                    debug = FALSE), silent = TRUE)
+  expect_s3_class(err, "try-error")
+  expect_match(attr(err, "condition")$message, "intentional crash #354")
+
+  ## the filter must have been stashed on the saved sim
+  saved <- savedSimEnv()$.sim
+  expect_identical(saved@.xData[["._spadesEvents"]], list(m354 = c("init", "advance", "boom")))
+
+  ## fix the crash and restart WITHOUT re-passing `events`
+  withr::local_options(spades.test354.crash = FALSE)
+  resumed <- restartSpades(debug = FALSE)
+  expect_s4_class(resumed, "simList")
+
+  ## the excluded `final` event must never have run; advance/boom did
+  expect_false("final" %in% resumed$steps)
+  expect_true("boom-fixed" %in% resumed$steps)
+  expect_true("advance" %in% resumed$steps)
+})
+
+test_that("restartSpades(events=) overrides the stashed filter (#354)", {
+  testInit(smcc = FALSE, debug = FALSE,
+           opts = list(reproducible.useMemoise = FALSE))
+  withr::local_options(reproducible.cachePath = tmpCache,
+                       spades.recoveryMode = TRUE,
+                       spades.saveSimOnExit = TRUE,
+                       spades.test354.crash = TRUE)
+
+  newModule(
+    name = "m354b", path = tmpdir, open = FALSE, useGitHub = FALSE, unitTests = FALSE,
+    events = list(
+      init = {
+        sim$steps <- "init"
+        sim <- scheduleEvent(sim, start(sim), "m354b", "advance")
+        sim <- scheduleEvent(sim, start(sim), "m354b", "boom")
+        sim <- scheduleEvent(sim, start(sim), "m354b", "final")
+      },
+      advance = {
+        sim$steps <- c(sim$steps, "advance")
+        sim <- scheduleEvent(sim, time(sim) + 1, "m354b", "advance")
+      },
+      boom = {
+        if (isTRUE(getOption("spades.test354.crash"))) stop("intentional crash #354")
+        sim$steps <- c(sim$steps, "boom-fixed")
+        sim <- scheduleEvent(sim, time(sim) + 1, "m354b", "boom")
+      },
+      final = {
+        sim$steps <- c(sim$steps, "final")
+        sim <- scheduleEvent(sim, time(sim) + 1, "m354b", "final")
+      }
+    )
+  )
+
+  mySim <- simInit(modules = "m354b", paths = list(modulePath = tmpdir),
+                   times = list(start = 0, end = 3))
+
+  err <- try(spades(mySim, events = list(m354b = c("init", "advance", "boom")),
+                    debug = FALSE), silent = TRUE)
+  expect_s3_class(err, "try-error")
+
+  ## a fresh filter passed to restartSpades wins over the stashed one
+  withr::local_options(spades.test354.crash = FALSE)
+  resumed <- restartSpades(events = list(m354b = c("init", "advance", "boom", "final")),
+                           debug = FALSE)
+  expect_true("final" %in% resumed$steps)
+})
+
 test_that("convertToPackage testing", {
   skip_on_cran()
 


### PR DESCRIPTION
## Problem

Fixes #354.

The `events =` argument to `spades()` filters which events run (via `isListedEvent()` / `doEvent()`). But that filter lived only as a function argument. On a crash, the `simList` is saved to `savedSimEnv()$.sim` **without** the filter, so when `restartSpades()` relaunches via `spades(sim, ...)` it runs with `events = NULL` — executing *all* events, including ones the user explicitly excluded.

In the issue's reprex, the first run was limited to `init`/`advance`/`boom`, but after `restartSpades()` the excluded `final` event ran on every step.

## Fix

- **`R/simulation-spades.R`**: persist the filter into the sim env as `._spadesEvents` at the start of the event loop (the sim env is exactly what gets saved on a crash). Set unconditionally — including `NULL` — so a later `spades()` call without `events` clears any stale filter rather than silently reusing an old one.
- **`R/restart.R`**: when `restartSpades()` relaunches `spades()`, reuse the stashed filter unless the caller passes a fresh `events`.

```r
dots <- list(...)
if (!"events" %in% ...names() && !is.null(sim@.xData[["._spadesEvents"]]))
  dots$events <- sim@.xData[["._spadesEvents"]]
sim <- do.call(spades, append(list(sim), dots))
```

## Tests

Adds two regression tests to `tests/testthat/test-mod.R`:
- the stashed filter is reused on restart, so an excluded event stays excluded;
- an `events` argument passed directly to `restartSpades()` overrides the stashed filter.

Verified locally against the reprex and three paths (filtered/unfiltered/override); `test-mod.R` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)