### PR TITLE
Silence extraneous output leaking into test logs

### DIFF
--- a/inst/templates/module.Rmd.template
+++ b/inst/templates/module.Rmd.template
@@ -29,7 +29,7 @@ dir.create("figures", showWarnings = FALSE)
 
 download.file(url = "https://img.shields.io/badge/Made%20with-Markdown-1f425f.png",
               destfile = "figures/markdownBadge.png",
-              mode = "wb")
+              mode = "wb", quiet = TRUE)
 ```
 
 [![made-with-Markdown](figures/markdownBadge.png)](https://commonmark.org)

--- a/tests/testthat/test-futureEvents.R
+++ b/tests/testthat/test-futureEvents.R
@@ -37,11 +37,15 @@ test_that("test spades.futureEvents", {
     writeLines(newModCode, con = f1)
   }
 
-  if (isWindows()) {
-    oldPlan <- future::plan(future.callr::callr, workers = 3)
-  } else {
-    oldPlan <- future::plan(future::multisession, workers = 3)
-  }
+  ## Use the callr backend on all platforms (not just Windows). With
+  ## future::multisession, the PSOCK worker processes inherit this session's
+  ## controlling terminal as their stderr. reproducible's Cache, running inside
+  ## a worker, briefly setwd()s into a scratch directory that it then removes,
+  ## leaving the worker in a non-existent working directory; a subprocess it
+  ## spawns then prints "sh: getcwd() failed" straight to our terminal. The
+  ## callr backend launches each worker with its own redirected stdout/stderr,
+  ## so that noise is contained instead of leaking into the test output.
+  oldPlan <- future::plan(future.callr::callr, workers = 3)
   # oldPlan <- future::plan("sequential", workers = 3)
   on.exit(future::plan(oldPlan), add = TRUE)
 


### PR DESCRIPTION
## Summary

Two sources of stray console output during `devtools::test()` are silenced.

### 1. `sh: 0: getcwd() failed: No such file or directory` (futureEvents test)

`future::multisession` PSOCK workers inherit the test session's controlling terminal as their OS-level stderr. Inside a worker, `reproducible`'s Cache briefly `setwd()`s into a scratch directory and then deletes it, leaving the worker process in a non-existent working directory; a subprocess it later spawns (`/bin/sh`) fails `getcwd()` and prints to our terminal. `parallelly`'s `outfile=` does not help because it redirects R-level output, not the inherited OS fd 2 the child shell writes to.

Switch to the `future.callr::callr` backend on all platforms (already used on Windows, already a test dependency). `callr` launches each worker with its own redirected stdout/stderr, containing the noise.

### 2. `trying URL '...shields.io...'` / `downloaded 3496 bytes` (module-template test)

`knitr::knit()` runs the generated module `.Rmd`, whose setup chunk calls `download.file()` for a badge without `quiet`. Added `quiet = TRUE` — also benefits every module created by `newModule()`.

## Testing

- `test-futureEvents.R`: 7/7 pass, 0 leaked lines
- `test-module-template.R`: 52/52 pass, 0 leaked lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)