### PR TITLE
chore(options): default spades.moduleCodeChecks to FALSE; point to codeCheckModule(s)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-06-08
-Version: 3.1.2.9013
+Version: 3.1.2.9014
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# SpaDES.core 3.1.2.9014 (development version)
+
+## Behaviour changes
+
+* **`spades.moduleCodeChecks` now defaults to `FALSE`** -- module code checks no
+  longer run automatically during every `simInit()` (they slowed it and are not
+  needed on every run). Run them manually instead with [codeCheckModule()] (one
+  module) or [codeCheckModules()] (one or more, e.g. a whole project) -- no
+  `simInit()` required. To restore the old in-`simInit()` checking, set
+  `options(spades.moduleCodeChecks = TRUE)` (or a named list of toggles). Docs in
+  `?spadesOptions` and the package overview updated accordingly.
+
 # SpaDES.core 3.1.2.9013 (development version)
 
 ## Bug fixes

--- a/R/options.R
+++ b/R/options.R
@@ -103,12 +103,17 @@
 #'     line of the messaging during spades calls.\cr
 #'
 #'   `spades.moduleCodeChecks`
-#'     \tab `list(suppressParamUnused = FALSE,
-#'   suppressUndefined = TRUE, suppressPartialMatchArgs = FALSE, suppressNoLocalFun = TRUE,
-#'   skipWith = TRUE)`
-#'     \tab Should the various code checks be run during `simInit`.
-#'   These are passed to `codetools::checkUsage()`.
-#'   Default is given by the function, plus these:\cr
+#'     \tab `FALSE`
+#'     \tab Should the various module code checks be run during `simInit`.
+#'   **As of `SpaDES.core` 3.1.2.9014 the default is `FALSE`** (checks no longer
+#'   run automatically during `simInit`, which they previously slowed). To run the
+#'   checks, call [codeCheckModule()] / [codeCheckModules()] manually (no
+#'   `simInit()` needed). To restore in-`simInit` checking, set this option to a
+#'   named list of toggles, e.g.
+#'   `list(suppressParamUnused = FALSE, suppressUndefined = TRUE,
+#'   suppressPartialMatchArgs = FALSE, suppressNoLocalFun = TRUE, skipWith = TRUE)`
+#'   (or `TRUE` for the defaults); these are passed through to
+#'   `codetools::checkUsage()`.\cr
 #'
 #'   `spades.moduleDocument` \tab  `TRUE`
 #'     \tab  When a module is an R package e.g., via `convertToPackage`,
