### PR TITLE
fix(metadata): keep a live SpatExtent in module deps (fixes R-CMD-check under terra >= 1.9-34)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-06-08
-Version: 3.1.2.9018
+Version: 3.1.2.9019
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# SpaDES.core 3.1.2.9019 (development version)
+
+## Bug fixes
+
+* Module metadata no longer errors "external pointer is not valid" (`moduleMetadata()`, printing `depends(sim)`, etc.) under `terra` >= 1.9-34. `defineModule()` dropped a module-supplied `spatialExtent` (an `if` with no `else`), so every `.moduleDeps` fell back to the class prototype -- a `SpatExtent` built at package-*build* time, whose external pointer is dead in the installed package. `defineModule()` now keeps the module's own extent, `eval()`s the quoted default when the extent is `NA`, and the prototype no longer holds a `terra` object.
+
 # SpaDES.core 3.1.2.9018 (development version)
 
 ## Bug fixes

--- a/R/module-define.R
+++ b/R/module-define.R
@@ -233,16 +233,16 @@ setMethod(
     }
     x$version <- as.numeric_version(x$version)
 
-    x$spatialExtent <- if (!isExtents(x$spatialExtent)) {
-      if (is.null(x$spatialExtent)) {
-        eval(moduleDefaults$extent)
-      } else {
-        if (is.na(x$spatialExtent)) {
-          moduleDefaults$extent
-        } else {
-          ext(x$spatialExtent)
-        }
-      }
+    ## NOTE: the missing `else` here used to drop a module-supplied extent (assigning NULL),
+    ## so `new(".moduleDeps")` fell back to the class prototype -- a `SpatExtent` created at
+    ## package *build* time, whose external pointer is dead once the package is loaded
+    ## (terra >= 1.9-34 errors "external pointer is not valid"). Always keep a live extent.
+    x$spatialExtent <- if (isExtents(x$spatialExtent)) {
+      x$spatialExtent
+    } else if (is.null(x$spatialExtent) || all(is.na(x$spatialExtent))) {
+      eval(moduleDefaults$extent) ## a `quote()`; must be eval'ed to give a `SpatExtent`
+    } else {
+      ext(x$spatialExtent)
     }
 
     x$timeframe <- if (is.null(x$timeframe) || any(is.na(x$timeframe))) {

--- a/R/module-dependencies-class.R
+++ b/R/module-dependencies-class.R
@@ -143,7 +143,10 @@ setClass(
   prototype = list(
     name = character(0), description = character(0), keywords = character(0),
     childModules = character(0), authors = person(), version = numeric_version("0.0.0"),
-    spatialExtent = terra::ext(rep(0L, 4L)), timeframe = as.POSIXlt(c(NA, NA)),
+    ## NOTE: must NOT be a `terra::ext()`: a prototype is created at package *build* time and
+    ## its external pointer is dead in the installed package. `defineModule()` always supplies
+    ## a live `SpatExtent` (`moduleDefaults$extent`), so `NULL` here is only ever a placeholder.
+    spatialExtent = NULL, timeframe = as.POSIXlt(c(NA, NA)),
     timeunit = NA_real_, citation = list(), documentation = list(),
     loadOrder = list(after = NULL, before = NULL), reqdPkgs = list(),
     parameters = data.frame(
@@ -155,7 +158,7 @@ setClass(
     outputObjects = ._outputObjectsDF()
   ),
   validity = function(object) {
-    if (!(isExtents(object@spatialExtent)))
+    if (!is.null(object@spatialExtent) && !(isExtents(object@spatialExtent)))
       stop("spatialExtent must be an Extent object or SpatExtent")
     if (length(object@name) != 1L) stop("name must be a single character string.")
     if (length(object@description) != 1L) stop("description must be a single character string.")

--- a/tests/testthat/test-module-deps-methods.R
+++ b/tests/testthat/test-module-deps-methods.R
@@ -275,3 +275,25 @@ test_that("Test cleaning up of desc in createsOutputs, expectsInputs, definePara
                  expect_false(grepl("\n", desc))
                })
 })
+
+test_that("spatialExtent of a module dependency is a live SpatExtent", {
+  ## the `.moduleDeps` prototype extent is created at package *build* time, so its external
+  ## pointer is dead in the installed package; `defineModule()` must supply its own.
+  ## terra >= 1.9-34 errors "external pointer is not valid" on such an object
+  testInit(sampleModReqdPkgs, smcc = FALSE)
+
+  mySim <- simInit(times = list(start = 0.0, end = 1.0, timeunit = "year"),
+                   modules = list("caribouMovement"),
+                   paths = list(modulePath = getSampleModules(tmpdir)))
+  ex <- mySim@depends@dependencies$caribouMovement@spatialExtent
+  expect_true(isExtents(ex))
+  expect_false(identical(format(ex@pntr$.pointer), "<pointer: (nil)>"))
+  expect_equal(as.numeric(terra::xmin(ex)), 0)
+
+  ## a module that supplies no extent still gets a live default
+  expect_false(isExtents(getClassDef(".moduleDeps", package = "SpaDES.core")@prototype@spatialExtent))
+  x <- suppressWarnings(defineModule(simInit(), list(name = "noExtent")))
+  ex0 <- x@depends@dependencies[[1]]@spatialExtent
+  expect_true(isExtents(ex0))
+  expect_false(identical(format(ex0@pntr$.pointer), "<pointer: (nil)>"))
+})


### PR DESCRIPTION
## Problem

Every `R-CMD-check` job with `nosuggests: false` has been failing on `development` since late June with `Status: 2 ERRORs` — `checking examples` and `checking examples with --run-donttest`, both dying in the `moduleMetadata` example:

```
### Name: moduleMetadata
$spatialExtent
Error: external pointer is not valid
```

The `nosuggests: true` jobs pass (no terra installed → example skipped), and `test-coverage` is green, which is why this looked platform-wide but selective.

## Root cause

A latent bug, detonated by **terra 1.9-34** (released 2026-06-20).

1. The `.moduleDeps` class prototype held `spatialExtent = terra::ext(rep(0L, 4L))`. Prototypes are evaluated at package **build** time and written to the lazy-load DB, and terra external pointers do not survive serialization. On the installed package:

   ```r
   getClassDef(".moduleDeps", package = "SpaDES.core")@prototype@spatialExtent@pntr$.pointer
   #> <pointer: (nil)>
   ```

2. `defineModule()` then routed *every* module to that dead object. The `spatialExtent` branch was an `if` with no `else`:

   ```r
   x$spatialExtent <- if (!isExtents(x$spatialExtent)) { ... }   # no else
   ```

   A module supplying a valid extent (all sample modules do) took the `FALSE` branch → the `if` returned `NULL` → the element was dropped from `x` → `do.call(new, c(".moduleDeps", x))` fell back to the prototype. Confirmed: `identical(dep@spatialExtent, proto@spatialExtent)` was `TRUE`.

3. terra ≤ 1.9-27 silently printed the nil-pointer extent as `0, 0, 0, 0`; 1.9-34 raises `external pointer is not valid`. Nothing in the recent `debug` commits is involved — the last green run simply predates the terra release.

A second, smaller bug in the same expression: the `NA` branch returned the *unevaluated* `quote(terra::ext(rep(0, 4)))` instead of `eval()`ing it.

## Fix

- `R/module-dependencies-class.R` — prototype `spatialExtent = NULL`; validity accepts `NULL`.
- `R/module-define.R` — `defineModule()` keeps a module-supplied extent, `eval()`s the quoted default for `NULL`/`NA`, and uses `all(is.na())` rather than a scalar `is.na()` on a length-4 vector.
- `tests/testthat/test-module-deps-methods.R` — regression test asserting the dependency's extent is a live `SpatExtent` (non-nil pointer), for a module that supplies one and one that doesn't.

## Verification

All on **terra 1.9-34**, the version CI installs:

| build | `moduleMetadata` example |
|---|---|
| pre-fix (`development` @ `adc15591`) | `Error: external pointer is not valid` — identical to CI |
| this branch | `SpatExtent : 0, 0, 0, 0` |

- `R CMD check --run-donttest`: **`checking examples ... OK`** (the failing CI step)
- Full test suite: `FAIL 0 | WARN 0 | SKIP 40 | PASS 913`, on both terra 1.9-27 and 1.9-34

## Note, separate from this PR

All four workflows use `actions/checkout@v4` (Node 20). Runners force Node 24 today, but Node 20 is removed from GitHub runners on 2026-09-16 — worth bumping to `@v5` before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cjsQEoVoFWbbNTaStpzkU
