### PR TITLE
Drop quickPlot @development remote; use CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,7 +82,6 @@ Suggests:
     withr
 Remotes:
     PredictiveEcology/Require@development,
-    PredictiveEcology/quickPlot@development,
     PredictiveEcology/reproducible@development,
     PredictiveEcology/SpaDES.tools@development
 Encoding: UTF-8


### PR DESCRIPTION
## Summary

Removes the `PredictiveEcology/quickPlot@development` entry from `Remotes:` in `DESCRIPTION`. quickPlot remains a declared dependency (`quickPlot (>= 1.0.2)`), but is no longer pinned to the GitHub development branch.

## Why

CRAN quickPlot is at **1.0.4**, which satisfies `>= 1.0.2`. Pinning `@development` forced pak/remotes to build quickPlot from source (`[bld][cmp]`) on every install of SpaDES.core and its reverse dependencies (e.g. SpaDES.project), for no functional gain. Dropping the remote lets resolvers use the CRAN binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)