### PR TITLE
fix(simInit): load all user objects when allowInitDuringSimInit = TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Description: Provides the core framework for a discrete event system to
 URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
-Date: 2026-05-26
-Version: 3.1.2.9007
+Date: 2026-06-05
+Version: 3.1.2.9008
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# SpaDES.core 3.1.2.9008 (development version)
+
+## Bug fixes
+
+* `simInit(objects = ...)` again loads *all* user-supplied objects when
+  `options(spades.allowInitDuringSimInit = TRUE)` (as set by some
+  `SpaDES.project::setupProject()` configurations). A regression in the
+  `.runInputObjectsPhase()` refactor restricted the loaded objects to those
+  declared as a module `inputObject`, silently dropping arbitrary objects passed
+  via `objects = list(...)` -- and every object when no module declares them.
+  The intended behaviour (don't let user inputs clobber objects an init produced
+  during `simInit`) is preserved via `objectsToUseUpdatesFromPrevInits()`.
+
 # SpaDES.core 3.1.2.9007 (development version)
 
 ## Bug fixes

--- a/R/simulation-simInit.R
+++ b/R/simulation-simInit.R
@@ -1499,13 +1499,13 @@ simInitAndSpades <- function(times, params, modules, objects, paths, inputs, out
       if (length(objNames) == length(objects)) {
         if (isTRUE(getOption("spades.allowInitDuringSimInit") &&
                    getOption("spades.dotInputObjects", TRUE))) {
-          inputObjectsAllMods <- inputObjects(sim)
-          if (is(inputObjectsAllMods, "list"))
-            inputObjectsAllMods <- inputObjectsAllMods |> rbindlist()
-          inputObjectsAllMods <- unique(inputObjectsAllMods$objectName)
-          objectNamesToUse <- inputObjectsAllMods[inputObjectsAllMods %in% sim$.userSuppliedObjNames]
-          objectsToUse <- objects[objectNamesToUse]
-          objectsToUse <- objectsToUseUpdatesFromPrevInits(sim, objectsToUse)
+          # Load *all* user-supplied objects, dropping only those an init that ran
+          # during simInit has already produced (so user inputs don't clobber init
+          # outputs -- handled by objectsToUseUpdatesFromPrevInits). Previously this
+          # also restricted to objects declared as a module `inputObject`, silently
+          # dropping arbitrary objects passed via `simInit(objects = ...)` (and all
+          # objects when no module declares them, e.g. no modules at all).
+          objectsToUse <- objectsToUseUpdatesFromPrevInits(sim, objects)
         } else {
           objectsToUse <- objects
         }

--- a/tests/testthat/test-inputObjectsPhase.R
+++ b/tests/testthat/test-inputObjectsPhase.R
@@ -173,3 +173,21 @@ test_that("allowInitDuringSimInit = TRUE still produces an equivalent simList", 
   outT <- spades(simT, debug = FALSE)
   expect_equal(outF$y, outT$y)
 })
+
+test_that("simInit(objects=) loads ALL user objects when allowInitDuringSimInit = TRUE", {
+  ## Regression: with spades.allowInitDuringSimInit = TRUE, simInit used to load
+  ## only objects declared as a module `inputObject`, silently dropping arbitrary
+  ## user-supplied objects (and every object when no module declares them).
+  testInit(smcc = FALSE, opts = list(reproducible.useMemoise = FALSE))
+
+  withr::local_options(spades.allowInitDuringSimInit = TRUE)
+  s <- suppressMessages(simInit(objects = list(a = 1, b = "x")))
+  expect_identical(s[["a"]], 1)
+  expect_identical(s[["b"]], "x")
+
+  ## and unchanged when the option is FALSE
+  withr::local_options(spades.allowInitDuringSimInit = FALSE)
+  s2 <- suppressMessages(simInit(objects = list(a = 1, b = "x")))
+  expect_identical(s2[["a"]], 1)
+  expect_identical(s2[["b"]], "x")
+})


### PR DESCRIPTION
## Problem (regression)
With `options(spades.allowInitDuringSimInit = TRUE)` — set by some `SpaDES.project::setupProject()` configs — `simInit(objects = list(...))` silently **drops** user objects that aren't declared as a module `inputObject`, and drops *all* objects when no module declares them:

```r
options(spades.allowInitDuringSimInit = TRUE)
s <- simInit(objects = list(a = 1))
s[["a"]]   # NULL  (should be 1)
```

Introduced by the `.finishSimInit()`/`.runInputObjectsPhase()` refactor (`04a6aff0`), which restricted the loaded set in `.runInputObjectsPhase()`:

```r
objectNamesToUse <- inputObjectsAllMods[inputObjectsAllMods %in% sim$.userSuppliedObjNames]
objectsToUse <- objects[objectNamesToUse]      # drops everything else
```

(With the option `FALSE` it was `objectsToUse <- objects`, hence "works in a clean session, breaks after setupProject".)

## Fix
Load all user objects, passing them only through `objectsToUseUpdatesFromPrevInits()` — which already provides the clobber-avoidance the option needs (don't overwrite objects an init produced during `simInit`). The `inputObjects`-only restriction was both wrong and redundant.

## Test
`tests/testthat/test-inputObjectsPhase.R`: a new regression test asserts arbitrary `objects = list(a = 1, b = "x")` survive `simInit` with the option both `TRUE` and `FALSE`. Fails before this change (`a == NULL` with the option on), passes after. `test-simulation.R` / `test-inputObjectsPhase.R` / `test-mod.R` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)