### PR TITLE
fix(saveSimList): row-filter saved outputs (missing comma)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-06-08
-Version: 3.1.2.9015
+Version: 3.1.2.9016
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# SpaDES.core 3.1.2.9016 (development version)
+
+## Bug fixes
+
+* `saveSimList()` no longer errors with "undefined columns selected" when `outputs(sim)` has rows. The saved-outputs filter was indexing the `outputs` `data.frame` by column instead of row (missing comma).
+
 # SpaDES.core 3.1.2.9015 (development version)
 
 ## Bug fixes

--- a/R/saveLoadSimList.R
+++ b/R/saveLoadSimList.R
@@ -231,7 +231,7 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
       otherFns <- c()
       if (isTRUE(outputs)) {
         os <- outputs(sim)
-        if (NROW(os)) otherFns <- c(otherFns, os[os$saved %in% TRUE]$file)
+        if (NROW(os)) otherFns <- c(otherFns, os[os$saved %in% TRUE, ]$file)
       }
       if (isTRUE(inputs)) {
         ins <- inputs(sim)
@@ -304,7 +304,7 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
       if (isTRUE(outputs)) {
         os <- outputs(sim)
         if (NROW(os)) {
-          outputFNs <- os[os$saved %in% TRUE]$file
+          outputFNs <- os[os$saved %in% TRUE, ]$file
           otherFns <- c(otherFns, outputFNs)
         }
       }


### PR DESCRIPTION
## Problem

`saveSimList()` errored with:

```
Error in `[.data.frame`(os, os$saved %in% TRUE) :
  undefined columns selected
```

whenever `outputs(sim)` had rows. The saved-outputs filter indexed the `outputs` `data.frame` with a single argument (`os[os$saved %in% TRUE]`), which R interprets as *column* selection rather than *row* filtering. The parallel `inputs` path already used the correct `[cond, ]` form.

## Fix

Add the missing comma at both occurrences (lines 234 and 307) so rows are filtered:

```r
os[os$saved %in% TRUE, ]$file
```

NEWS + version bump to 3.1.2.9016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)