### PR TITLE
feat: advertise sim paths to reproducible for portable file-backed objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # SpaDES.core 3.1.2.9014 (development version)
 
+## New features
+
+* **File-backed objects (e.g. `terra` `SpatRaster`) cached during a run are now
+  portable across machines/users.** `simInit()` and `spades()` advertise the
+  simulation's project paths to `reproducible` via
+  `options(reproducible.fileBackedAnchors = paths(sim))`, so a file-backed
+  object's backing file is stored *relative* to a named, machine-independent
+  anchor (`cachePath`, `inputPath`, `outputPath`, `modulePath`, ...) and restored
+  under the equivalent anchor on another machine or user account — for example
+  when retrieved from a shared cloud cache. Previously such an object embedded an
+  absolute path (e.g. `/home/<producer>/.../inputs/x.tif`) that did not exist for
+  the receiver, causing `Cache` retrieval to fail. The anchors are set during
+  both the `simInit()` `.inputObjects` phase and the `spades()` event loop, and an
+  explicit user-set `reproducible.fileBackedAnchors` is always respected.
+  Requires `reproducible` with `fileBackedAnchors` support.
+
 ## Behaviour changes
 
 * **`spades.moduleCodeChecks` now defaults to `FALSE`** -- module code checks no

--- a/R/paths.R
+++ b/R/paths.R
@@ -235,3 +235,31 @@ setPaths <- function(cachePath, inputPath, modulePath, outputPath, rasterPath, s
 
   return(invisible(originalPaths))
 }
+
+#' Make file-backed objects portable across machines/users
+#'
+#' Sets `options(reproducible.fileBackedAnchors = paths)` so that file-backed
+#' objects (e.g. a \pkg{terra} `SpatRaster`) cached during a `simInit()` /
+#' `spades()` run are stored *relative* to a named, machine-independent project
+#' anchor (`cachePath`, `inputPath`, `outputPath`, `modulePath`, ...) and can
+#' therefore be restored under the equivalent anchor on another machine or user
+#' account — for example when retrieved from a shared cloud cache. See the
+#' `reproducible.fileBackedAnchors` entry in `reproducible::reproducibleOptions()`.
+#'
+#' It is deliberately a no-op when the option is already set (by the user, or by
+#' an outer/enclosing run), so an explicit setting always wins. When it does set
+#' the option it returns `TRUE` invisibly; the caller is then responsible for
+#' restoring the previous (`NULL`) value, typically via `on.exit()`.
+#'
+#' @param paths A named list of project paths, e.g. `paths(sim)` / `getPaths()`.
+#' @return Invisibly, `TRUE` if this call set the option, otherwise `FALSE`.
+#' @keywords internal
+#' @noRd
+.useFileBackedAnchors <- function(paths) {
+  if (is.null(getOption("reproducible.fileBackedAnchors")) &&
+      length(paths) && !is.null(names(paths))) {
+    options(reproducible.fileBackedAnchors = paths)
+    return(invisible(TRUE))
+  }
+  invisible(FALSE)
+}

--- a/R/simulation-simInit.R
+++ b/R/simulation-simInit.R
@@ -492,6 +492,13 @@ setMethod(
     }, add = TRUE)
     paths(sim) <- paths #paths accessor does important stuff
 
+    # Let reproducible store/restore file-backed objects (e.g. SpatRaster) relative
+    #   to these project anchors, so they remain portable across machines/users
+    #   (e.g. a shared cloud cache). `.inputObjects` runs Cache() during simInit, so
+    #   the anchors must be in place here too. Skips if the user already set them.
+    if (isTRUE(.useFileBackedAnchors(paths(sim))))
+      on.exit(options(reproducible.fileBackedAnchors = NULL), add = TRUE)
+
     names(modules) <- unlist(modules)
     adjustModuleNameSpacing(modules) # changes options("spades.messagingNumCharsModule")
 

