### PR TITLE
fix(simInit): remove the box package dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-06-05
-Version: 3.1.2.9009
+Version: 3.1.2.9010
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# SpaDES.core 3.1.2.9010 (development version)
+
+## Dependency changes
+
+* `simInit` no longer installs (or loads) the **`box`** package. `box` does not
+  work well within the `SpaDES` ecosystem, so the default for the
+  `spades.reqdPkgsDontLoad` option is now `NULL` (was `"box"`), and the unused,
+  unimplemented `spades.useBox` option and its associated (disabled) `box::use`
+  machinery have been removed. The generic `spades.reqdPkgsDontLoad` mechanism --
+  install a package but do not `library()`/`require()` it -- is retained for any
+  package a user explicitly lists.
+
 # SpaDES.core 3.1.2.9009 (development version)
 
 ## Bug fixes

--- a/R/options.R
+++ b/R/options.R
@@ -155,10 +155,9 @@
 #'   with `restartSimInit` (see `?restartSimInit`).
 #'   There is a message which describes how to find that.\cr
 #'
-#'   `spades.reqdPkgsDontLoad` \tab `"box"` \tab Specify any packages that should not
+#'   `spades.reqdPkgsDontLoad` \tab `NULL` \tab Specify any packages that should not
 #'   be \emph{loaded} i.e., no `library` or `require`, but they should be installed if
-#'   listed. The default (`"box"`) is a package that returns a warning if it is
-#'   loaded, and so it is excluded from loading.\cr
+#'   listed in a module's `reqdPkgs`.\cr
 #'
 #'   `spades.saveFileExtensions` \tab `NULL` \tab
 #'   a `data.frame` with 3 columns, `exts`, `fun`, and `package` indicating which
@@ -204,17 +203,6 @@
 #'   `spades.useragent` \tab `"https://github.com/PredictiveEcology/SpaDES"`.
 #'     \tab The default user agent to use for downloading modules from GitHub.\cr
 #'
-#'   `spades.useBox` \tab FALSE
-#'     \tab Unimplemented while memory problems with `box` are resolved.
-#'     When it is turned on, this option determines
-#'     whether to manage which packages are loaded using the package `box`.
-#'     This will have as an effect that `reqdPkgs` will be strict; if a given
-#'     module is missing a `reqdPkgs`, then the module will fail to run, with
-#'     an error saying the package/function doesn't exist. Without `box`,
-#'     modules may run, even though `reqdPkgs` is incorrect, because other modules
-#'     may have specified their own packages, which cover the needs of another
-#'     package. `useBox = TRUE` will force modules to be accurate with their `reqdPkgs`.\cr
-#'
 #'   `spades.useRequire` \tab `!tolower(Sys.getenv("SPADES_USE_REQUIRE")) %in% "false"`
 #'     \tab The default for that environment variable is unset, so this returns
 #'     `TRUE`. If this is `TRUE`, then during the `simInit` call, when packages are
@@ -258,7 +246,7 @@ spadesOptions <- function() {
     spades.evalPostEvent = NULL,
     spades.qsThreads = 1L,
     spades.recoveryMode = 1,
-    spades.reqdPkgsDontLoad = "box",
+    spades.reqdPkgsDontLoad = NULL,
     spades.restartRInterval = 0,
     spades.restartR.clearFiles = TRUE,
     spades.restartR.RDataFilename = "sim_restartR.RData",
@@ -275,7 +263,6 @@ spadesOptions <- function() {
     spades.tolerance = .Machine$double.eps^0.5,
     spades.urlLog = TRUE,
     spades.useragent = "https://github.com/PredictiveEcology/SpaDES",
-    # spades.useBox = FALSE,
     spades.useRequire = !tolower(Sys.getenv("SPADES_USE_REQUIRE")) %in% "false",
     spades.keepCompleted = TRUE
   )

--- a/R/restart.R
+++ b/R/restart.R
@@ -229,16 +229,15 @@ restartSpades <- function(sim = NULL, module = NULL, numEvents = 1L, restart = T
 
       ## evaluate the rest of the parsed file
       sim <- currentModuleTemporary(sim, module)
-      pkgs = slot(slot(depends(sim), "dependencies")[[module]], "reqdPkgs")
       if (doesntUseNamespacing) {
-        evalWithActiveCode(pp[[1]], sim@.xData, sim = sim, pkgs = pkgs)
+        evalWithActiveCode(pp[[1]], sim@.xData, sim = sim)
       }
 
       if (length(subFiles)) {
         pp[seq_len(length(subFiles)) + 1] <- lapply(subFiles, function(ff) parse(ff))
       }
       lapply(pp, function(pp1)
-        evalWithActiveCode(pp1, sim@.xData[[dotMods]][[module]], sim = sim, pkgs = pkgs))
+        evalWithActiveCode(pp1, sim@.xData[[dotMods]][[module]], sim = sim))
       message(cli::col_blue("Reparsing ", module, " source code"))
     }
     invisible()

