### PR TITLE
fix: throttle C-level (archive) cli progress flood on non-dynamic terminals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-06-05
-Version: 3.1.2.9010
+Version: 3.1.2.9011
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# SpaDES.core 3.1.2.9011 (development version)
+
+## Bug fixes
+
+* **Progress-bar flood from `archive::archive_extract()`** (e.g. via
+  `prepInputs()`) inside a module is now throttled on Windows and other
+  non-dynamic sessions. The progress frames are routed through the
+  `spades()`/`simInit()` message handler by `cli::start_app(output = "message")`;
+  `.isCliProgressTick()` previously recognised a non-dynamic frame only when
+  `cli::cli_progress_num() >= 1`, but `archive`'s bar lives in compiled
+  `libarchive` code, so cli's R-level registry never sees it and the count stays
+  `0`. Every frame therefore fell through and was re-printed with a full
+  Date-Time-Module-Event prefix, flooding the log with thousands of near-identical
+  lines (and pushing earlier messages out of view). Such frames are now also
+  recognised by their leading cli **Braille spinner glyph** (`U+2800`-`U+28FF`,
+  cli's default spinner family, which never begins a normal message), plus the
+  trailing blank frame that closes the bar, so the flood collapses to one line per
+  `getOption("spades.progressInterval", 2)` seconds. The same path covers other
+  C-level cli progress bars routed through the handler.
+
 # SpaDES.core 3.1.2.9010 (development version)
 
 ## Dependency changes

--- a/R/simulation-spades.R
+++ b/R/simulation-spades.R
@@ -2217,27 +2217,49 @@ loggingMessagePrefixLength <- 15
 
 # Is a captured message a cli progress-bar tick?
 #
-# Progress bars (e.g. from archive::archive_extract()) are routed through
+# Progress bars (e.g. from archive::archive_extract() or pak) are routed through
 # message() by cli::start_app(output = "message"), so they reach our
 # withCallingHandlers() message handler. We must recognise them to throttle,
 # rather than prepend a Date-Time-Module-Event prefix to every animation frame.
-# There are two emission styles:
+# There are several emission styles:
 #
 # 1. Dynamic terminals: each tick carries a carriage return (\r) or a
 #    cursor-movement/erase CSI sequence (\x1b[...[A-HJ-KST], or \x1b[?...[hl]
 #    cursor show/hide). Colour/SGR codes end in 'm' and are excluded so coloured
 #    regular messages are not mistaken for ticks.
-# 2. Non-dynamic terminals (non-interactive, logged, CI, RStudio jobs): cli
-#    emits each tick as a plain newline-terminated line with *no* control
-#    characters, so the case-1 regex cannot see it. Such a frame is a progress
-#    tick iff it is a cli message (class "cliMessage") AND cli reports at least
-#    one active progress bar. cli alerts are also "cliMessage" but report zero
-#    active bars, so they are not throttled.
+#
+# The remaining styles only apply to cli-emitted messages (class "cliMessage");
+# a plain base message() is never a progress tick.
+#
+# 2. Non-dynamic terminals (non-interactive, logged, CI, RStudio jobs) with an
+#    *R-level* cli progress bar (e.g. pak): cli emits each tick as a plain
+#    newline-terminated line with no control characters, so the case-1 regex
+#    cannot see it, but cli reports at least one active progress bar via
+#    cli_progress_num(). cli alerts are also "cliMessage" but report zero active
+#    bars, so they are not throttled.
+# 3. Non-dynamic terminals with a *C-level* progress bar (e.g.
+#    archive::archive_extract(), whose bar lives in compiled libarchive code):
+#    cli's R-level registry never sees the bar, so cli_progress_num() stays 0 and
+#    case 2 misses it. Such a frame still begins with a cli spinner glyph; match
+#    the Braille spinner family (U+2800-U+28FF), cli's default and the one
+#    archive/pak use. Braille glyphs never begin a normal message, so this stays
+#    high-precision while finally catching the archive-extraction flood on
+#    Windows (and other non-dynamic sessions).
+# 4. The blank frame cli emits to close out a C-level bar: an empty cliMessage
+#    arriving while a progress bar is already in progress. Treated as a tick so
+#    the existing empty-frame handling muffles it instead of printing a bare,
+#    prefixed, empty line.
 .isCliProgressTick <- function(m, msg) {
   if (isTRUE(grepl("\r|\x1b\\[[0-9;]*[A-HJ-KST]|\x1b\\[\\?[0-9;]+[hl]", msg, perl = TRUE)))
     return(TRUE)
-  inherits(m, "cliMessage") &&
-    isTRUE(tryCatch(cli::cli_progress_num() >= 1L, error = function(e) FALSE))
+  if (!inherits(m, "cliMessage"))
+    return(FALSE)
+  if (isTRUE(tryCatch(cli::cli_progress_num() >= 1L, error = function(e) FALSE)))
+    return(TRUE)
+  clean <- trimws(cli::ansi_strip(msg))
+  if (isTRUE(grepl("^[\u2800-\u28FF]", clean, perl = TRUE)))
+    return(TRUE)
+  !nzchar(clean) && isTRUE(.pkgEnv$.inProgressBar)
 }
 
 loggingMessage <- function(mess, suffix = NULL, prefix = NULL) {

--- a/tests/testthat/test-progressThrottle.R
+++ b/tests/testthat/test-progressThrottle.R
@@ -47,6 +47,35 @@ test_that(".isCliProgressTick detects progress in dynamic and non-dynamic cli mo
   # 4. A plain base message is never a tick.
   msg <- "a normal log message\n"
   expect_false(.isCliProgressTick(baseCond(msg), msg))
+
+  # 5. C-level progress bar (e.g. archive::archive_extract(), whose bar lives in
+  #    compiled libarchive code). cli's R-level registry never sees it, so
+  #    cli_progress_num() stays 0 and case 2 cannot fire; this is the real
+  #    archive-extraction flood reported on Windows. The frame is recognised by
+  #    its leading Braille spinner glyph (cli's default spinner family).
+  expect_equal(cli::cli_progress_num(), 0L)               # no R-level bar active
+  brailleTick <- "\u2839 13 extracted | 2.3 GB ( 15 MB/s) | 2m 30.4s\n"
+  expect_false(grepl("\r", brailleTick))                  # truly no control chars
+  expect_true(.isCliProgressTick(cliCond(brailleTick), brailleTick))
+
+  # 5b. The same content as a *base* message (not cli) is not a tick: only cli
+  #     output is routed through start_app(output = "message").
+  expect_false(.isCliProgressTick(baseCond(brailleTick), brailleTick))
+
+  # 5c. A cli alert whose symbol is not a spinner is not a tick, even with no bar.
+  tickAlert <- "\u2714 finished extracting\n"             # heavy check mark
+  expect_false(.isCliProgressTick(cliCond(tickAlert), tickAlert))
+
+  # 6. The blank frame cli emits to close out a C-level bar: an empty cliMessage
+  #    is a tick only while a progress bar is already in progress, so the handler
+  #    can muffle it instead of printing a bare, prefixed, empty line.
+  blank <- "\n"
+  oldInBar <- .pkgEnv$.inProgressBar
+  on.exit(.pkgEnv$.inProgressBar <- oldInBar, add = TRUE)
+  .pkgEnv$.inProgressBar <- TRUE
+  expect_true(.isCliProgressTick(cliCond(blank), blank))
+  .pkgEnv$.inProgressBar <- FALSE
+  expect_false(.isCliProgressTick(cliCond(blank), blank))
 })
 
 test_that("non-dynamic cli progress is throttled, not re-prefixed per frame", {
@@ -106,4 +135,75 @@ test_that("non-dynamic cli progress is throttled, not re-prefixed per frame", {
   # the unfixed path would have emitted one prefixed line per tick.
   expect_lt(length(shown), nTicks)
   expect_gt(length(shown), 0L)
+})
+
+test_that("C-level (archive-style) progress flood is throttled, not re-prefixed", {
+  testInit(smcc = FALSE, debug = FALSE)
+  skip_if_not_installed("cli")
+
+  # This is the regression that actually shipped: a flood of Braille-spinner
+  # progress frames (e.g. archive::archive_extract()) whose bar lives in compiled
+  # code, so cli::cli_progress_num() == 0 and the frames carry no carriage return.
+  # The earlier "non-dynamic cli progress" test could not catch it because it
+  # registers a real R-level cli_progress_bar(), exercising a different detection
+  # branch. Here every frame is exactly the kind that previously slipped past
+  # .isCliProgressTick() and got a per-frame Date-Time-Module prefix (the flood).
+  # Driven through a faithful replica of the spades()/simInit() handler throttle,
+  # which calls the real .isCliProgressTick(): pre-fix it would emit one line per
+  # frame (length(shown) == nFrames); post-fix it collapses to a handful.
+  withr::local_options(spades.progressInterval = 2)
+
+  expect_equal(cli::cli_progress_num(), 0L)   # no R-level bar: forces the C-level path
+  cliCond <- function(msg)
+    structure(
+      class = c("cliMessage", "simpleMessage", "message", "condition"),
+      list(message = msg, call = NULL)
+    )
+
+  pe <- new.env(parent = emptyenv())
+  pe$.inProgressBar <- FALSE
+  pe$.progressLastShown <- NULL
+  shown <- character(0)
+
+  handler <- function(m) {
+    msg <- m$message
+    if (.isCliProgressTick(m, msg)) {
+      clean <- trimws(cli::ansi_strip(msg))
+      if (nchar(clean) == 0L) {
+        tryCatch(invokeRestart("muffleMessage"), error = function(e) NULL)
+        return()
+      }
+      now <- Sys.time()
+      if (!isTRUE(pe$.inProgressBar)) {
+        pe$.inProgressBar <- TRUE
+        pe$.progressLastShown <- now
+        shown[[length(shown) + 1L]] <<- clean
+      } else if (as.numeric(now - pe$.progressLastShown) >=
+                 getOption("spades.progressInterval", 2)) {
+        shown[[length(shown) + 1L]] <<- clean
+        pe$.progressLastShown <- now
+      }
+      tryCatch(invokeRestart("muffleMessage"), error = function(e) NULL)
+      return()
+    }
+    pe$.inProgressBar <- FALSE
+    shown[[length(shown) + 1L]] <<- msg
+    tryCatch(invokeRestart("muffleMessage"), error = function(e) NULL)
+  }
+
+  # 40 realistic archive frames, all carrying a leading Braille spinner, emitted
+  # in rapid succession (no \r, no active R-level bar) -- exactly the flood.
+  nFrames <- 40L
+  frames <- sprintf("\u2839 %d extracted | %.1f GB ( 15 MB/s) | 2m %d.4s\n",
+                    seq_len(nFrames), seq_len(nFrames) / 10, seq_len(nFrames))
+  withCallingHandlers(
+    for (f in frames) message(cliCond(f)),
+    message = handler
+  )
+
+  # Every frame is a Braille tick, so with spades.progressInterval = 2s and a
+  # rapid burst only the first survives; pre-fix all 40 would have been prefixed.
+  expect_lt(length(shown), nFrames)
+  expect_gt(length(shown), 0L)
+  expect_true(all(grepl("^[\u2800-\u28FF]", shown)))   # what survived really were ticks
 })


### PR DESCRIPTION
## Problem

When `archive::archive_extract()` runs inside a SpaDES module (e.g. via `prepInputs()`), the log floods with thousands of near-identical progress frames, pushing all earlier messages out of view:

```
Jun07 14:21:30 simInit/simInit/Bmss_b:.inputObjects ⠸ 13 extracted | 2.3 GB ( 15 MB/s) | 2m 30.4s
Jun07 14:21:30 simInit/simInit/Bmss_b:.inputObjects ⠼ 13 extracted | 2.3 GB ( 15 MB/s) | 2m 30.4s
... (thousands more) ...
```

Reported on Windows; affects any non-dynamic session (logged runs, CI, RStudio jobs). The same thing happens with `pak` during package installation inside a module.

## Root cause

These progress frames are routed through the `spades()`/`simInit()` message handler by `cli::start_app(output = "message")`. The earlier fix (#365) added `.isCliProgressTick()`, which throttles such frames, but it recognised a non-dynamic frame only when `cli::cli_progress_num() >= 1`.

`archive`'s progress bar lives in **compiled `libarchive` code**, so cli's *R-level* registry never sees it and `cli_progress_num()` stays `0`. With no carriage return either, every frame fell through detection and was re-printed with a full Date-Time-Module-Event prefix — the flood.

The prior regression test passed despite this because it registered a *real* R-level `cli_progress_bar()`, which exercises a different detection branch than what `archive`/`pak` actually do.

## Fix

Extend `.isCliProgressTick()` with two registry-independent cases:

- **Leading Braille spinner glyph** (`U+2800`–`U+28FF`) — cli's default spinner family and exactly what `archive`/`pak` emit (and what the flood shows: `⠸⠼⠴…`). Braille glyphs never begin a normal message, so this stays high-precision (verified it ignores `ℹ`/`✔` alerts and plain messages).
- **The trailing blank frame** that closes a C-level bar (treated as a tick only while a bar is already in progress, so it's muffled instead of printing a bare prefixed empty line).

Result: in a log (non-dynamic) the flood now collapses to **one line per `getOption("spades.progressInterval", 2)` seconds**; in an interactive terminal the existing `\r` path still does in-place overwrite.

## Tests

Added **deterministic** regression tests that reproduce the exact C-level condition (Braille frame with `cli_progress_num() == 0`) and **fail under the previous detector**:

- a unit test of `.isCliProgressTick()` (cases 5, 5b, 5c, 6), and
- a flood test through a faithful replica of the handler throttle calling the real `.isCliProgressTick()` (40 frames → collapses; pre-fix all 40 leaked).

All tests in `test-progressThrottle.R` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)