### PR TITLE
fix(cache): exclude parameter-definition table from module cache digest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Description: Provides the core framework for a discrete event system to
 URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
-Date: 2026-05-26
-Version: 3.1.2.9007
+Date: 2026-06-05
+Version: 3.1.2.9008
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# SpaDES.core 3.1.2.9008 (development version)
+
+## Bug fixes
+
+* Module caching (`.useCache` for `.inputObjects` and events) no longer folds the
+  module's *parameter-definition table* into the cacheId. Previously the digest
+  included `sim@depends@dependencies[[module]]@parameters` (the `defineParameter`
+  rows: defaults, descriptions, min/max) in addition to the resolved parameter
+  *values* in `sim@params`. The values are what affect the computation and are
+  already digested separately, so the definition table was redundant -- and it
+  caused two concrete problems: (1) a parameter whose **default** was derived from
+  the environment (e.g. `getOption(...)`, an eagerly-evaluated `P(sim)$...`) made
+  the cacheId differ across machines/OSs, so the same call never shared a (cloud)
+  cache; and (2) it silently re-introduced parameters that `.useCache`/
+  `.useCacheArgs` exclusion (`paramsDontCacheOn`) had removed from the value
+  digest, because the definition table is not filtered. The cacheId now depends on
+  the resolved parameter values only. **This changes existing cacheIds once**
+  (a one-time recompute), after which identical runs on different machines share a
+  cache as intended. `inputObjects`/`outputObjects` metadata (`sourceURL`,
+  `objectClass`, ...) is unchanged -- those are genuine read-inputs (e.g. via
+  `extractURL()`), not redundant definitions.
+
 # SpaDES.core 3.1.2.9007 (development version)
 
 ## Bug fixes

--- a/R/simulation-simInit.R
+++ b/R/simulation-simInit.R
@@ -2453,7 +2453,18 @@ debugToVerbose <- function(debug) {
 }
 
 
-metadataToDigest <- c("inputObjects", "outputObjects", "parameters","childModules", "loadOrder", "reqdPkgs",
+# Module-metadata slots (of `sim@depends@dependencies[[module]]`) included in the
+# cache digest for `.inputObjects`/events. "parameters" is deliberately omitted:
+# that slot is the `defineParameter` table (defaults, descriptions, min/max), but
+# the behaviourally-relevant input is the *resolved parameter value* in
+# `sim@params`, which is digested separately via `classOptions$params`
+# (`paramsWoKnowns`). Digesting the definition table too was redundant and, worse,
+# made the cacheId depend on environment-derived defaults (e.g. a default of
+# `getOption(...)`), so the same module digested differently across machines/OSs
+# and never shared a (cloud) cache. It also re-introduced parameters that
+# `paramsDontCacheOn` had explicitly excluded from the value digest (e.g.
+# `.useCache`, `.useCacheArgs`), since the definition table is not filtered.
+metadataToDigest <- c("inputObjects", "outputObjects", "childModules", "loadOrder", "reqdPkgs",
                       "spatialExtent", "timeframe", "timeunit", "version")
 
 objectsToUseUpdatesFromPrevInits <- function(sim, objectsToUse) {


### PR DESCRIPTION
## Problem
Module `.useCache` caching (for `.inputObjects` and events) digested the module's **parameter-definition table** (`sim@depends@dependencies[[module]]@parameters` — `defineParameter` defaults, descriptions, min/max) *in addition to* the resolved parameter values in `sim@params`.

The values are what affect the computation and are already digested separately (`classOptions$params` / `paramsWoKnowns`). Digesting the definition table too was redundant and caused two concrete bugs:

1. **Cross-machine cache misses.** A parameter whose *default* is environment-derived (e.g. `getOption(...)`, an eager `P(sim)$...`) made the cacheId differ across machines/OSs (e.g. cloud on under Linux, off under Windows), so the same call never shared a cloud cache. Observed via `showSimilar = TRUE`: the only differing arg was `sim.depends.<module>.parameters` — the definition table — while the runtime `params` digest matched.
2. **Leaked exclusions.** Params that `paramsDontCacheOn` removes from the value digest (`.useCache`, `.useCacheArgs`) were silently re-introduced through the (unfiltered) definition table.

## Fix
Drop `"parameters"` from `metadataToDigest` (used only by the two cache-digest sites). The cacheId now depends on resolved parameter **values** only.

`inputObjects`/`outputObjects` metadata is **kept** — `sourceURL`/`objectClass` are read at runtime (e.g. via `extractURL()`), so they're genuine inputs, not redundant definitions.

## Impact
- Existing `.inputObjects`/event cacheIds shift **once** (one-time recompute), then stabilize and become cross-machine shareable.

## Follow-up (not in this PR)
- Optionally drop the documentation-only `desc` column from the `inputObjects` digest (column-level, needs a different mechanism than the slot-level change here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)