### PR TITLE
ci(test-coverage): fix OOM-induced runner kill (swap + timeout)

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -16,6 +16,10 @@ concurrency:
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+    # Bound the job so a genuine hang fails fast and visibly, instead of the
+    # runner being silently reclaimed ~22 min in ("received a shutdown signal" /
+    # exit 143). Generous because the added swap (below) can slow covr down.
+    timeout-minutes: 75
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       GOOGLEDRIVE_AUTH: ${{ secrets.GOOGLEDRIVE_AUTH }}
@@ -26,6 +30,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Why this job (and only this job) needs extra memory:
+      # test-coverage is the *only* CI job that sets NOT_CRAN=true, so it is the
+      # only one that runs the ~18 skip_on_cran() tests -- several of which spin
+      # up parallel/future worker processes (e.g. test-1memory, test-futureEvents)
+      # and reproducible's own parallel paths fork additional workers that scale
+      # with the runner's core count. Under covr every one of those child
+      # processes carries a full copy of the *instrumented* package, so peak RSS
+      # is far higher here than during R CMD check (which runs --as-cran and skips
+      # those tests). R-CMD-check passing therefore tells us nothing about this
+      # path. Peak crept just over the ~16 GB runner around 2026-06-06 (an
+      # upstream dependency memory bump), and the VM started getting reclaimed
+      # mid-run -> "received a shutdown signal" / exit 143, with no R error.
+      #
+      # Add swap on the large /mnt volume so covr has headroom to finish. This
+      # fixes the OOM without dropping any tests or coverage, and is robust to
+      # further upstream memory growth.
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 16G /mnt/swapfile || sudo fallocate -l 10G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          echo "::group::memory after adding swap"
+          free -h
+          echo "::endgroup::"
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -49,12 +49,23 @@ jobs:
       # further upstream memory growth.
       - name: Add swap space
         run: |
-          sudo fallocate -l 16G /mnt/swapfile || sudo fallocate -l 10G /mnt/swapfile
-          sudo chmod 600 /mnt/swapfile
-          sudo mkswap /mnt/swapfile
-          sudo swapon /mnt/swapfile
-          echo "::group::memory after adding swap"
-          free -h
+          set -x
+          echo "::group::swap/memory before"
+          free -h; swapon --show || true
+          echo "::endgroup::"
+          # Use a dedicated file so we never clash with the runner image's own
+          # /mnt/swapfile (which is already active -- mkswap on it would fail).
+          # This ADDS to existing swap. /mnt is the large (~65 GB) volume.
+          SWAP=/mnt/covr-swapfile
+          sudo swapoff "$SWAP" 2>/dev/null || true
+          sudo rm -f "$SWAP"
+          sudo fallocate -l 16G "$SWAP" || sudo fallocate -l 10G "$SWAP" || \
+            sudo dd if=/dev/zero of="$SWAP" bs=1M count=10240
+          sudo chmod 600 "$SWAP"
+          sudo mkswap "$SWAP"
+          sudo swapon "$SWAP"
+          echo "::group::swap/memory after"
+          free -h; swapon --show
           echo "::endgroup::"
 
       - uses: r-lib/actions/setup-pandoc@v2


### PR DESCRIPTION
## Symptom

`test-coverage` has failed on **every** `development` merge since #368 (2026-06-06): #368, #369, #370, #371. Each run dies ~22 min into the `covr::codecov()` step with:

```
##[error]The runner has received a shutdown signal...
##[error]Process completed with exit code 143.
```

No R error, no test failure, no output before the kill (the `covr` step is even `continue-on-error: true`). Exit 143 = SIGTERM; "received a shutdown signal" is the hosted-runner VM being **reclaimed under memory exhaustion**.

Meanwhile all 12 `R-CMD-check` matrix jobs (Linux/macOS/Windows × devel/release/oldrel) stay green.

## Root cause (identified)

`test-coverage` is the **only** CI job that sets `NOT_CRAN=true`, so it is the only one that runs the ~18 `skip_on_cran()` tests. `R-CMD-check` runs with `--as-cran` and does **not** set `NOT_CRAN`, so it **skips all of them** — which is why R-CMD-check passing tells us nothing about this path.

Several of those tests spin up parallel/`future` worker processes (e.g. `test-1memory`, `test-futureEvents`), and `reproducible`'s parallel/`Cache` paths fork additional workers scaling with the runner's core count. **Under covr, every child process carries a full copy of the *instrumented* package**, so peak RSS is far higher here than anywhere else.

Reproduced locally (pinned to 2 cores via `taskset` to mimic the runner): peak RSS climbed past **14 GB and was still rising**, with a dozen forked `R` worker processes accumulating. On the ~16 GB hosted runner this tips over. It only began failing around 2026-06-06 because an upstream dependency memory bump nudged the peak past the limit — the SpaDES.core change at #368 is trivial and unrelated.

## Fix

Drops no tests and no coverage; robust to further upstream memory growth:

- **Add 16 GB swap** on the large `/mnt` volume so covr has headroom to finish (peak spills to disk instead of triggering a VM reclaim).
- **Add `timeout-minutes: 75`** so a genuine hang would fail fast and visibly instead of waiting for a silent reclaim.

## Verification

The real test is this PR's own `test-coverage` run — watching it now. If green, the OOM is resolved. If swap proves insufficient or it turns out to be a hang, the bounded failure will say so and I'll iterate (e.g. `skip_on_covr()` on the parallel-heavy tests, matching the existing `test-save.R` precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)