--- a/R/simulation-parseModule.R
+++ b/R/simulation-parseModule.R
@@ -287,7 +287,7 @@ setMethod(
           sim@.xData$.mods[[mBase]]$.isPackage <- TRUE
           activeCode[["main"]] <- evalWithActiveCode(tmp[["parsedFile"]][!tmp[["defineModuleItem"]]],
                                                      asNamespace(.moduleNameNoUnderscore(mBase)),
-                                                     sim = sim, pkgs = tmp[["parsedFile"]][tmp[["defineModuleItem"]]][[1]][[3]]$reqdPkgs)
+                                                     sim = sim)
         } else {
           sim@.xData$.mods[[mBase]]$.isPackage <- FALSE
 
@@ -297,11 +297,10 @@ setMethod(
           # The simpler line commented below will not allow actual code to be put into module,
           #  e.g., startSim <- start(sim)
           #  The more complex one following will allow that.
-          reqdPkgsHere <- eval(tmp[["parsedFile"]][tmp[["defineModuleItem"]]][[1]][[3]]$reqdPkgs)
           # eval(tmp[["parsedFile"]][!tmp[["defineModuleItem"]]], envir = sim@.xData$.mods[[mBase]])
           activeCode[["main"]] <- evalWithActiveCode(tmp[["parsedFile"]][!tmp[["defineModuleItem"]]],
                                                      sim@.xData$.mods[[mBase]],
-                                                     sim = sim, pkgs = reqdPkgsHere)
+                                                     sim = sim)
 
           # doesntUseNamespacing <- parseOldStyleFnNames(sim, mBase, )
           doesntUseNamespacing <- !.isNamespaced(sim, mBase)
@@ -316,7 +315,7 @@ setMethod(
             #lockBinding(mBase, sim@.envir) ## guard against clobbering from module code (#80)
             out1 <- evalWithActiveCode(tmp[["parsedFile"]][!tmp[["defineModuleItem"]]],
                                        sim@.xData$.mods,
-                                       sim = sim, pkgs = tmp[["parsedFile"]][tmp[["defineModuleItem"]]][[1]][[3]]$reqdPkgs)
+                                       sim = sim)
             #unlockBinding(mBase, sim@.envir) ## will be re-locked later on
           }
 
@@ -337,13 +336,13 @@ setMethod(
               if (doesntUseNamespacing) {
                 #eval(parsedFile1, envir = sim@.xData)
                 evalWithActiveCode(parsedFile1, sim@.xData$.mods,
-                                   sim = sim, pkgs = tmp[["parsedFile"]][tmp[["defineModuleItem"]]][[1]][[3]]$reqdPkgs)
+                                   sim = sim)
               }
 
               # duplicate -- put in namespaces location
               #eval(parsedFile1, envir = sim@.xData$.mods[[mBase]])
               activeCode[[Rfiles]] <- evalWithActiveCode(parsedFile1, sim@.xData$.mods[[mBase]],
-                                                         sim = sim, pkgs = tmp[["parsedFile"]][tmp[["defineModuleItem"]]][[1]][[3]]$reqdPkgs)
+                                                         sim = sim)
             }
           }
 
