### PR TITLE
test: isolate figure output per test in test-Plots.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,14 @@
   Supply a new `events` argument to `restartSpades()` to override it. See
   `?restartSpades`.
 
+## Bug fixes
+
+* Fixed a plotting test that could fail when the test suite was run more than
+  once in the same R session: the tests had been writing their figures to one
+  shared folder, so leftover files from one test could be mistaken for
+  another's. Each test now writes to its own folder. (Test-only change; no
+  effect on the package itself.)
+
 # SpaDES.core 3.1.2.9002 (development version)
 
 These changes are all to the module code checker, which warns module authors

--- a/tests/testthat/test-Plots.R
+++ b/tests/testthat/test-Plots.R
@@ -69,7 +69,7 @@ test_that("Plots function 1", {
 
 
     ', fill = TRUE)
-    sim <- simInit(modules = "test", paths = list(modulePath = tmpdir),
+    sim <- simInit(modules = "test", paths = list(modulePath = tmpdir, outputPath = file.path(tmpdir, "outputs")),
                    times = list(start = 0, end = 10, timeunit = "year"))
     mess <- capture_messages({
       simOut <- spades(sim, debug = TRUE)
@@ -144,7 +144,7 @@ test_that("Plots function 2", {
       }
 ', fill = TRUE)
   expect_error({
-    sim <- simInit(modules = "test", paths = list(modulePath = tmpdir),
+    sim <- simInit(modules = "test", paths = list(modulePath = tmpdir, outputPath = file.path(tmpdir, "outputs")),
                    times = list(start = 0, end = 10, timeunit = "year"))
     }, "needs a newer version of SpaDES.core"
   )
@@ -237,7 +237,7 @@ test_that("Plots - base R fn (non-gg result)", {
     fnHist <- function(d, ...) hist(d$a, main = "test", ...)
   ', fill = TRUE)
 
-  sim <- simInit(modules = "test", paths = list(modulePath = tmpdir),
+  sim <- simInit(modules = "test", paths = list(modulePath = tmpdir, outputPath = file.path(tmpdir, "outputs")),
                  times = list(start = 0, end = 1, timeunit = "year"))
   suppressMessages(simOut <- spades(sim, debug = FALSE))
   files <- dir(figurePath(sim), full.names = TRUE, recursive = TRUE)
@@ -279,7 +279,7 @@ test_that("Plots - terra SpatRaster and SpatVector", {
     }
   ', fill = TRUE)
 
-  sim <- simInit(modules = "test", paths = list(modulePath = tmpdir),
+  sim <- simInit(modules = "test", paths = list(modulePath = tmpdir, outputPath = file.path(tmpdir, "outputs")),
                  times = list(start = 0, end = 1, timeunit = "year"))
   suppressMessages(simOut <- spades(sim, debug = FALSE))
   files <- dir(figurePath(sim), full.names = TRUE, recursive = TRUE)
@@ -325,7 +325,7 @@ test_that("Plots - named ... args without data argument", {
     }
   ', fill = TRUE)
 
-  sim <- simInit(modules = "test", paths = list(modulePath = tmpdir),
+  sim <- simInit(modules = "test", paths = list(modulePath = tmpdir, outputPath = file.path(tmpdir, "outputs")),
                  times = list(start = 0, end = 1, timeunit = "year"))
   suppressMessages(simOut <- spades(sim, debug = FALSE))
   files <- dir(figurePath(sim), full.names = TRUE, recursive = TRUE)
@@ -363,7 +363,7 @@ test_that("Plots - ggplot object passed directly as data", {
     }
   ', fill = TRUE)
 
-  sim <- simInit(modules = "test", paths = list(modulePath = tmpdir),
+  sim <- simInit(modules = "test", paths = list(modulePath = tmpdir, outputPath = file.path(tmpdir, "outputs")),
                  times = list(start = 0, end = 1, timeunit = "year"))
   suppressMessages(simOut <- spades(sim, debug = FALSE))
   files <- dir(figurePath(sim), full.names = TRUE, recursive = TRUE)


### PR DESCRIPTION
## Summary

`test-Plots.R` tests only set `modulePath` in their `simInit()` calls, so `figurePath(sim)` resolved to the **session-wide default** output path (`tempdir()/SpaDES/outputs/figures`) — shared by every test in the file. Not all of those tests clean up their figures, so running the test suite a **second time in the same R session** (e.g., calling `devtools::test()` twice) left files from one test (`hist_test*`, `ras_test*`, …) in the folder that "Plots function 1" then checks with `expect_true(all(grepl("testing", files)))`, producing a spurious failure on the second run.

## Fix

Each test now passes its own `outputPath = file.path(tmpdir, "outputs")` (where `tmpdir` is the unique per-test directory from `testInit()`), so figures are isolated per test and per session run.

This is a **test-only** change — no package code is touched.

## Verification

Before: on the base commit, `test-Plots.R` passes on the first run in a session but fails on the 2nd/3rd. After: it passes on three consecutive runs in the same session. (The failure was pre-existing and reproduces on `development` independent of any other in-flight work.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)