### PR TITLE
messageForErrorOutputObject

### DIFF
--- a/R/module-define.R
+++ b/R/module-define.R
@@ -303,10 +303,21 @@ setMethod(
       x$outputObjects <- ._outputObjectsDF()
     } else {
       if (is(x$outputObjects, "data.frame")) {
-        if (!all(colnames(x$outputObjects) %in% colnames(._outputObjectsDF())) ||
-            !all(colnames(._outputObjectsDF()) %in% colnames(x$outputObjects))) {
+        cnTooMany <- colnames(x$outputObjects) %in% colnames(._outputObjectsDF())
+        cnTooFew <- colnames(._outputObjectsDF()) %in% colnames(x$outputObjects)
+        if (!all(cnTooMany) || !all(cnTooFew)) {
+          anExtra <- colnames(x$outputObjects)[!cnTooMany]
+          aMissing <- colnames(._outputObjectsDF())[!cnTooFew]
+          if (length(anExtra)) {
+            wh <- which(!sapply(x$outputObjects[[anExtra]], is.null))
+            if (length(wh)) {
+              stop("There is an incorrect argument in outputObject. Object: `",
+                   x$outputObjects$objectName[wh],"` should not have ",
+                   anExtra)    
+            }
+          }
           stop("invalid data.frame `outputObjects` in module `", x$name, "`:",
-               "provided: ", paste(colnames(x$outputObjects), collapse = ", "), "\n",
+               "\nprovided: ", paste(colnames(x$outputObjects), collapse = ", "), "\n",
                "expected: ", paste(colnames(._outputObjectsDF()), collapse = ", "))
         }
       } else {


### PR DESCRIPTION
## Summary
Improves the error message raised when a module's `outputObjects` data.frame has invalid columns.

Previously, an invalid `outputObjects` data.frame only produced a generic message listing the provided vs. expected column names. Now, when an extra column contains non-NULL values, the error identifies the specific object and the offending argument, making the misconfiguration much easier to diagnose.

## Changes
- `R/module-define.R`: detect extra/missing columns separately; when an extra column holds non-NULL values, report the object name and the bad argument before falling back to the generic provided/expected message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)