### PR TITLE
ci: migrate to PredictiveEcology/actions reusable workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,154 +1,22 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches:
-      - main
-      - development
+    branches: [main, development]
   pull_request:
-    branches:
-      - main
-      - development
+    branches: [main, development]
 
 name: R-CMD-check
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }}, nosuggests ${{ matrix.config.nosuggests }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macOS-latest,   nosuggests: false, r: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'devel', http-user-agent: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'release'}
-          - {os: windows-latest, nosuggests: true,  r: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'oldrel-1'}
-          - {os: windows-latest, nosuggests: false, r: 'oldrel-2'}
-          - {os: ubuntu-latest,  nosuggests: false, r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,  nosuggests: false, r: 'release'}
-          - {os: ubuntu-latest,  nosuggests: true,  r: 'release'}
-          - {os: ubuntu-latest,  nosuggests: false, r: 'oldrel-1'}
-          - {os: ubuntu-latest,  nosuggests: false, r: 'oldrel-2'}
-
-    env:
-      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.nosuggests }}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      SPADES_USE_REQUIRE: false
-      # pak respects this for individual download retries on transient errors.
-      R_PKG_INSTALL_RETRIES: 3
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # setup-pandoc occasionally fails with HTTP 5xx (CDN blip).
-      # Three attempts with continue-on-error ride out transient failures.
-      - id: pandoc1
-        continue-on-error: true
-        uses: r-lib/actions/setup-pandoc@v2
-      - if: steps.pandoc1.outcome == 'failure'
-        id: pandoc2
-        continue-on-error: true
-        uses: r-lib/actions/setup-pandoc@v2
-      - if: steps.pandoc1.outcome == 'failure' && steps.pandoc2.outcome == 'failure'
-        uses: r-lib/actions/setup-pandoc@v2
-
-      # On Linux we used to install the ubuntugis-unstable PPA via
-      # PredictiveEcology/actions/install-spatial-deps@v0.2. Launchpad's
-      # CDN (ppa.launchpadcontent.net) has been intermittently unreachable
-      # for hours at a time, and even a 3-attempt × 60 s retry can't cover
-      # it. The Ubuntu 24.04 (Noble) GHA runner image already preinstalls
-      # libgdal-dev, libproj-dev, libgeos-dev, libudunits2-dev (GDAL 3.8 /
-      # PROJ 9.4), which is recent enough for everything SpaDES.core needs.
-      # So skip the PPA entirely on Linux and just `apt-get install` the
-      # canonical names from stock Noble — idempotent if already present,
-      # and immune to Launchpad outages.
-      - if: runner.os != 'Linux'
-        uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - if: runner.os == 'Linux'
-        name: Install spatial deps (Linux, stock Noble)
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -f -y || true
-          sudo apt-get install -y --fix-missing \
-            libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
-
-      # On macOS the system GDAL/PROJ install (via Homebrew) does not always
-      # leave `proj.db` on PROJ's default search path. Without that file, every
-      # `terra::project()` / `terra::crs()` call emits
-      #   PROJ: proj_identify: Cannot find proj.db (GDAL error 1)
-      # and reprojections fail outright. Point PROJ at Homebrew's data dir
-      # explicitly so spatial tests can run.
-      - name: Configure PROJ data path (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          PROJ_PREFIX="$(brew --prefix proj 2>/dev/null || true)"
-          PROJ_DATA="$PROJ_PREFIX/share/proj"
-          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/usr/local/share/proj"; fi
-          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/opt/homebrew/share/proj"; fi
-          echo "PROJ_DATA=$PROJ_DATA" >> "$GITHUB_ENV"
-          echo "PROJ_LIB=$PROJ_DATA"  >> "$GITHUB_ENV"
-          echo "Using PROJ_DATA=$PROJ_DATA"
-          ls -1 "$PROJ_DATA" | head -5 || true
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          http-user-agent: ${{ matrix.config.http-user-agent }}
-          Ncpus: 2
-          r-version: ${{ matrix.config.r }}
-          # Posit Public Package Manager — pre-built Windows + macOS binaries
-          # served from a CDN. Far more reliable than CRAN mirrors for the
-          # binary-download step that has been failing intermittently on the
-          # Windows runner under `pak`.
-          use-public-rspm: true
-
-      - id: deps
-        continue-on-error: true
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          # Pin pak to its stable channel; the action defaults to devel which
-          # occasionally regresses on Windows.
-          pak-version: stable
-          # Bump when the stock-Noble libgdal/proj soversion changes (or
-          # when a stale binary cache otherwise refuses to load). Previous
-          # cache had `terra` binaries built against libgdal.so.37 from the
-          # old ubuntugis-unstable PPA; runners now ship libgdal.so.34 from
-          # stock Noble, so the cache must be invalidated to force a fresh
-          # source build (notably for ubuntu oldrel-1).
-          cache-version: 2
-          extra-packages: |
-            any::rcmdcheck
-          needs: check
-
-      # Fallback: when setup-r-dependencies fails (most often a transient
-      # binary-fetch failure under pak on Windows oldrel), retry the install
-      # via a fresh pak-stable install + pkg_install loop, up to 3 attempts
-      # with 60s backoff. continue-on-error: true on the primary step lets
-      # this step run and decide the job's actual success/failure.
-      - name: Install R deps (retry fallback)
-        if: steps.deps.outcome == 'failure'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          retry_wait_seconds: 60
-          retry_on: error
-          # GitHub Actions needs the `{0}` placeholder so the runner knows
-          # where to inject the script body. Plain `Rscript` would shell out
-          # to bash and silently fail on Linux jobs.
-          shell: 'Rscript {0}'
-          command: |
-            install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
-            pak::local_install_dev_deps(ask = FALSE, dependencies = TRUE)
-            pak::pkg_install(c("any::rcmdcheck"), ask = FALSE)
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
-          build_args: 'c("--no-manual", "--compact-vignettes=gs+qpdf")'
+    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
+    secrets: inherit
+    with:
+      # Extra legs SpaDES.core tested pre-migration, on top of the reusable base
+      # (release + oldrel-1 + ubuntu nosuggests): windows nosuggests, and
+      # windows/ubuntu oldrel-2. Vignette compaction is the reusable default.
+      extra-config: '[{"config":{"os":"windows-latest","nosuggests":true,"r":"release"}},{"config":{"os":"windows-latest","nosuggests":false,"r":"oldrel-2"}},{"config":{"os":"ubuntu-latest","nosuggests":false,"r":"oldrel-2"}}]'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,10 +1,9 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
@@ -13,39 +12,5 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          Ncpus: 2
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::pkgdown
-            local::.
-          needs: website
-
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    uses: PredictiveEcology/actions/.github/workflows/pkgdown.yaml@main
+    secrets: inherit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,132 +1,17 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches:
-      - main
-      - development
+    branches: [main, development]
   pull_request:
-    branches:
-      - main
-      - development
+    branches: [main, development]
 
 name: test-coverage
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
-    # Bound the job so a genuine hang fails fast and visibly, instead of the
-    # runner being silently reclaimed ~22 min in ("received a shutdown signal" /
-    # exit 143). Generous because the added swap (below) can slow covr down.
-    timeout-minutes: 75
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      GOOGLEDRIVE_AUTH: ${{ secrets.GOOGLEDRIVE_AUTH }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      USING_COVR: true
-      NOT_CRAN: true
-      R_PKG_INSTALL_RETRIES: 3
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # Why this job (and only this job) needs extra memory:
-      # test-coverage is the *only* CI job that sets NOT_CRAN=true, so it is the
-      # only one that runs the ~18 skip_on_cran() tests -- several of which spin
-      # up parallel/future worker processes (e.g. test-1memory, test-futureEvents)
-      # and reproducible's own parallel paths fork additional workers that scale
-      # with the runner's core count. Under covr every one of those child
-      # processes carries a full copy of the *instrumented* package, so peak RSS
-      # is far higher here than during R CMD check (which runs --as-cran and skips
-      # those tests). R-CMD-check passing therefore tells us nothing about this
-      # path. Peak crept just over the ~16 GB runner around 2026-06-06 (an
-      # upstream dependency memory bump), and the VM started getting reclaimed
-      # mid-run -> "received a shutdown signal" / exit 143, with no R error.
-      #
-      # Add swap on the large /mnt volume so covr has headroom to finish. This
-      # fixes the OOM without dropping any tests or coverage, and is robust to
-      # further upstream memory growth.
-      - name: Add swap space
-        run: |
-          set -x
-          echo "::group::swap/memory before"
-          free -h; swapon --show || true
-          echo "::endgroup::"
-          # Use a dedicated file so we never clash with the runner image's own
-          # /mnt/swapfile (which is already active -- mkswap on it would fail).
-          # This ADDS to existing swap. /mnt is the large (~65 GB) volume.
-          SWAP=/mnt/covr-swapfile
-          sudo swapoff "$SWAP" 2>/dev/null || true
-          sudo rm -f "$SWAP"
-          sudo fallocate -l 16G "$SWAP" || sudo fallocate -l 10G "$SWAP" || \
-            sudo dd if=/dev/zero of="$SWAP" bs=1M count=10240
-          sudo chmod 600 "$SWAP"
-          sudo mkswap "$SWAP"
-          sudo swapon "$SWAP"
-          echo "::group::swap/memory after"
-          free -h; swapon --show
-          echo "::endgroup::"
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      # Stock Noble apt; ubuntugis-unstable PPA dropped — see the rationale
-      # in R-CMD-check.yaml.
-      - name: Install spatial deps (Linux, stock Noble)
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -f -y || true
-          sudo apt-get install -y --fix-missing \
-            libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://predictiveecology.r-universe.dev/'
-          Ncpus: 2
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          pak-version: stable
-          # Bump when the stock-Noble libgdal/proj soversion changes (or when
-          # a stale binary cache otherwise refuses to load). Previous cache
-          # (cache-version: 1) had a `terra` binary built against
-          # libgdal.so.37 from the old ubuntugis-unstable PPA; runners now
-          # ship libgdal.so.34 from stock Noble, so the cache must be
-          # invalidated to force a fresh source build.
-          cache-version: 2
-          extra-packages: |
-            any::covr
-
-      - id: covr
-        name: Test coverage
-        continue-on-error: true
-        # Wrap covr in tryCatch so the per-session tempdir's
-        # `test-all.Rout.fail` is dumped to the GHA log _before_ R exits and
-        # the tempdir is cleaned up. Without this, a covr failure surfaces
-        # only as an opaque "Failure in <path>/test-all.Rout.fail" with the
-        # actual failing test names and tracebacks lost.
-        run: |
-          res <- tryCatch(
-            covr::codecov(token = Sys.getenv("CODECOV_TOKEN")),
-            error = function(e) e
-          )
-          if (inherits(res, "error")) {
-            files <- list.files(
-              tempdir(), pattern = "test-all\\.Rout\\.fail$",
-              recursive = TRUE, full.names = TRUE
-            )
-            for (f in files) {
-              cat("==========================================\n")
-              cat("=== ", f, " ===\n", sep = "")
-              cat("==========================================\n")
-              cat(readLines(f, warn = FALSE), sep = "\n")
-              cat("\n")
-            }
-            stop(res)
-          }
-        shell: Rscript {0}
-
-      - if: steps.covr.outcome == 'failure'
-        name: Re-fail the job
-        run: exit 1
+    uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@main
+    secrets: inherit

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -22,7 +22,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
Replaces standalone R-CMD-check / test-coverage / pkgdown with **thin callers** of the shared reusable workflows in `PredictiveEcology/actions`. CI logic (`actions/checkout@v5`, spatial deps, retry fallback, matrix, `GOOGLEDRIVE_AUTH`/`CODECOV_TOKEN`) is maintained centrally, resolving the Node-20 checkout deprecation.

- Extra matrix legs (windows nosuggests, windows+ubuntu oldrel-2) preserved via `extra-config`.
- SpaDES.core's previous custom `build_args` (`--compact-vignettes=gs+qpdf`) is now the reusable workflow's **default** (actions#7), so no per-package build-args is needed.
- `update-citation-cff.yaml` (no reusable equivalent) gets an in-place `checkout@v4`->`@v5` bump.

Merge order: needs `actions#7` (default vignette compaction) on `main` so vignettes stay compacted; `extra-config` is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)