@@ -229,13 +234,11 @@ spadesOptions <- function() {
     spades.lowMemory = FALSE,
     spades.memoryUseInterval = 0,
     spades.messagingNumCharsModule = 21,
-    spades.moduleCodeChecks = list(
-      skipWith = TRUE,
-      suppressNoLocalFun = TRUE,
-      suppressParamUnused = FALSE,
-      suppressPartialMatchArgs = FALSE,
-      suppressUndefined = TRUE
-    ),
+    # Module code checks are OFF by default as of SpaDES.core 3.1.2.9014. They
+    # slowed every simInit() and most users do not need them on every run. Run
+    # them manually instead with codeCheckModule()/codeCheckModules(). Set this to
+    # the named list of toggles (see ?spadesOptions) to re-enable in-simInit checks.
+    spades.moduleCodeChecks = FALSE,
     spades.codeCheckEngine = "v1",
     spades.modulePath = file.path(.spadesTempDir(), "modules"),
     spades.moduleRepo = "PredictiveEcology/SpaDES-modules",

--- a/R/spades-core-package.R
+++ b/R/spades-core-package.R
@@ -228,17 +228,20 @@
 #'
 #' @section 9 Code checking:
 #'
-#' When `simInit()` runs, it can statically check each module's code against
-#' the metadata: every `sim$x` and parameter access is checked to be sure it
-#' matches the declared inputs, outputs, and parameters.
+#' SpaDES.core can statically check each module's code against the metadata:
+#' every `sim$x` and parameter access is checked to be sure it matches the
+#' declared inputs, outputs, and parameters. **As of `SpaDES.core` 3.1.2.9014
+#' these checks no longer run automatically during `simInit()`** (the default of
+#' `spades.moduleCodeChecks` is now `FALSE`); run them manually instead:
 #'
 #' \tabular{ll}{
-#'   [codeCheckModule()] \tab Run the checks on a module on disk (no `simInit()` needed).\cr
+#'   [codeCheckModule()]  \tab Run the checks on a single module on disk (no `simInit()` needed).\cr
+#'   [codeCheckModules()] \tab Vectorized form: run on one or more modules (e.g. a whole project).\cr
 #' }
 #'
 #' Controlled by these options:
 #' \tabular{ll}{
-#'   `spades.moduleCodeChecks` \tab Turn the in-`simInit()` checks on (`TRUE`) or off (`FALSE`).\cr
+#'   `spades.moduleCodeChecks` \tab Default `FALSE` (off). Set to `TRUE` (or a named list of toggles) to re-enable the in-`simInit()` checks.\cr
 #'   `spades.codeCheckEngine` \tab `"v1"` (default) or `"v2"` (new, structured output).\cr
 #' }
 #'

--- a/man/SpaDES.core-package.Rd
+++ b/man/SpaDES.core-package.Rd
@@ -246,17 +246,20 @@ or no output at all.
 \section{9 Code checking}{
 
 
-When \code{simInit()} runs, it can statically check each module's code against
-the metadata: every \code{sim$x} and parameter access is checked to be sure it
-matches the declared inputs, outputs, and parameters.
+SpaDES.core can statically check each module's code against the metadata:
+every \code{sim$x} and parameter access is checked to be sure it matches the
+declared inputs, outputs, and parameters. \strong{As of \code{SpaDES.core} 3.1.2.9014
+these checks no longer run automatically during \code{simInit()}} (the default of
+\code{spades.moduleCodeChecks} is now \code{FALSE}); run them manually instead:
 
 \tabular{ll}{
-\code{\link[=codeCheckModule]{codeCheckModule()}} \tab Run the checks on a module on disk (no \code{simInit()} needed).\cr
+\code{\link[=codeCheckModule]{codeCheckModule()}}  \tab Run the checks on a single module on disk (no \code{simInit()} needed).\cr
+\code{\link[=codeCheckModules]{codeCheckModules()}} \tab Vectorized form: run on one or more modules (e.g. a whole project).\cr
 }
 
 Controlled by these options:
 \tabular{ll}{
-\code{spades.moduleCodeChecks} \tab Turn the in-\code{simInit()} checks on (\code{TRUE}) or off (\code{FALSE}).\cr
+\code{spades.moduleCodeChecks} \tab Default \code{FALSE} (off). Set to \code{TRUE} (or a named list of toggles) to re-enable the in-\code{simInit()} checks.\cr
 \code{spades.codeCheckEngine} \tab \code{"v1"} (default) or \code{"v2"} (new, structured output).\cr
 }
 }

--- a/man/spadesOptions.Rd
+++ b/man/spadesOptions.Rd
@@ -108,10 +108,16 @@ has terminated.\cr
 line of the messaging during spades calls.\cr
 
 \code{spades.moduleCodeChecks}
-\tab \code{list(suppressParamUnused = FALSE, suppressUndefined = TRUE, suppressPartialMatchArgs = FALSE, suppressNoLocalFun = TRUE, skipWith = TRUE)}
-\tab Should the various code checks be run during \code{simInit}.
-These are passed to \code{codetools::checkUsage()}.
-Default is given by the function, plus these:\cr
+\tab \code{FALSE}
+\tab Should the various module code checks be run during \code{simInit}.
+\strong{As of \code{SpaDES.core} 3.1.2.9014 the default is \code{FALSE}} (checks no longer
+run automatically during \code{simInit}, which they previously slowed). To run the
+checks, call \code{\link[=codeCheckModule]{codeCheckModule()}} / \code{\link[=codeCheckModules]{codeCheckModules()}} manually (no
+\code{simInit()} needed). To restore in-\code{simInit} checking, set this option to a
+named list of toggles, e.g.
+\code{list(suppressParamUnused = FALSE, suppressUndefined = TRUE, suppressPartialMatchArgs = FALSE, suppressNoLocalFun = TRUE, skipWith = TRUE)}
+(or \code{TRUE} for the defaults); these are passed through to
+\code{codetools::checkUsage()}.\cr
 
 \code{spades.moduleDocument} \tab  \code{TRUE}
 \tab  When a module is an R package e.g., via \code{convertToPackage},


### PR DESCRIPTION
## What

`spades.moduleCodeChecks` now defaults to **`FALSE`** (was a named list of toggles). Module code checks no longer run automatically during every `simInit()` — they slowed it and aren't needed on every run.

Run them **manually** instead (no `simInit()` required):
- `codeCheckModule(path)` — one module on disk
- `codeCheckModules(paths)` — one or more (e.g. a whole project)

To restore the old in-`simInit()` behaviour: `options(spades.moduleCodeChecks = TRUE)` (or a named list of toggles).

## Changes

- `R/options.R` — default changed `list(...)` → `FALSE`; the `?spadesOptions` doc entry updated to say it's no longer the default and to point at `codeCheckModule()`/`codeCheckModules()`.
- `R/spades-core-package.R` — package-overview section updated likewise (now lists both manual functions).
- `man/spadesOptions.Rd`, `man/SpaDES.core-package.Rd` — regenerated/updated to match.
- NEWS + version bump.

## Why it's safe

- The consuming code already supported `FALSE`: the in-`simInit()` gate is `isTRUE(opt) || length(names(opt)) > 1`, and countless examples already set `options(spades.moduleCodeChecks = FALSE)`.
- `testInit()`'s `smcc` default was already `FALSE`, so the test suite already ran with checks off; `test-codecheck.R` passes (77) since it enables checks explicitly where needed.

Verified: `simInit()` runs clean with checks skipped (no "Module Code Checking" message); `codeCheckModule()` still returns findings regardless of the option default.

> Note: bumps to `3.1.2.9014` (same as #375, off the same base) — trivial DESCRIPTION/NEWS conflict for whichever merges second; the "as of 3.1.2.9014" doc strings assume this lands at that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)