@@ -607,15 +606,13 @@ setMethod(
 
 #' @keywords internal
 evalWithActiveCode <- function(parsedModuleNoDefineModule, envir, parentFrame = parent.frame(),
-                               sim, pkgs) {
+                               sim) {
 
   # browser(expr = exists("._evalWithActiveCode_1"))
   # Create a temporary environment to source into, adding the sim object so that
   #   code can be evaluated with the sim, e.g., currentModule(sim)
   #tmpEnvir <- new.env(parent = asNamespace("SpaDES.core"))
-  tmpEnvirForPkgs <- new.env(parent = envir)
-  # tmpEnvir <- new.env(parent = envir)
-  tmpEnvir <- new.env(parent = tmpEnvirForPkgs)
+  tmpEnvir <- new.env(parent = envir)
 
 
   # This needs to be unconnected to main sim so that object sizes don't blow up
@@ -633,25 +630,6 @@ evalWithActiveCode <- function(parsedModuleNoDefineModule, envir, parentFrame = 
   #   it says, how big is the function, compared to how big is the environment that holds the function
   #   If it is 1, it means there are only functions in that environment, no objects
   # length(serialize(tmpEnvir$prepare_IgnitionFit, NULL))/object.size(mget(ls(tmpEnvir), tmpEnvir))
-
-  if (getOption("spades.useBox", FALSE) && FALSE) { # TURN THIS OFF AS THERE ARE MEMORY HOGGING ISSUES WITH BOX
-    pkgs <- Require::extractPkgName(unlist(eval(pkgs)))
-    pkgs <- reqdPkgsDontLoad(pkgs) # some are explicitly not to be loaded
-    cm <- currentModule(tmpEnvir$sim)
-    if (length(cm))
-      if (!cm %in% unlist(.coreModules())) {
-        # pkgs <- Require::extractPkgName(unlist(eval(pkgs)))
-        lapply(pkgs, function(p) {
-          allFns <- ls(envir = asNamespace(p))
-          val <- paste0("box::use(", p, "[...]", ")")
-          eval(as.call(parse(text = val))[[1]], envir = tmpEnvirForPkgs)
-          if (any("mod" == allFns)) {
-            rm(list = "mod", envir = parent.env(tmpEnvirForPkgs))
-            messageVerbose("mod will be masked from ", p)
-          }
-        })
-      }
-  }
 
   activeCode <- unlist(lapply(ll, function(x) identical("ERROR", x)))
 

--- a/R/simulation-simInit.R
+++ b/R/simulation-simInit.R
@@ -832,11 +832,6 @@ setMethod(
     warningSplitOnColon(w)
     invokeRestart("muffleWarning")
   }
-  # This is a box mishap
-  if (isTRUE(any(grepl("'package:stats' may not be available when loading",
-                       w$message)))) {
-    invokeRestart("muffleWarning")
-  }
 }
 
 ## Only deal with objects as character
@@ -1748,10 +1743,6 @@ simInitAndSpades <- function(times, params, modules, objects, paths, inputs, out
           #   runFnCallAsExpr <- is.null(attr(sim, "runFnCallAsExpr"))
           # }
           if (runFnCallAsExpr) {
-            pkgs <- Require::extractPkgName(unlist(moduleMetadata(sim, currentModule(sim))$reqdPkgs))
-            pkgs <- c(pkgs, "stats")
-            # if (getOption("spades.useBox", FALSE) && FALSE)
-            #   do.call(box::use, lapply(pkgs, as.name))
             if (any(mBase %in% getOption("spades.debugModule"))) {
               browser()
             }
@@ -2041,7 +2032,7 @@ loadPkgs <- function(reqdPkgs) {
     pkgsDontLoad <- getOption("spades.reqdPkgsDontLoad", NULL)
     allPkgs <- reqdPkgsDontLoad(allPkgs, pkgsDontLoad)
 
-    if (getOption("spades.useRequire") && !getOption("spades.useBox", FALSE)) {
+    if (getOption("spades.useRequire")) {
       getCRANrepos(ind = 1) # running this first is neutral if it is set
       Require(allPkgs, require = TRUE, standAlone = FALSE, upgrade = FALSE)
       if (!is.null(pkgsDontLoad)) {
@@ -2051,10 +2042,8 @@ loadPkgs <- function(reqdPkgs) {
       }
       # RequireWithHandling(allPkgs, standAlone = FALSE, upgrade = FALSE)
     } else {
-      if (!getOption("spades.useBox", FALSE)) {
-        allPkgs <- unique(Require::extractPkgName(allPkgs))
-        loadedPkgs <- lapply(allPkgs, base::require, character.only = TRUE)
-      }
+      allPkgs <- unique(Require::extractPkgName(allPkgs))
+      loadedPkgs <- lapply(allPkgs, base::require, character.only = TRUE)
     }
   }
 }

--- a/man/spadesOptions.Rd
+++ b/man/spadesOptions.Rd
@@ -158,10 +158,9 @@ module's \code{.inputObjects} runs, so an interrupted \code{simInit} can be reco
 with \code{restartSimInit} (see \code{?restartSimInit}).
 There is a message which describes how to find that.\cr
 
-\code{spades.reqdPkgsDontLoad} \tab \code{"box"} \tab Specify any packages that should not
+\code{spades.reqdPkgsDontLoad} \tab \code{NULL} \tab Specify any packages that should not
 be \emph{loaded} i.e., no \code{library} or \code{require}, but they should be installed if
-listed. The default (\code{"box"}) is a package that returns a warning if it is
-loaded, and so it is excluded from loading.\cr
+listed in a module's \code{reqdPkgs}.\cr
 
 \code{spades.saveFileExtensions} \tab \code{NULL} \tab
 a \code{data.frame} with 3 columns, \code{exts}, \code{fun}, and \code{package} indicating which
@@ -205,17 +204,6 @@ data came from. Set to \code{FALSE} to turn the recording off.\cr
 
 \code{spades.useragent} \tab \code{"https://github.com/PredictiveEcology/SpaDES"}.
 \tab The default user agent to use for downloading modules from GitHub.\cr
-
-\code{spades.useBox} \tab FALSE
-\tab Unimplemented while memory problems with \code{box} are resolved.
-When it is turned on, this option determines
-whether to manage which packages are loaded using the package \code{box}.
-This will have as an effect that \code{reqdPkgs} will be strict; if a given
-module is missing a \code{reqdPkgs}, then the module will fail to run, with
-an error saying the package/function doesn't exist. Without \code{box},
-modules may run, even though \code{reqdPkgs} is incorrect, because other modules
-may have specified their own packages, which cover the needs of another
-package. \code{useBox = TRUE} will force modules to be accurate with their \code{reqdPkgs}.\cr
 
 \code{spades.useRequire} \tab \code{!tolower(Sys.getenv("SPADES_USE_REQUIRE")) \%in\% "false"}
 \tab The default for that environment variable is unset, so this returns

--- a/tests/test-all.R
+++ b/tests/test-all.R
@@ -3,7 +3,6 @@ withr::local_options(spades.debug = FALSE)
 
 ## run all tests using different combinations of env vars
 if (nzchar(Sys.getenv("NOT_CRAN")) && as.logical(Sys.getenv("NOT_CRAN"))) {
-  withr::local_options(spades.useBox = FALSE)
   # Sys.setenv(R_REPRODUCIBLE_USE_DBI = "false")
   test_check("SpaDES.core")
 } else {

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -1062,6 +1062,32 @@ paste0("    reqdPkgs = list(\'", dontLoad, "\'),"),'
 
 })
 
+test_that("box is not a dependency: not installed/loaded during simInit", {
+  testInit()
+
+  # The package must not ship any reference to `box`; previously the default of
+  # `spades.reqdPkgsDontLoad` was "box", which caused simInit to *install* box
+  # (via Require(..., require = FALSE)) even though it does not work within the
+  # SpaDES ecosystem. The default is now NULL, and the unimplemented
+  # `spades.useBox` option has been removed entirely.
+  opts <- spadesOptions()
+  expect_null(opts[["spades.reqdPkgsDontLoad"]])
+  expect_false("spades.useBox" %in% names(opts))
+  expect_null(getOption("spades.reqdPkgsDontLoad"))
+
+  # Regression: a basic simInit must neither install nor load the box namespace.
+  # If box happens to already be loaded in this session, we cannot make the
+  # assertion meaningfully, so skip.
+  skip_if(isNamespaceLoaded("box"),
+          "box already loaded in this session; cannot test that simInit avoids it")
+
+  newModule("testNoBox", tmpdir, open = FALSE)
+  sim <- simInit(modules = "testNoBox", paths = list(modulePath = tmpdir),
+                 times = list(start = 0, end = 1, timeunit = "year"))
+  expect_is(sim, "simList")
+  expect_false(isNamespaceLoaded("box"))
+})
+
 test_that("cli progress bars are throttled and not flooded during spades()", {
   skip_if_not_installed("cli")
   testInit()


### PR DESCRIPTION
## Summary

`simInit` previously **installed** the `box` package on every call (even though it never *loaded* it), because the `spades.reqdPkgsDontLoad` option defaulted to `"box"` and that list is passed to `Require::Require(..., require = FALSE)`. `box` does not work within the SpaDES ecosystem, so this removes the dependency entirely.

## Changes

- **Default `spades.reqdPkgsDontLoad` is now `NULL`** (was `"box"`) — box is no longer installed during `simInit`.
- Removed the unimplemented, `&& FALSE`-guarded **`spades.useBox`** option and its disabled `box::use` machinery (`options.R`, `simulation-simInit.R`, `simulation-parseModule.R`), plus the box-specific warning muffler (`'package:stats' may not be available...`).
- `evalWithActiveCode()` loses its now-unused `pkgs` argument and the empty `tmpEnvirForPkgs` intermediate environment; all call sites updated (`simulation-parseModule.R`, `restart.R`).
- Updated docs (`spadesOptions` roxygen + generated `.Rd`) and `NEWS.md`; version bumped to `3.1.2.9010`.

The **generic** `spades.reqdPkgsDontLoad` mechanism (install a package but do not `library()`/`require()` it) is retained for any package a user explicitly lists — only its box default is gone.

## Testing

- New regression test in `test-simulation.R`: asserts `box` is not a default and is not loaded by a basic `simInit`.
- Ran locally (`NOT_CRAN=true`): `test-mod.R` (incl. `convertToPackage` namespace path), `test-inputObjectsPhase.R`, and the new box assertions all pass. The `evalWithActiveCode` refactor is exercised by every module-parse path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)