### PR TITLE
fix(cache): omit parameter-definition table from the module cacheId

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-06-05
-Version: 3.1.2.9008
+Version: 3.1.2.9009
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# SpaDES.core 3.1.2.9009 (development version)
+
+## Bug fixes
+
+* The module **parameter-definition table** (`defineParameter` defaults/min/max/class)
+  is no longer included in the `.useCache` cacheId for `.inputObjects`/events. Only
+  the resolved parameter *values* (digested separately) affect caching now. Including
+  the definition table made the cacheId depend on metadata that can differ across
+  machines/OSs/package versions even when the run is identical -- e.g. an
+  environment-derived default (`getOption(...)`), or a platform-dependent attribute
+  on a table column -- so the same call produced different cacheIds on Linux vs
+  Windows and could not share a (cloud) cache. (Extends the earlier removal of the
+  human-readable `desc` columns from this digest.) **This changes existing cacheIds
+  once** (a one-time recompute), after which identical runs across machines share a
+  cache as intended.
+
 # SpaDES.core 3.1.2.9008 (development version)
 
 ## Bug fixes

--- a/R/cache.R
+++ b/R/cache.R
@@ -248,7 +248,16 @@ setMethod(
     })
     dependsFirst <- obj[["depends"]] <- list()
     if (!isTRUE(all(sapply(object@depends@dependencies, is.null)))) {
-      for (ii in c("inputObjects", "outputObjects", "parameters")) {
+      # NOTE: "parameters" is intentionally excluded. The parameter *definition*
+      # table (`defineParameter` defaults/min/max/class) is metadata, not a
+      # computation input -- the resolved parameter *values* are digested separately
+      # (the `@params` slot, via `classOptions$params`). Including the definition
+      # table made the cacheId depend on environment-derived defaults (e.g.
+      # `getOption(...)`) and on metadata representations that can differ across
+      # platforms/package versions, so identical runs on different machines/OSs
+      # produced different cacheIds and could not share a (cloud) cache. Same
+      # rationale as the earlier removal of the human-readable `desc` columns.
+      for (ii in c("inputObjects", "outputObjects")) {
         dependsFirst[[ii]] <-
           .robustDigest(lapply(object@depends@dependencies,
                                function(mo) {

--- a/tests/testthat/test-cacheParamMetadata.R
+++ b/tests/testthat/test-cacheParamMetadata.R
@@ -1,0 +1,31 @@
+test_that(".inputObjects/event cacheId ignores the parameter-definition table", {
+  skip_on_cran()
+  ## The parameter *definition* table (defineParameter defaults/min/max/class) is
+  ## metadata, not a computation input -- only resolved param *values* should affect
+  ## the cacheId. It must not enter the digest, else env-derived defaults or
+  ## platform-dependent metadata digesting (row order, string encoding, version skew)
+  ## split the cacheId across machines/OSs and break (cloud) cache sharing.
+  testInit(opts = list(spades.loadReqdPkgs = FALSE, spades.moduleCodeChecks = FALSE,
+                       reproducible.useMemoise = FALSE))
+  modDir <- file.path(tmpdir, "m"); dir.create(modDir, recursive = TRUE, showWarnings = FALSE)
+  cat(file = file.path(modDir, "m.R"), sep = "", '
+defineModule(sim, list(name = "m", description = "", keywords = "", authors = person("A","B"),
+  childModules = character(0), version = list(m = "0.0.1"), timeframe = as.POSIXlt(c(NA, NA)),
+  timeunit = "year", citation = list(), documentation = list(), reqdPkgs = list(),
+  parameters = rbind(
+    defineParameter("alpha", "numeric", 1, 0, 10, "a"),
+    defineParameter("beta",  "numeric", 2, 0, 10, "b"),
+    defineParameter(".useCache", "character", ".inputObjects", NA, NA, "c")),
+  inputObjects = bindrows(), outputObjects = bindrows()))
+doEvent.m <- function(sim, eventTime, eventType, debug = FALSE) { switch(eventType, init = {}); invisible(sim) }
+')
+  s <- suppressMessages(simInit(modules = "m", paths = list(modulePath = tmpdir),
+                                times = list(start = 0, end = 1)))
+  p <- s@depends@dependencies[["m"]]@parameters
+  d1 <- reproducible::CacheDigest(s)$outputHash
+  ## mutate the parameter-definition table the way platforms differ on it
+  ## (row order here; encoding/defaults are analogous) -- cacheId must not move:
+  s@depends@dependencies[["m"]]@parameters <- p[rev(seq_len(nrow(p))), ]
+  d2 <- reproducible::CacheDigest(s)$outputHash
+  expect_identical(d1, d2)
+})


### PR DESCRIPTION
## Problem
The `.useCache` digest for `.inputObjects`/events digested the module's parameter **definition** table (`defineParameter` defaults/min/max/class) on top of the resolved parameter **values**. The values are what affect the result and are digested separately (the `@params` slot, via `classOptions$params`), so the definition table was redundant — and it made the cacheId **platform-unstable**: identical runs on Linux vs Windows produced different cacheIds, so a cloud cache could never be shared.

## Diagnosis
Intercepting `reproducible::CacheDigest`'s `preDigest` (the per-argument digest list) on both OSs, the **only** differing key was `sim.depends.<module>.parameters`. Drilling in: the parameter *values* (`sim.params.*`), spatial inputs, functions, and I/O metadata were byte-identical; only the definition table differed. Even raw `digest::digest(p$paramName)` differs across OS while `digest::digest(p$paramName[1:32])` (attributes stripped) is identical — i.e. a platform-dependent attribute on a table column (and, in general, environment-derived defaults like `getOption(...)`) leak into the cacheId.

## Fix
Drop `"parameters"` from the hardcoded `c("inputObjects","outputObjects","parameters")` loop in the `simList` `.robustDigest` method (`R/cache.R`). The cacheId now depends on resolved parameter **values** only. This mirrors the earlier removal of the human-readable `desc` columns from the same digest (commit `7b89c5fd`).

## Impact
- Module `.inputObjects`/event cacheIds shift **once** (one-time recompute), then stabilize and become cross-machine/OS shareable.

## Test
`tests/testthat/test-cacheParamMetadata.R`: reordering the parameter-definition table no longer moves the cacheId. `test-cache` / `test-inputObjectsPhase` / `test-useCacheArgs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)