### PR TITLE
fix(cache): strip absolute module paths from event cacheId (cross-OS cloud cache)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-06-08
-Version: 3.1.2.9012
+Version: 3.1.2.9013
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# SpaDES.core 3.1.2.9013 (development version)
+
+## Bug fixes
+
+* **Event (`init`, etc.) `cacheId` is now stable across machines/OSs**, so cloud
+  caching of events can be shared (e.g. Linux <-> Windows). The module's absolute
+  install path is carried as the *name* of its `sim@modules` entry and as the
+  *name* of each event's `moduleName` (a named character: name = full path, value
+  = module name). Those paths differ across machines, so `.robustDigest()` of the
+  `modules` and `events` slots produced different `cacheId`s for byte-identical
+  runs -- breaking shared/cloud cache reuse for the event path. The simList
+  `.robustDigest` method now strips those path names before digesting (only the
+  module *name*, not its location, is relevant). `.inputObjects` was already
+  unaffected (it uses the basename and excludes the event queue). One-time
+  `cacheId` shift for events. Same cross-OS rationale as the earlier
+  parameter-definition-table and `desc`-column removals.
+
 # SpaDES.core 3.1.2.9011 (development version)
 
 ## Bug fixes

--- a/R/cache.R
+++ b/R/cache.R
@@ -184,6 +184,26 @@ setMethod(
       }
     }
 
+    # Strip absolute module paths before digesting. A module's path is carried as
+    # the *name* of its `object@modules` entry, and as the *name* of each event's
+    # `moduleName` (a named character: name = full path, value = module name).
+    # Those paths differ across machines/OSs, so they split the cacheId -- the
+    # same identical run on Linux vs Windows produced different `sim.modules` and
+    # `sim.events.moduleName` hashes (diagnosed via CacheDigest's preDigest), so
+    # `init`/event results could not be shared via a (cloud) cache, even though
+    # only the module *name* (not its install location) is relevant to caching.
+    # `.inputObjects` was unaffected because its classOptions use the basename and
+    # exclude the event queue. (Same cross-OS rationale as the parameters/desc
+    # removals above.)
+    object@modules <- lapply(object@modules, unname)
+    names(object@modules) <- NULL
+    if (length(object@events)) {
+      object@events <- lapply(object@events, function(e) {
+        if (!is.null(e[["moduleName"]])) e[["moduleName"]] <- unname(e[["moduleName"]])
+        e
+      })
+    }
+
     # Inputs
     # if (curMod %in% "fireSense_dataPrepPredict") browser()
     if (NROW(object@inputs)) { # this is the argument for simInit --> this shouldn't matter/ should be ignored

--- a/tests/testthat/test-cacheModulePathInEvent.R
+++ b/tests/testthat/test-cacheModulePathInEvent.R
@@ -1,0 +1,38 @@
+test_that("event cacheId ignores absolute module paths (modules + event moduleName)", {
+  skip_on_cran()
+  ## A module's install path is carried as the *name* of its `sim@modules` entry
+  ## and as the *name* of each event's `moduleName`. Those paths differ across
+  ## machines/OSs and must NOT enter the cacheId, else an identical `init`/event
+  ## run on Linux vs Windows gets a different cacheId and cannot share a (cloud)
+  ## cache. `.inputObjects` is unaffected (basename + no event queue); this guards
+  ## the event path.
+  testInit(opts = list(spades.loadReqdPkgs = FALSE, spades.moduleCodeChecks = FALSE,
+                       reproducible.useMemoise = FALSE))
+  modDir <- file.path(tmpdir, "m"); dir.create(modDir, recursive = TRUE, showWarnings = FALSE)
+  cat(file = file.path(modDir, "m.R"), sep = "", '
+defineModule(sim, list(name = "m", description = "", keywords = "", authors = person("A","B"),
+  childModules = character(0), version = list(m = "0.0.1"), timeframe = as.POSIXlt(c(NA, NA)),
+  timeunit = "year", citation = list(), documentation = list(), reqdPkgs = list(),
+  parameters = rbind(defineParameter(".useCache", "character", "init", NA, NA, "c")),
+  inputObjects = bindrows(), outputObjects = bindrows()))
+doEvent.m <- function(sim, eventTime, eventType, debug = FALSE) { switch(eventType, init = {}); invisible(sim) }
+')
+  s <- suppressMessages(simInit(modules = "m", paths = list(modulePath = tmpdir),
+                                times = list(start = 0, end = 1)))
+  ## digest the simList the way the event path does (events digested, module = "m")
+  co <- list(events = "init", current = FALSE, completed = FALSE, simtimes = FALSE,
+             modules = "m")
+  d1 <- reproducible::CacheDigest(s, classOptions = co)$outputHash
+
+  ## Re-point the module path everywhere it is carried as a *name* (emulates a
+  ## different machine/OS install location). cacheId must not move.
+  newPath <- "/some/other/abs/path/to/m"
+  nm <- names(s@modules); nm[nzchar(nm)] <- newPath; names(s@modules) <- nm
+  s@events <- lapply(s@events, function(e) {
+    if (!is.null(e[["moduleName"]]) && !is.null(names(e[["moduleName"]])))
+      names(e[["moduleName"]]) <- newPath
+    e
+  })
+  d2 <- reproducible::CacheDigest(s, classOptions = co)$outputHash
+  expect_identical(d1, d2)
+})


### PR DESCRIPTION
## Problem

An **event** (`init`, etc.) cloud-cached fine on the first machine but **never matched on a second OS** — the same byte-identical run produced a different `cacheId` on Linux vs Windows, so the cloud entry couldn't be reused. (`.inputObjects` was unaffected and shared correctly.)

## Diagnosis

Diffed `CacheDigest`'s per-element `preDigest` for the same `doEvent.scfmDataPrep::init` call on both machines. **Everything matched** — `.FUN`, every `moduleFunctions.*`, `sim.depends.scfmDataPrep.inputObjects`, all `sim.params.*` — **except**:

```
sim.modules              ← differs
sim.events.moduleName    ← differs (×3)
```

Cause: a module's absolute install path is carried as the **name** of its `sim@modules` entry, and as the **name** of each event's `moduleName` (a named character — name = full path, value = module name):

```r
$`/home/.../modules/scfmDataPrep`   # list NAME = path (machine-specific)
[1] "scfmDataPrep"                  # value = module name
```

So `.robustDigest()` of the `modules` and `events` slots embeds the install path → different `cacheId` per machine. `.inputObjects` escaped this because its `classOptions` use the basename and exclude the event queue.

## Fix

In the simList `.robustDigest` method, strip those path **names** before digesting — only the module *name*, not its location, is relevant to the cacheId:

```r
object@modules <- lapply(object@modules, unname)
names(object@modules) <- NULL
if (length(object@events))
  object@events <- lapply(object@events, function(e) {
    if (!is.null(e[["moduleName"]])) e[["moduleName"]] <- unname(e[["moduleName"]])
    e
  })
```

This operates on the method's internal `Copy(object, objects = FALSE, queues = FALSE)` only, so the **live simList is untouched** (it still has the real paths to run) and the **`Copy` method is not changed**. One-time `cacheId` shift for events; same cross-OS rationale as the earlier parameter-definition-table and `desc`-column removals (#369).

## Verification

- Two independent module install paths now yield an **identical** `init` cacheId (was different) — reproduced locally by running the same module from two abs paths and diffing the `preDigest`.
- New regression test (`test-cacheModulePathInEvent.R`): re-pointing the module path no longer moves the event cacheId.
- Full `test-cache.R` (92) + `test-cacheParamMetadata.R` still pass — cache hits/misses intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)