### PR TITLE
ci: rebuild qs2/stringfish from source when RcppParallel's oneTBB ABI break kills their binaries

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -148,6 +148,27 @@ jobs:
             pak::local_install_dev_deps(ask = FALSE, dependencies = TRUE)
             pak::pkg_install(c("any::rcmdcheck"), ask = FALSE)
 
+      # Transient workaround; delete once CRAN ships rebuilt binaries.
+      # RcppParallel 6.0.0 (2026-07-23) bundles oneTBB 2022.0.0 and changed the
+      # TBB ABI -- upstream NEWS: "packages which depend on RcppParallel may need
+      # to be rebuilt". CRAN's macOS-arm64 `qs2`/`stringfish` binaries predate it
+      # and fail to `dlopen` (`qs2.so`: missing `tbb::task::note_affinity`;
+      # `stringfish.so`: missing `tbb::internal::concurrent_vector_base_v3::
+      # internal_grow_by`). `qs2` is in Imports, so this kills `R CMD build` at
+      # the "install the package to build vignettes" stage, before any check runs.
+      # Probe rather than version-check: we cannot know which release fixes this,
+      # but we can ask whether it loads, so the step self-retires. `stringfish`
+      # must be rebuilt first -- rebuilding `qs2` alone leaves it broken.
+      - name: Rebuild RcppParallel-linked deps from source if their binaries can't load
+        shell: Rscript {0}
+        run: |
+          if (!requireNamespace("qs2", quietly = TRUE)) {
+            message("qs2 failed to load; rebuilding against installed RcppParallel ",
+                    packageVersion("RcppParallel"))
+            install.packages(c("stringfish", "qs2"), type = "source")
+            loadNamespace("qs2") # fail loudly if the rebuild did not fix it
+          }
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true


### PR DESCRIPTION
## Problem

Every macOS `R-CMD-check` job dies **before `R CMD check` runs at all** — no `check` directory is produced, so no test output is uploaded:

```
* installing the package (it is needed to build vignettes)
** byte-compile and prepare package for lazy loading
Error in dyn.load(...):
  unable to load shared object '.../qs2/libs/qs2.so':
  Symbol not found: __ZN3tbb4task13note_affinityEt
  Referenced from: .../qs2/libs/qs2.so
  Expected in:     .../RcppParallel/lib/libtbb.dylib
ERROR: lazy loading failed for package 'SpaDES.core'
##[error]Error in proc$get_built_file() : Build process failed
```

`__ZN3tbb4task13note_affinityEt` demangles to `tbb::task::note_affinity(unsigned short)` — the classic TBB `task` API, **removed in oneTBB**.

## Cause

| package | version | built |
|---|---|---|
| qs2 | 0.2.2 | **2026-06-03** |
| RcppParallel | 6.2.0 | **2026-07-30** (6.0.0 on 2026-07-23) |

From RcppParallel's own NEWS for 6.0.0:

> RcppParallel now bundles oneTBB 2022.0.0. **Note that the TBB ABI has changed; packages which depend on RcppParallel may need to be rebuilt.**

CRAN's macOS-arm64 qs2 binary predates that and has old-TBB flow-graph internals inlined into it. `pak` reports the install as successful — the breakage only appears at `dlopen`. Because **qs2 is in `Imports`** (`R/Plots.R`, `R/saveLoadSimList.R`), loading SpaDES.core loads qs2's DLL, which is why this kills `R CMD build` at the install-to-build-vignettes stage.

macOS-only because Windows and Linux binaries were rebuilt against a compatible RcppParallel.

## Fix

A **functional probe**, not a version check — we can't know which qs2 release will fix this, but we can ask whether it loads. The step becomes a no-op the moment CRAN ships rebuilt binaries, at which point it can simply be deleted.

**Rebuilding qs2 alone is not sufficient.** I tested that first and it still failed to load, on a different package:

```
unable to load shared object '.../stringfish/libs/stringfish.so':
  undefined symbol: _ZN3tbb8internal25concurrent_vector_base_v316internal_grow_byEmmPFvPvPKvmES4_
```

`stringfish` is a qs2 dependency and links RcppParallel too. The break cascades to every RcppParallel-linked package in the tree — here, exactly `{stringfish, qs2}`, and order matters.

## Verification

Built both from source against RcppParallel 6.2.0 in a scratch library (main library untouched):

```
versions: stringfish 0.19.2  qs2 0.2.2  | RcppParallel 6.2.0
[1] "qs2 LOADS OK"
round-trip identical: TRUE
```

qs2's own sources use only oneTBB-surviving APIs (`global_control`, `concurrent_queue`, `enumerable_thread_specific`, `flow::graph`) with no `tbb::task`, and it ships a `tbb_flow_compat.h` shim — so the source build is clean. Its configure correctly detects oneTBB and compiles with `-DTBB_INTERFACE_NEW`.

Caveat: verified on Linux/gcc, not macOS/clang-arm64. The compile exercises the same modern-TBB API on both, but this PR's own CI run is the real proof.

## Relationship to #384

Independent. #384 fixes a separate terra >= 1.9-34 failure that was breaking *all* platforms; its Windows jobs are already green. macOS cannot go green on either PR until this one lands. Suggest merging this first, then rerunning #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cjsQEoVoFWbbNTaStpzkU
