### PR TITLE
fix(cache): evaluate quoted .useCacheArgs on .inputObjects path in module context

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Description: Provides the core framework for a discrete event system to
 URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
-Date: 2026-05-26
-Version: 3.1.2.9007
+Date: 2026-06-05
+Version: 3.1.2.9008
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# SpaDES.core 3.1.2.9008 (development version)
+
+## Bug fixes
+
+* `.useCacheArgs` entries on the `.inputObjects` path are now evaluated at the
+  splice site, in the module's context (`sim@current` is the module being
+  processed), matching the event path in `.runEvent()`. Previously a quoted
+  entry such as `useCloud = quote(P(sim)$.useCloud)` reached `reproducible::Cache()`
+  as an unevaluated call and was forced later, where the module context was no
+  longer available, so module-context accessors like `P(sim)` resolved to the
+  wrong module (or `NULL`). As a result, e.g. cloud caching of `.inputObjects`
+  keyed off `.useCloud` silently did not engage. Quoted entries now resolve to
+  this module's parameters before being merged into the `Cache()` call.
+
 # SpaDES.core 3.1.2.9007 (development version)
 
 ## Bug fixes

--- a/R/simulation-simInit.R
+++ b/R/simulation-simInit.R
@@ -1772,6 +1772,14 @@ simInitAndSpades <- function(times, params, modules, objects, paths, inputs, out
             #                     modules = mBase)
             extraCacheArgs <- sim@params[[mBase]][[._txtDotUseCacheArgs]][[".inputObjects"]]
             if (!is.list(extraCacheArgs)) extraCacheArgs <- list()
+            # Evaluate any quoted entries (e.g. `quote(P(sim)$.useCloud)`) here, while
+            # `sim@current$moduleName` is `mBase` (set above), so module-context accessors
+            # like P(sim) resolve to this module. Otherwise they would reach Cache() as
+            # unevaluated language objects and be forced later in the wrong context. This
+            # mirrors the event path in `.runEvent()` (see simulation-spades.R).
+            isCalls <- sapply(extraCacheArgs, function(x) is.call(x))
+            if (isTRUE(any(isCalls)))
+              extraCacheArgs[isCalls] <- lapply(extraCacheArgs[isCalls], eval, envir = environment())
 
             defaultCacheArgs <- list(
               FUN = quote(.inputObjects(sim)),

--- a/tests/testthat/test-useCacheArgs.R
+++ b/tests/testthat/test-useCacheArgs.R
@@ -167,6 +167,46 @@ test_that(".useCacheArgs evaluates quoted entries at the splice site", {
               info = "Quoted cacheId in .useCacheArgs should be eval'd to a string before reaching Cache()")
 })
 
+test_that(".useCacheArgs evaluates quoted entries on the .inputObjects path with module context", {
+  skip_on_cran()
+
+  ## A quoted .useCacheArgs entry on the .inputObjects path must resolve in this
+  ## module's context (sim@current == module), i.e. currentModule(sim)/P(sim)
+  ## return *this* module. (Note: this exercises an arg Cache forces early; the
+  ## subtler late-forced case -- e.g. useCloud during cloud I/O -- is what the
+  ## splice-time pre-evaluation in .runModuleInputObjects guards, validated in
+  ## real cloud use rather than here.)
+  testInit(opts = list(reproducible.useMemoise = FALSE,
+                       reproducible.verbose     = 0,
+                       spades.saveSimOnExit     = FALSE))
+
+  modName <- "testUseCacheArgsQuotedIO"
+  suppressMessages(newModule(modName, path = tmpdir, open = FALSE))
+
+  args <- list(
+    modules = list(modName),
+    paths   = list(modulePath = tmpdir, cachePath = tmpCache),
+    params  = stats::setNames(
+      list(list(
+        .useCache     = ".inputObjects",
+        ## Resolves to "io_<modName>" only if evaluated with module context;
+        ## an unevaluated language object reaching Cache() would not.
+        .useCacheArgs = list(.inputObjects = list(
+          cacheId = quote(paste0("io_", currentModule(sim)))))
+      )),
+      modName
+    )
+  )
+
+  try(reproducible::clearCache(x = tmpCache, ask = FALSE), silent = TRUE)
+  ## .inputObjects runs during simInit(), so the cache entry exists afterwards.
+  mySim <- suppressMessages(do.call(simInit, args))
+
+  cache <- reproducible::showCache(tmpCache, cacheId = paste0("io_", modName), verbose = -1)
+  expect_true(NROW(cache) > 0,
+              info = "Quoted .useCacheArgs on .inputObjects must be eval'd with module context")
+})
+
 test_that(".useCacheArgs is excluded from the per-module cache digest", {
   ## The grep("useCache", .knownDotParams) at simulation-spades.R:2367 should
   ## auto-include .useCacheArgs in paramsDontCacheOn now that .useCacheArgs is


### PR DESCRIPTION
## Problem
The event path (`.runEvent`) evaluates quoted `.useCacheArgs` entries at the splice site (added in 5bae3a8f), but the `.inputObjects` path in `.runModuleInputObjects` never got the same step. So a quoted entry like `useCloud = quote(P(sim)$.useCloud)` reached `reproducible::Cache()` as an unevaluated language object and was forced **later**, inside Cache's cloud I/O, where the module context (`sim@current`) is gone — so `P(sim)` resolved to the wrong module (or `NULL`), and cloud caching of `.inputObjects` keyed off `.useCloud` silently did not engage.

(Args that Cache forces *early* — e.g. `cacheId` — happened to resolve, because `sim@current` is still the module at that point. That's why the issue was subtle.)

## Fix
Evaluate `is.call` entries right after reading `.useCacheArgs`, in `environment()` where `sim@current$moduleName == mBase`, mirroring the event path. Quoted entries now resolve in this module's context before being merged into the `Cache()` call.

## Test
Adds a test exercising a quoted module-context entry (`currentModule(sim)`) on the `.inputObjects` path. Note: it exercises an early-forced arg, so it documents/guards quoted-entry support on this path; the subtler late-forced `useCloud` case is validated in real cloud use (no cloud test infra here).

## Note
Supersedes #366 (which targeted the wrong lever — `metadataToDigest` — and is being closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)