--- a/R/simulation-spades.R
+++ b/R/simulation-spades.R
@@ -991,6 +991,12 @@ setMethod(
         do.call(setPaths, append(list(silent = TRUE), oldGetPaths))
       }, add = TRUE)
 
+      # Make file-backed objects (e.g. SpatRaster) cached during this run portable
+      #   across machines/users by storing them relative to the sim's project
+      #   anchors (see reproducible.fileBackedAnchors). Skips if already set.
+      if (isTRUE(.useFileBackedAnchors(sim@paths)))
+        on.exit(options(reproducible.fileBackedAnchors = NULL), add = TRUE)
+
       if (!is.null(sim@.xData[["._randomSeed"]])) {
         message("Resetting .Random.seed of session to the pre-existing value \n",
                 "because sim$._randomSeed is not NULL. ",

--- a/tests/testthat/test-fileBackedAnchors.R
+++ b/tests/testthat/test-fileBackedAnchors.R
@@ -1,0 +1,91 @@
+# simInit()/spades() advertise the simulation's project paths to reproducible via
+# options(reproducible.fileBackedAnchors = paths(sim)), so that file-backed objects
+# (e.g. terra SpatRaster) cached during a run are stored relative to a named,
+# machine-independent anchor and can be restored on another machine/user (e.g. a
+# shared cloud cache). An explicit user setting must always win, and the option
+# must be restored after the run.
+
+## minimal module that records the option value during .inputObjects and/or init.
+## `dummy` is an unprovided expected input so that `.inputObjects` actually runs
+## (simInit skips `.inputObjects` when all expected inputs are already supplied).
+mkAnchMod <- function(tmpdir, name, dotIO = "sim", initBody = "sim") {
+  newModule(name, tmpdir, open = FALSE)
+  code <- sprintf('
+defineModule(sim, list(name = "%s", description = "", keywords = "", authors = person("a", "b"),
+  childModules = character(0), version = list(%s = "0.0.1"), timeframe = as.POSIXlt(c(NA, NA)),
+  timeunit = "year", citation = list(), documentation = list(), reqdPkgs = list(),
+  parameters = rbind(defineParameter(".useCache", "logical", FALSE, NA, NA, "")),
+  inputObjects = bindrows(expectsInput("dummy", "ANY", "")), outputObjects = bindrows()))
+doEvent.%s <- function(sim, eventTime, eventType, debug = FALSE) {
+  if (eventType == "init") { %s }
+  sim
+}
+.inputObjects <- function(sim) { %s; sim }
+', name, name, name, initBody, dotIO)
+  cat(code, file = file.path(tmpdir, name, paste0(name, ".R")), fill = TRUE)
+}
+
+test_that(".useFileBackedAnchors sets the option only when it is unset", {
+  withr::local_options(reproducible.fileBackedAnchors = NULL)
+  p <- list(cachePath = "/c", inputPath = "/i")
+
+  expect_true(isTRUE(SpaDES.core:::.useFileBackedAnchors(p)))
+  expect_identical(getOption("reproducible.fileBackedAnchors"), p)
+
+  # already set -> no-op, returns FALSE, value preserved
+  keep <- list(inputPath = "/keep")
+  options(reproducible.fileBackedAnchors = keep)
+  expect_false(isTRUE(SpaDES.core:::.useFileBackedAnchors(p)))
+  expect_identical(getOption("reproducible.fileBackedAnchors"), keep)
+
+  # unnamed / empty paths -> no-op
+  options(reproducible.fileBackedAnchors = NULL)
+  expect_false(isTRUE(SpaDES.core:::.useFileBackedAnchors(list())))
+  expect_null(getOption("reproducible.fileBackedAnchors"))
+})
+
+test_that("simInit() and spades() set fileBackedAnchors from paths() and restore after", {
+  testInit(smcc = FALSE, opts = list(reproducible.useMemoise = FALSE))
+  withr::local_options(reproducible.cachePath = tmpCache,
+                       reproducible.fileBackedAnchors = NULL)
+
+  mkAnchMod(tmpdir, "anchMod",
+            dotIO = 'sim$ioAnchors <- getOption("reproducible.fileBackedAnchors")',
+            initBody = 'sim$initAnchors <- getOption("reproducible.fileBackedAnchors")')
+
+  sim <- simInit(modules = "anchMod",
+                 paths = list(modulePath = tmpdir, cachePath = tmpCache),
+                 times = list(start = 0, end = 1))
+
+  # during .inputObjects (run inside simInit) the anchors were the sim's paths
+  expect_false(is.null(sim$ioAnchors))
+  expect_identical(sim$ioAnchors, paths(sim))
+  # ...and the option is restored once simInit() returns
+  expect_null(getOption("reproducible.fileBackedAnchors"))
+
+  out <- spades(sim, debug = FALSE)
+
+  # during the init event (run inside spades) the anchors were again the sim's paths
+  expect_false(is.null(out$initAnchors))
+  expect_identical(out$initAnchors, paths(sim))
+  # ...and restored after spades() too
+  expect_null(getOption("reproducible.fileBackedAnchors"))
+})
+
+test_that("an explicit reproducible.fileBackedAnchors is not overridden", {
+  testInit(smcc = FALSE, opts = list(reproducible.useMemoise = FALSE))
+  userAnchors <- list(inputPath = "/my/custom/inputs", cachePath = tmpCache)
+  withr::local_options(reproducible.cachePath = tmpCache,
+                       reproducible.fileBackedAnchors = userAnchors)
+
+  mkAnchMod(tmpdir, "anchMod2",
+            dotIO = 'sim$ioAnchors <- getOption("reproducible.fileBackedAnchors")')
+
+  sim <- simInit(modules = "anchMod2",
+                 paths = list(modulePath = tmpdir, cachePath = tmpCache),
+                 times = list(start = 0, end = 1))
+
+  # the user's explicit anchors were used during the run, and left untouched after
+  expect_identical(sim$ioAnchors, userAnchors)
+  expect_identical(getOption("reproducible.fileBackedAnchors"), userAnchors)
+})


### PR DESCRIPTION
## Why

A file-backed object (e.g. a `terra` `SpatRaster`) embeds an **absolute** path to its backing file. When such an object is cached and later retrieved on another machine/user — notably a **shared cloud cache** — that path does not exist for the receiver and `Cache()` retrieval fails, e.g. during a module's `.inputObjects`:

```
Error : [rast] file does not exist: /home/<producer>/.../inputs/rstLCC_dehchoN_2020.tif
Warning: cannot create dir '/home/<producer>', reason 'Operation not supported'
```

The companion `reproducible` PR (PredictiveEcology/reproducible#507) makes file-backed objects portable **when it is told the project's anchor directories** via the new option `reproducible.fileBackedAnchors`. This PR wires SpaDES.core to supply them automatically.

## What

- New internal helper `.useFileBackedAnchors(paths)` (`R/paths.R`): sets `options(reproducible.fileBackedAnchors = paths)` **only when the option is unset** (an explicit user/outer setting always wins), returning `TRUE` if it set it so the caller can restore on exit.
- `simInit()` and `spades()` call it from their existing paths/`on.exit` blocks, so the anchors are in place during **both** the `simInit()` `.inputObjects` phase (where the original failure occurred) and the `spades()` event loop, and are restored afterward.

With this, a file-backed object's backing file is stored relative to a named, machine-independent anchor (`cachePath`/`inputPath`/`outputPath`/`modulePath`/...) and restored under the receiver's equivalent anchor.

## Tests

`tests/testthat/test-fileBackedAnchors.R`:
- `.useFileBackedAnchors` sets only when unset; no-op when already set or paths empty/unnamed.
- `simInit()` and `spades()` set the option to `paths(sim)` during the run (observed from inside `.inputObjects` and the `init` event) and restore it (to `NULL`) afterward.
- An explicit user-set `reproducible.fileBackedAnchors` is used during the run and left untouched.

## Depends on

PredictiveEcology/reproducible#507 (provides `reproducible.fileBackedAnchors`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)