### PR TITLE
fix: avoid NULL dep when simInit gets .globals without modules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Description: Provides the core framework for a discrete event system to
 URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
-Date: 2026-05-21
-Version: 3.1.2.9004
+Date: 2026-05-26
+Version: 3.1.2.9005
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# SpaDES.core 3.1.2.9005 (development version)
+
+## Bug fixes
+
+* `simInit()` no longer errors when called with `params = list(.globals = ...)`
+  but no `modules`. Previously this failed with
+  `no applicable method for `@` applied to an object of class "NULL"`
+  because the default empty dependency list (`list(NULL)`) was iterated by
+  `updateParamsFromGlobals()`.
+
 # SpaDES.core 3.1.2.9004 (development version)
 
 ## New features

--- a/R/simulation-simInit.R
+++ b/R/simulation-simInit.R
@@ -2110,7 +2110,9 @@ resolveDepsRunInitIfPoss <- function(sim, modules, paths, params, objects, input
 }
 
 updateParamsFromGlobals <- function(sim, dontUseGlobals = list(), verbose = getOption("reproducible.verbose")) {
-  modDefaultParams <- Map(mod = sim@depends@dependencies, function(mod) mod@parameters$paramName)
+  deps <- Filter(Negate(is.null), sim@depends@dependencies)
+  if (!length(deps)) return(sim)
+  modDefaultParams <- Map(mod = deps, function(mod) mod@parameters$paramName)
   sim@params <- updateParamsSlotFromGlobals(sim@params, dontUseGlobals = dontUseGlobals,
                                             modDefaultParams = modDefaultParams, verbose = verbose)
   sim

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -317,6 +317,22 @@ test_that("simInit with R subfolder scripts", {
   expect_true(mySim@.xData$.mods$child1$a(2) == 3) # Fns
 })
 
+test_that("simInit with .globals but no modules does not error (#empty-deps)", {
+  testInit()
+
+  # Regression: previously errored with
+  #   "no applicable method for `@` applied to an object of class \"NULL\""
+  # because sim@depends@dependencies defaults to list(NULL) and
+  # updateParamsFromGlobals() tried mod@parameters on the NULL element.
+  d <- 1
+  expect_error(
+    sim <- suppressMessages(simInit(params = list(.globals = list(d = d)))),
+    NA
+  )
+  expect_s4_class(sim, "simList")
+  expect_identical(sim@params$.globals$d, d)
+})
+
 test_that("simulation runs with simInit with duplicate modules named", {
   testInit(sampleModReqdPkgs, opts = list(spades.debug = 1))
 


### PR DESCRIPTION
## Summary
- `simInit(params = list(.globals = ...))` (no `modules`) errored with `no applicable method for \`@\` applied to an object of class "NULL"` because the default `sim@depends@dependencies` is `list(NULL)` and `updateParamsFromGlobals()` blindly did `mod@parameters` on each element.
- Filter `NULL` deps and short-circuit when none remain.
- Adds a regression test; bumps to `3.1.2.9005` and updates `NEWS.md`.

## Test plan
- [x] `testthat::test_file("tests/testthat/test-simulation.R", desc = "simInit with .globals but no modules does not error (#empty-deps)")` passes locally
- [ ] Full R CMD check / test suite on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)