### PR TITLE
Increase test coverage to 76%, and fix the twelve defects it uncovered

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -111,7 +111,10 @@ setMethod(
 #'
 #' @param ...    Additional arguments. Not implemented.
 #'
-#' @return  Invisibly return `TRUE` indicating object exists; `FALSE` if not.
+#' @return  Invisibly returns `TRUE` if every parameter supplied is used by a
+#'          module and every parameter a module uses was supplied; `FALSE` if
+#'          any are unmatched; and `NA` if the simulation has no user modules,
+#'          in which case there is nothing to check.
 #'          Sensible messages are produced identifying missing parameters.
 #'
 #' @include simList-class.R
@@ -260,7 +263,9 @@ setMethod(
         }
       }
     } else {
-      allFound <- FALSE
+      ## no user modules, so there is nothing to check: neither "all found"
+      ## nor "something missing"
+      allFound <- NA
     }
     return(invisible(allFound))
 })

--- a/R/debugging.R
+++ b/R/debugging.R
@@ -15,7 +15,7 @@ writeEventInfo <- function(sim, file = "events.txt", append = FALSE) {
   f <- normPath(file)
   curr <- current(sim)
   cat(paste(curr$moduleName, curr$eventType, curr$eventTime), ":\n",
-      file = file, append = append)
+      file = f, append = append)
 }
 
 #' Write RNG state info to file
@@ -34,6 +34,7 @@ writeRNGInfo <- function(file = "seed.txt", append = FALSE) {
   fseed <- normPath(file)
   cat("\tStart of new RNG stream: ", file = fseed, append = append)
   ## NOTE: the first element of .Random.seed specifies the RNG type, so omit it
-  cat(.Random.seed[2:11], file = fseed, sep = ", ", append = append)
-  cat(".", file = fseed, sep = "\n", append = append)
+  ## the remaining writes must always append, or they truncate what came above
+  cat(.Random.seed[2:11], file = fseed, sep = ", ", append = TRUE)
+  cat(".", file = fseed, sep = "\n", append = TRUE)
 }

--- a/R/module-template.R
+++ b/R/module-template.R
@@ -754,7 +754,9 @@ setMethod(
   "copyModule",
   signature = c(from = "character", to = "character", path = "character"),
   definition = function(from, to, path, ...) {
-    if (!dir.exists(to)) {
+    ## test the directory actually being created, not a bare relative name
+    ## resolved against the working directory
+    if (!dir.exists(file.path(path, to))) {
       dir.create(file.path(path, to))
       dir.create(file.path(path, to, "data"))
       dir.create(file.path(path, to, "tests"))
@@ -783,8 +785,10 @@ setMethod(
                         to = file.path(path, to, "data"), ...))
     }
 
-    ## files in "tests" dir
-    ids <- which(basename(dirname(files)) == "test")
+    ## files in "tests" dir -- the directory is `tests`, plural (see the
+    ## dir.create above and the destination below); matching "test" meant a
+    ## file sitting directly in tests/ (e.g. unitTests.R) was never copied
+    ids <- which(basename(dirname(files)) == "tests")
     if (length(ids) > 0) {
       result <- c(result, file.copy(from = files[ids],
                                     to = file.path(path, to, "tests"), ...))

--- a/R/progress.R
+++ b/R/progress.R
@@ -2,8 +2,10 @@
 doEvent.progress <- function(sim, eventTime, eventType, debug = FALSE) {
   if (eventType == "init") {
     ids <- na.omit(match(names(P(sim, module = ".progress")), c("type", "interval")))
+    ## `tu` is used again below, outside this if/else -- bind it here so that
+    ## block cannot reference an unbound variable if the branches change
+    tu <- sim@simtimes[["timeunit"]]
     if (interactive()) {
-      tu <- sim@simtimes[["timeunit"]]
       defaults <- list(type = "text", interval = (end(sim, tu) - start(sim, tu)) / (end(sim, tu) - start(sim, tu)))
 
       # Check whether a .progress is specified in the simList

--- a/R/saveLoadSimList.R
+++ b/R/saveLoadSimList.R
@@ -15,6 +15,34 @@
 #' The user does not need to specify the filename any differently,
 #' as the code will search based on the filename without the file extension.
 #'
+#' @section Two ways to use this:
+#'
+#' \describe{
+#'   \item{1. Portable -- take the simulation with you}{
+#'     Save everything: the objects, the metadata, and the files behind any
+#'     file-backed objects. Use this to move a simulation to another machine
+#'     or hand it to someone else.
+#'
+#'     `saveSimList(sim, "mySim.rds", projectPath = projectPath)`
+#'
+#'     `projectPath` is the root that everything is stored relative to, so the
+#'     whole thing can be unpacked somewhere else and still resolve. A
+#'     file-backed object is re-rooted on load if it lives under `projectPath`
+#'     or under one of the sim's own paths (`outputPath`, `inputPath`,
+#'     `cachePath`, ...).
+#'   }
+#'   \item{2. In place -- keep the metadata, leave the files alone}{
+#'     Save the information but not the file bundle, on the assumption you
+#'     still have the paths the run used -- above all `outputPath(sim)`.
+#'
+#'     `saveSimList(sim, "mySim.rds", projectPath = projectPath, files = FALSE)`
+#'
+#'     Reload it and use `outputs(sim)` to see what the run wrote, then read
+#'     back whatever you actually need. This is usually the practical choice:
+#'     a real run writes far too many objects to bundle into an archive.
+#'   }
+#' }
+#'
 #' @details
 #' There is a family of 2 functions that are mutually useful for saving and
 #' loading `simList` objects and their associated files (e.g., file-backed
@@ -77,6 +105,37 @@
 #' Invoked for side effects of saving both a `.qs2` (or `.rds`) file,
 #' and a compressed archive (one of `.tar.gz` if using non-Windows OS or `.zip` on Windows).
 #'
+#' @examples
+#' ## ---- 1. Portable: take everything with you ----
+#' projectPath <- file.path(tempdir(), "myProject")
+#' outPath <- file.path(projectPath, "outputs")
+#' dir.create(outPath, recursive = TRUE, showWarnings = FALSE)
+#'
+#' sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"),
+#'                paths = list(outputPath = outPath))
+#' sim$anObject <- 1:10
+#'
+#' saveSimList(sim, file.path(projectPath, "portable.rds"),
+#'             projectPath = projectPath)
+#'
+#' ## unpack it anywhere -- pass the new location as projectPath
+#' sim2 <- loadSimList(file.path(projectPath, "portable.rds"),
+#'                     projectPath = projectPath)
+#' sim2$anObject
+#'
+#' ## ---- 2. In place: metadata only, files stay put ----
+#' ## `files = FALSE` skips bundling; the run's own files are left where
+#' ## they are, and the reloaded simList tells you where to find them
+#' saveSimList(sim, file.path(projectPath, "inPlace.rds"),
+#'             projectPath = projectPath, files = FALSE)
+#'
+#' sim3 <- loadSimList(file.path(projectPath, "inPlace.rds"),
+#'                     projectPath = projectPath)
+#' outputPath(sim3)   # where the run wrote its outputs
+#' outputs(sim3)      # the manifest of what it wrote
+#'
+#' unlink(projectPath, recursive = TRUE)
+#'
 #' @aliases saveSim
 #' @export
 #' @importFrom fs path_common
@@ -116,8 +175,11 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
 
   # clean up misnamed arguments
   if (!is.null(dots$fileBackedDir)) {
-    if (is.null(filebackedDir)) {
-      filebackedDir <- dots$fileBackedDir
+    ## `filebackedDir` is not a formal of this function; referring to it bare
+    ## errored with "object 'filebackedDir' not found" instead of normalising
+    ## the misspelling. Mirror the filebackend/fileBackend block below.
+    if (is.null(dots$filebackedDir)) {
+      dots$filebackedDir <- dots$fileBackedDir
       dots$fileBackedDir <- NULL
     }
   }
@@ -170,8 +232,11 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
 
   ## Pre-wrap file-backed objects one-by-one so a single inaccessible backing file
   ## does not abort the entire save; failed objects are saved as NULL with a warning.
-  sim <- .wrapResiliently(sim)
-  sim <- .wrap(sim, cachePath = NULL, paths = paths(sim)) # wrap remaining / non-file-backed
+  sim <- .wrapResiliently(sim, projectPath = projectPath)
+  ## wrap remaining / non-file-backed; `projectPath` is offered as an anchor so a
+  ## file-backed object that sits under it -- but under none of the sim's named
+  ## paths -- can still be re-rooted on load instead of silently becoming NULL
+  sim <- .wrap(sim, cachePath = NULL, paths = .wrapAnchors(sim, projectPath))
   sim@.xData$._sim <- NULL # remove circular reference; sim is already a Copy here
   sim@current <- list() # it is presumed that this event should be considered finished prior to saving
 
@@ -263,7 +328,7 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
       allFns <- na.omit(allFns)
 
       relFns <- makeRelative(c(fileToDelete, lazyDbExisting, allFns), projectPath) |> unname()
-      archiveWrite(filename, relFns, verbose)
+      archiveWrite(filename, relFns, verbose, projectPath = projectPath)
       unlink(fileToDelete)
       unlink(lazyDbExisting)
     }
@@ -327,7 +392,7 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
 
       relFns <- makeRelative(c(fileToDelete, allFns), projectPath) |> unname()
 
-      archiveWrite(filename, relFns, verbose)
+      archiveWrite(filename, relFns, verbose, projectPath = projectPath)
 
       unlink(fileToDelete)
     }
@@ -457,7 +522,9 @@ loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
       if (identical(projectPath, getwd())) {
         pths <- paths(tmpsim)
       } else {
-        pths <- list(projectPath = projectPath)
+        ## include the sim's own paths too, so an object anchored to a named
+        ## path (e.g. outputPath) still resolves, not just projectPath ones
+        pths <- c(paths(tmpsim), list(projectPath = projectPath))
       }
 
       newFiles <- remapFilenames(tags = tags, cachePath = NULL, paths = pths)
@@ -718,13 +785,31 @@ recoverDataTableFromQs <- function(sim) {
   out
 }
 
+## Anchors offered to .wrap()/.unwrap() when deciding what a file-backed
+## object's location should be recorded relative to. reproducible's
+## relativeToWhat() sorts anchors longest-path-first and takes the first that is
+## a prefix, so adding the (usually outermost) projectPath never displaces a
+## more specific anchor such as outputPath -- it only catches files that would
+## otherwise have no anchor at all.
+.wrapAnchors <- function(sim, projectPath = NULL) {
+  anchors <- paths(sim)
+  ## reproducible already appends `getwd = getwd()` as a final anchor, so only
+  ## add projectPath when it is a DIFFERENT directory. Adding it when they are
+  ## the same creates two anchors for one directory and which name wins becomes
+  ## order-dependent, changing the paths recorded for file-backed objects.
+  if (!is.null(projectPath) && nzchar(projectPath) &&
+      !identical(normPath(projectPath), normPath(getwd())))
+    anchors <- c(anchors, list(projectPath = projectPath))
+  anchors
+}
+
 ## Pre-wrap each file-backed object in sim@.xData individually so that one
 ## inaccessible backing file does not abort saveSimList. Failed objects are
 ## replaced with NULL and a warning is issued; the subsequent monolithic
 ## .wrap(sim, ...) then succeeds on the remaining objects.
-.wrapResiliently <- function(sim) {
+.wrapResiliently <- function(sim, projectPath = NULL) {
   nms <- ls(sim@.xData, all.names = FALSE)
-  simPaths <- paths(sim)
+  simPaths <- .wrapAnchors(sim, projectPath)
   for (nm in nms) {
     obj <- sim@.xData[[nm]]
     fns <- tryCatch(Filenames(obj), error = function(e) character(0))
@@ -834,8 +919,20 @@ archiveExtract <- function(archiveName, exdir) {
   filename
 }
 
-archiveWrite <- function(archiveName, relFns, verbose) {
+archiveWrite <- function(archiveName, relFns, verbose, projectPath = getwd()) {
   relFns <- unname(relFns)
+
+  ## `relFns` are relative to `projectPath`. Both archive::archive_write_files()
+  ## and zip() resolve relative paths against the working directory, and store
+  ## them in the archive as given -- so we have to be sitting in `projectPath`
+  ## while writing, or the paths neither resolve nor land in the archive with
+  ## the right internal structure. `archiveName` is made absolute first so it
+  ## still points at the same file once we have moved.
+  archiveName <- fs::path_abs(archiveName) |> as.character()
+  if (!identical(fs::path_norm(projectPath), fs::path_norm(getwd()))) {
+    owd <- setwd(projectPath)
+    on.exit(setwd(owd), add = TRUE)
+  }
 
   if (requireNamespace("archive") && !isWindows()) {
     archiveName <- archiveConvertFileExt(archiveName, "tar.gz")

--- a/R/simulation-spades.R
+++ b/R/simulation-spades.R
@@ -616,7 +616,9 @@ scheduleConditionalEvent <- function(sim,
         needSort <- FALSE
       }
       if (needSort) {
-        ord <- order(unlist(lapply(sim$._conditionalEvents, function(x) x$eventTime)),
+        ## conditional events carry minEventTime/maxEventTime, not eventTime;
+        ## sorting on a field that does not exist yields NULL and errors
+        ord <- order(unlist(lapply(sim$._conditionalEvents, function(x) x$minEventTime)),
                      unlist(lapply(sim$._conditionalEvents, function(x) x$eventPriority)))
         sim$._conditionalEvents <- sim$._conditionalEvents[ord]
       }
@@ -1235,6 +1237,10 @@ setMethod(
         ##   (`.stepEvent()` = recoverModePre -> doEvent -> recoverModePost, with the
         ##   accumulator on sim@.xData[["._rmo"]]). The same step is intended to drive
         ##   simInit's `.inputObjects` phase.
+        ## the event about to run; a conditional event must not re-fire
+        ## immediately after itself
+        justRan <- if (length(sim@events)) sim@events[[1]]
+
         sim <- .stepEvent(sim, recoverMode, allObjNames,
                           thisSpadesCallRandomStr = thisSpadesCallRandomStr,
                           debug = debug, notOlderThan = notOlderThan,
@@ -1243,13 +1249,34 @@ setMethod(
         ## Conditional Scheduling -- adds only 900 nanoseconds per event, if none exist
         if (exists("._conditionalEvents", envir = sim, inherits = FALSE)) {
           condEventsToOmit <- integer()
+          ## `sim@simtimes[["current"]]` and cond$min/maxEventTime are both in
+          ## seconds. `time(sim)` is in the sim's timeunit, so comparing against
+          ## it never matched for a non-zero minEventTime.
+          curTime <- as.numeric(sim@simtimes[["current"]])
           for (condNum in seq(sim$._conditionalEvents)) {
             cond <- sim$._conditionalEvents[[condNum]]
+            ## never run a conditional event twice in a row: a different event
+            ## must always come between two runs of the same one
+            if (!is.null(justRan) &&
+                identical(cond$moduleName, justRan[["moduleName"]]) &&
+                identical(cond$eventType, justRan[["eventType"]]))
+              next
             if (isTRUE(eval(cond$condition))) {
-              curTime <- time(sim)
-              if (curTime >= cond$minEventTime && curTime <= cond$maxEventTime) {
-                message("  Conditional Event -- ", cond$condition, " is true. Scheduling for now")
-                sim <- scheduleEvent(sim, eventTime = curTime, moduleName = cond$moduleName,
+              if (curTime <= as.numeric(cond$maxEventTime)) {
+                ## a conditional event jumps the queue: scheduling at the
+                ## current time puts it at the head, so it can run immediately
+                ## on becoming true. The `justRan` skip above is what stops it
+                ## doing that twice in a row.
+                schedTime <- if (curTime < as.numeric(cond$minEventTime)) {
+                  ## not into the window yet -- run at the start of it
+                  as.numeric(cond$minEventTime)
+                } else {
+                  curTime
+                }
+                attr(schedTime, "unit") <- "second"
+                message("  Conditional Event -- ", cond$condition,
+                        " is true. Scheduling.")
+                sim <- scheduleEvent(sim, eventTime = schedTime, moduleName = cond$moduleName,
                                      eventType = cond$eventType, eventPriority = cond$eventPriority)
                 condEventsToOmit <- c(condEventsToOmit, condNum)
               }
@@ -2367,11 +2394,12 @@ loggingMessage <- function(mess, suffix = NULL, prefix = NULL) {
 #' @param code An expression that defines the code to execute during the event. This will
 #'    be captured, and pasted into a new function (`doEvent.moduleName.eventName`),
 #'    remaining unevaluated until that new function is called.
-#' @param envir An optional environment to specify where to put the resulting function.
-#'     The default will place a function called `doEvent.moduleName.eventName` in the
-#'     module function location, i.e., `sim[[dotMods]][[moduleName]]`. However, if this
-#'     location does not exist, then it will place it in the `parent.frame()`, with a message.
-#'     Normally, especially, if used within SpaDES module code, this should be left missing.
+#' @param envir An optional environment specifying where to put the resulting
+#'     function. The default is the `parent.frame()`, i.e. the calling environment,
+#'     which for an interactive user is the global environment. Placing the function
+#'     directly in the module environment (`sim[[dotMods]][[moduleName]]`) is not yet
+#'     implemented; it requires `defineEvent()` to be integrated into the module
+#'     parsing steps. Until then, `defineEvent()` is intended for standalone use.
 #' @export
 #' @seealso [defineModule()], [simInit()], [scheduleEvent()]
 #' @examples
@@ -2416,22 +2444,15 @@ loggingMessage <- function(mess, suffix = NULL, prefix = NULL) {
 defineEvent <- function(sim, eventName = "init", code, moduleName = NULL,
                         envir = parent.frame()) {
   code <- substitute(code)
-  curMod <- currentModule(sim)
   if (is.null(moduleName))
     moduleName <- currentModule(sim)
 
-  useSimModsEnv <- FALSE
-  if (missing(envir)) {
-    if (is.null(moduleName)) {
-      if (length(curMod) > 0) {
-        useSimModsEnv <- TRUE
-      }
-    } else {
-      if (exists(moduleName, sim[[dotMods]], inherits = FALSE))
-        useSimModsEnv <- TRUE
-    }
-    # envir <- if (useSimModsEnv) sim[[dotMods]][[moduleName]] else parent.frame()
-  }
+  ## TODO: placing the event function in `sim[[dotMods]][[moduleName]]` is not
+  ##   implemented yet -- it needs `defineEvent()` woven into `.parseModule()` and
+  ##   the rest of the `.parse*` family, which is where the module environment is
+  ##   actually available. Until then this is standalone-only: the function is
+  ##   always assigned into `envir` (`parent.frame()` by default) and always
+  ##   recorded in the registry below, so the event loop can find it.
 
   eventFnName <-  makeEventFn(moduleName, eventName)
   fn <- defineEventFnMaker(substitute(code), eventFnName)
@@ -2445,13 +2466,11 @@ defineEvent <- function(sim, eventName = "init", code, moduleName = NULL,
   # ")
 
   parsedFn <- parse(text = fn)
-  if (!useSimModsEnv) {
-    if (is.null(sim@.xData[[eventFnElementEnvir()]])) {
-      sim@.xData[[eventFnElementEnvir()]] <- new.env(parent = asNamespace("SpaDES.core"))
-    }
-    sim@.xData[[eventFnElementEnvir()]][[eventFnName]] <- list(envir = envir,
-                                                               digest = .robustDigest(parsedFn))
+  if (is.null(sim@.xData[[eventFnElementEnvir()]])) {
+    sim@.xData[[eventFnElementEnvir()]] <- new.env(parent = asNamespace("SpaDES.core"))
   }
+  sim@.xData[[eventFnElementEnvir()]][[eventFnName]] <- list(envir = envir,
+                                                             digest = .robustDigest(parsedFn))
 
   assign(eventFnName, eval(parsedFn, envir = new.env(parent = asNamespace("SpaDES.core"))),
          envir = envir)

--- a/R/spades-core-deprecated.R
+++ b/R/spades-core-deprecated.R
@@ -17,26 +17,26 @@
 #' @param ... Unused.
 #' @rdname deprecated
 experiment <- function(...) {
-  .Deprecated(msg = .messageDeprecatedFn(match.call()[[1]]), "SpaDES.experiment")
+  .Deprecated(msg = .messageDeprecatedFn(match.call()[[1]], "SpaDES.project"))
 }
 
 
 #' @export
 #' @rdname deprecated
 experiment2 <- function(...) {
-  .Deprecated(msg = .messageDeprecatedFn(match.call()[[1]]), "SpaDES.experiment")
+  .Deprecated(msg = .messageDeprecatedFn(match.call()[[1]], "SpaDES.experiment"))
 }
 
 #' @export
 #' @rdname deprecated
 POM <- function(...) {
-  .Deprecated(msg = .messageDeprecatedFn(match.call()[[1]]), "SpaDES.experiment")
+  .Deprecated(msg = .messageDeprecatedFn(match.call()[[1]], "SpaDES.experiment"))
 }
 
 #' @export
 #' @rdname deprecated
 simInitAndExperiment <- function(...) {
-  .Deprecated(msg = .messageDeprecatedFn(match.call()[[1]]), "SpaDES.experiment")
+  .Deprecated(msg = .messageDeprecatedFn(match.call()[[1]], "SpaDES.experiment"))
 }
 
 #' @rdname deprecated

--- a/R/times.R
+++ b/R/times.R
@@ -263,7 +263,12 @@ convertTimeunit <- function(time, unit, envir, skipChecks = FALSE) {
         if (isTRUE(time %% 1 == 0)) {
           if (time[1] < .pkgEnv[["nUnitConversions"]]) {
             if (unit %in% .spadesTimes) {
+              ## the lookup table gives the time in SECONDS; keep the unit
+              ## attribute so the conversion below still runs -- dropping it
+              ## (as.numeric) skipped that block and mislabelled seconds as
+              ## the target unit for any non-second target
               time <- as.numeric(.pkgEnv[["unitConversions"]][time[1] + 1L, attr(time, "unit")])
+              attr(time, "unit") <- timeUnit <- "second"
             }
           }
         }

--- a/TODO-cran-submission-status.md
+++ b/TODO-cran-submission-status.md
@@ -23,11 +23,13 @@ reproducible repo but **not yet submitted**. It does not block SpaDES.core.
 
 ## State of this repo
 
-Branch `development`, last commit `ec079809` (7 days old).
+Branch `development`, last commit `94d4ec86`, pushed 2026-08-25.
 `DESCRIPTION`: **Version 3.2.0, Date 2026-08-24**.
 
-There is **substantial uncommitted release prep**, written 2026-08-24 16:12–16:15.
-It has been reviewed — findings below — and is sound. It is **not committed**.
+The release prep is now **committed and pushed** as `52b83515` ("Prepare 3.2.0
+CRAN release") plus `94d4ec86` (these TODO notes). NAMESPACE equivalence was
+re-verified by parsing both files: 512 directives each, zero differences.
+The table below records what that commit contains.
 
 | file | change | verdict |
 |---|---|---|
@@ -37,7 +39,7 @@ It has been reviewed — findings below — and is sound. It is **not committed*
 | `.Rbuildignore` | `+^TODO.*\.md$` | pairs with the untracked `TODO-defineEvent.md` |
 | `inst/WORDLIST` | +28 | the spell-check step |
 | `NEWS.md` | −250 lines, 3.2.0 section | condensed |
-| `cran-comments.md` | rewritten, **plus my edits** (below) | see below |
+| `cran-comments.md` | rewritten for the post-archival resubmission | see below |
 | untracked `man/dot-restart*.Rd` ×4 | roxygen output for `R/restart.R` | expected |
 | untracked `TODO-defineEvent.md` | design note | build-ignored |
 
@@ -46,7 +48,7 @@ Also verified: all 21 active `getFromNamespace()` re-exports resolve (against
 reproducible 3.2.0**, which is installed in the personal library from the
 `v3.2.0` tag.
 
-### Edits I made to `cran-comments.md` (uncommitted, on top of the above)
+### `cran-comments.md` edits folded into that commit
 
 1. Opening now states `reproducible` **is** back on CRAN as of 2026-08-25 with
    the link, instead of "should be processed after it is back on CRAN".
@@ -79,24 +81,46 @@ The single NOTE has five parts:
   dev installs of the whole ecosystem, since those three entries point at the
   `@development` branches.
 
-## Open question — submission order
+## Submission order — decided
 
-SpaDES.core `Suggests: SpaDES.tools (>= 2.1.1)`, and **SpaDES.tools is still
-archived** (2026-07-13, same cause). That produces the "not in mainstream
-repositories" NOTE.
+**Wait for SpaDES.tools.** Dependency order is
+reproducible → SpaDES.tools → SpaDES.core → SpaDES; submitting SpaDES.tools
+first makes SpaDES.core's "not in mainstream repositories" NOTE disappear.
+(Maintainer's call, 2026-08-25.)
 
-Dependency order is **reproducible → SpaDES.tools → SpaDES.core → SpaDES**.
+⚠️ **You are not SpaDES.tools' maintainer** — `cre` is Alex M Chubaty
+(`achubaty@for-cast.ca`), reasserted deliberately at `7f06f55`. CRAN only
+accepts submissions from the maintainer's address, so the final click is his.
 
-* Submitting SpaDES.tools first makes the NOTE disappear.
-* Submitting SpaDES.core now means explaining the NOTE to a reviewer.
+### SpaDES.tools prep done for him (2026-08-25)
 
-SpaDES.tools is at `2.1.2` on `development` with a **clean working tree**, so it
-may be closer to ready. **This has not been decided.**
+Local branch `release/2.1.3` in `~/GitHub/SpaDES.tools`, commit `1fb61ff`.
+**Not pushed.**
+
+* `CRAN-SUBMISSION` records 2.1.1 as the last submission — **2.1.2 was prepped
+  (`b5f7abb`) but never submitted**, so the last CRAN version is 2.1.1.
+* Version set to **2.1.3**, not 2.1.2. `origin/development` is already public
+  at `2.1.2.9000`, and `2.1.2.9000 > 2.1.2`, so releasing as 2.1.2 would leave
+  everyone tracking `@development` refusing to upgrade.
+* Stripped `Remotes: PredictiveEcology/reproducible@development` (added
+  `1beaaa9` on 2026-08-21 only because reproducible was off CRAN).
+* NEWS `(development version)` → `SpaDES.tools 2.1.3`.
+* `cran-comments.md` rewritten for the post-archival resubmission.
+* Local `R CMD check --as-cran` on the 2.1.3 tarball: **2 NOTEs, both benign**
+  — New submission/archived, and `V8 unavailable` for math rendering (local
+  environment only). No `Remotes` NOTE, and no "Suggests not in mainstream
+  repositories" NOTE: its own deps are all on CRAN.
+
+Still outstanding there: push the branch, CI green, win-builder ×3, and the
+**R-hub sanitizer/valgrind runs** the Rcpp changes warrant (this is not a
+pure-R package, unlike `reproducible`). revdepcheck is a no-op against CRAN —
+both CRAN revdeps (SpaDES.core, SpaDES) are archived — and was last run
+2026-05-16 over the 10 ecosystem packages with 0 new problems.
 
 ## Next steps
 
-1. Decide the order above.
-2. Commit the reviewed prep (it is all sound; nothing is known to be wrong).
+1. ~~Decide the order~~ / ~~commit the prep~~ — both done 2026-08-25.
+2. Get SpaDES.tools submitted (see above) — that gates this package.
 3. Checklist steps 1–3: local `--as-cran` (clean apart from the NOTE), CI green,
    then win-builder ×3. Mac builder is **dead** — `submit.html` serves 200 but
    `/macbuilder/v1/submit` returns 502 on every attempt. R-hub was skipped for
@@ -117,6 +141,16 @@ may be closer to ready. **This has not been decided.**
 
 ## Gotchas worth carrying over
 
+* **A `getFromNamespace()` re-export can import a package you never declared.**
+  `R/reexports.R` assigns at build time, so the *function object* from the other
+  package lands in this namespace, and `R CMD check` attributes its `::` calls
+  to us. `.updateTagsRepo` pulled in `glue::`, which is why CI was red on
+  `ec079809` with `'::' or ':::' import not declared from: 'glue'` — a
+  **WARNING**, so CRAN-blocking. It reproduces only against the *installed*
+  package: `tools:::.check_packages_used(dir = ".")` on the source tree is
+  clean, `tools:::.check_packages_used(package = "SpaDES.core")` is not.
+  Dropping the re-export fixed it; the other 21 were scanned and are clean.
+  Re-scan after adding any re-export.
 * **`gh` is a snap here.** It cannot read files under `/tmp` *or* under hidden
   directories in `$HOME`. Use `--body "$(cat …)"` or stage in a non-hidden dir.
 * **win-builder**: FTP is broken; use the HTTP form. Slot mapping is *not* in

--- a/man/checkParams.Rd
+++ b/man/checkParams.Rd
@@ -17,7 +17,10 @@ checkParams(sim, coreParams, ...)
 \item{...}{Additional arguments. Not implemented.}
 }
 \value{
-Invisibly return \code{TRUE} indicating object exists; \code{FALSE} if not.
+Invisibly returns \code{TRUE} if every parameter supplied is used by a
+module and every parameter a module uses was supplied; \code{FALSE} if
+any are unmatched; and \code{NA} if the simulation has no user modules,
+in which case there is nothing to check.
 Sensible messages are produced identifying missing parameters.
 }
 \description{

--- a/man/defineEvent.Rd
+++ b/man/defineEvent.Rd
@@ -24,11 +24,12 @@ remaining unevaluated until that new function is called.}
 \item{moduleName}{Character string of the name of the module. If this function is
 used within a module, then it will try to find the module name.}
 
-\item{envir}{An optional environment to specify where to put the resulting function.
-The default will place a function called \code{doEvent.moduleName.eventName} in the
-module function location, i.e., \code{sim[[dotMods]][[moduleName]]}. However, if this
-location does not exist, then it will place it in the \code{parent.frame()}, with a message.
-Normally, especially, if used within SpaDES module code, this should be left missing.}
+\item{envir}{An optional environment specifying where to put the resulting
+function. The default is the \code{parent.frame()}, i.e. the calling environment,
+which for an interactive user is the global environment. Placing the function
+directly in the module environment (\code{sim[[dotMods]][[moduleName]]}) is not yet
+implemented; it requires \code{defineEvent()} to be integrated into the module
+parsing steps. Until then, \code{defineEvent()} is intended for standalone use.}
 }
 \description{
 There are two ways to define what occurs during an event: defining a function

--- a/man/saveSimList.Rd
+++ b/man/saveSimList.Rd
@@ -101,6 +101,72 @@ values should be project-relative paths.
 E.g., \code{list(cachePath = "cache", inputPath = "inputs", outputPath = "outputs")}.
 }
 }
+\section{Two ways to use this}{
+
+
+\describe{
+\item{1. Portable -- take the simulation with you}{
+Save everything: the objects, the metadata, and the files behind any
+file-backed objects. Use this to move a simulation to another machine
+or hand it to someone else.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{`saveSimList(sim, "mySim.rds", projectPath = projectPath)`
+
+`projectPath` is the root that everything is stored relative to, so the
+whole thing can be unpacked somewhere else and still resolve. A
+file-backed object is re-rooted on load if it lives under `projectPath`
+or under one of the sim's own paths (`outputPath`, `inputPath`,
+`cachePath`, ...).
+}\if{html}{\out{</div>}}
+
+}
+\item{2. In place -- keep the metadata, leave the files alone}{
+Save the information but not the file bundle, on the assumption you
+still have the paths the run used -- above all \code{outputPath(sim)}.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{`saveSimList(sim, "mySim.rds", projectPath = projectPath, files = FALSE)`
+
+Reload it and use `outputs(sim)` to see what the run wrote, then read
+back whatever you actually need. This is usually the practical choice:
+a real run writes far too many objects to bundle into an archive.
+}\if{html}{\out{</div>}}
+
+}
+}
+}
+
+\examples{
+## ---- 1. Portable: take everything with you ----
+projectPath <- file.path(tempdir(), "myProject")
+outPath <- file.path(projectPath, "outputs")
+dir.create(outPath, recursive = TRUE, showWarnings = FALSE)
+
+sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"),
+               paths = list(outputPath = outPath))
+sim$anObject <- 1:10
+
+saveSimList(sim, file.path(projectPath, "portable.rds"),
+            projectPath = projectPath)
+
+## unpack it anywhere -- pass the new location as projectPath
+sim2 <- loadSimList(file.path(projectPath, "portable.rds"),
+                    projectPath = projectPath)
+sim2$anObject
+
+## ---- 2. In place: metadata only, files stay put ----
+## `files = FALSE` skips bundling; the run's own files are left where
+## they are, and the reloaded simList tells you where to find them
+saveSimList(sim, file.path(projectPath, "inPlace.rds"),
+            projectPath = projectPath, files = FALSE)
+
+sim3 <- loadSimList(file.path(projectPath, "inPlace.rds"),
+                    projectPath = projectPath)
+outputPath(sim3)   # where the run wrote its outputs
+outputs(sim3)      # the manifest of what it wrote
+
+unlink(projectPath, recursive = TRUE)
+
+}
 \seealso{
 \code{\link[=loadSimList]{loadSimList()}}
 }

--- a/tests/testthat/helper-initTests.R
+++ b/tests/testthat/helper-initTests.R
@@ -1,3 +1,15 @@
+## TRUE when the tests are running under coverage instrumentation.
+##
+## covr sets R_COVR itself, which `covr::in_covr()` reads, so this detects a
+## bare local `covr::package_coverage()` run as well as CI. The previous
+## `Sys.getenv("USING_COVR")` check only caught CI, because USING_COVR is set
+## by the GitHub workflow rather than by covr -- so covr-sensitive assertions
+## fired (and failed) on a local coverage run.
+inCovr <- function() {
+  identical(Sys.getenv("USING_COVR"), "true") ||
+    (requireNamespace("covr", quietly = TRUE) && isTRUE(covr::in_covr()))
+}
+
 cleanMessage <- function(mm) {
   mm1 <- gsub(".{1}\\[.{1,2}m", "", mm)
   mm1 <- gsub("\\n", "", mm1)

--- a/tests/testthat/test-1memory.R
+++ b/tests/testthat/test-1memory.R
@@ -28,7 +28,7 @@ test_that("testing memoryUse", {
   mySim2 <- simInit(times = times, params = params,
                     modules = modules, objects = list(), paths = paths)
 
-  if (!identical(Sys.getenv("USING_COVR"), "true")) {
+  if (!inCovr()) {
 
     mySim3 <- spades(mySim2, debug = FALSE)
     suppressWarnings({

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -88,7 +88,7 @@ test_that("test event-level cache & memory leaks", {
   # On covr::package_coverage -- this shows a HUGE difference ... about 130x. I don't know exactly why,
   #   but I feel like it is due to capturing of each call, which is unique to covr
   #   So this should be skipped on covr
-  if (!identical(Sys.getenv("USING_COVR"), "true")) {
+  if (!inCovr()) {
     expect_identical(length(grep("causing a memory leak", warnsFunction)), 0L)
   }
 

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -1,0 +1,126 @@
+## checkObject() and checkParams().
+
+## the core parameter names simInit passes to checkParams()
+coreParamsList <- function() {
+  append(list(".savePath", ".saveObjects", ".seed"),
+         list(".saveInterval", ".saveInitialTime", ".plotInterval", ".plotInitialTime"))
+}
+
+test_that("checkObject accepts an object that exists in the sim", {
+  testInit()
+
+  sim <- simInit()
+  sim$existingObj <- 1:5
+
+  expect_true(checkObject(sim, object = sim$existingObj))
+})
+
+test_that("checkObject accepts an object referenced by name", {
+  testInit()
+
+  sim <- simInit()
+  sim$existingObj <- 1:5
+
+  expect_true(checkObject(sim, name = "existingObj"))
+})
+
+test_that("checkObject rejects an object that is not there, and says so", {
+  testInit()
+
+  sim <- simInit()
+
+  expect_false(suppressMessages(checkObject(sim, name = "notThere")))
+
+  ## the explanatory message is verbose-gated
+  withr::local_options(spades.debug = TRUE)
+  expect_message(checkObject(sim, name = "notThere"), "does not exist")
+})
+
+test_that("checkObject accepts a layer that is present", {
+  testInit()
+
+  sim <- simInit()
+  sim$aList <- list(alpha = 1, beta = 2)
+
+  expect_true(checkObject(sim, name = "aList", layer = "alpha"))
+})
+
+test_that("checkObject rejects a layer that is absent, and names it", {
+  testInit()
+
+  sim <- simInit()
+  sim$aList <- list(alpha = 1, beta = 2)
+
+  expect_false(suppressMessages(checkObject(sim, name = "aList", layer = "zeta")))
+
+  withr::local_options(spades.debug = TRUE)
+  expect_message(checkObject(sim, name = "aList", layer = "zeta"),
+                 "zeta is not a layer")
+})
+
+test_that("checkObject demands a simList", {
+  testInit()
+
+  expect_error(checkObject(name = "anything"), "Must provide a simList object")
+})
+
+test_that("checkParams passes a module whose parameters are all used", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+
+  expect_true(suppressMessages(checkParams(sim, coreParamsList())))
+})
+
+test_that("checkParams flags a user parameter the module never uses", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp),
+            params = list(randomLandscapes = list(bogusUnusedParam = 1)))
+  )
+
+  expect_false(suppressMessages(checkParams(sim, coreParamsList())))
+
+  withr::local_options(spades.debug = TRUE)
+  expect_message(checkParams(sim, coreParamsList()),
+                 "bogusUnusedParam is not used in module randomLandscapes")
+})
+
+test_that("checkParams flags a global parameter no module uses", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp),
+            params = list(.globals = list(bogusGlobal = "x")))
+  )
+
+  expect_false(suppressMessages(checkParams(sim, coreParamsList())))
+
+  withr::local_options(spades.debug = TRUE)
+  expect_message(checkParams(sim, coreParamsList()),
+                 "Global parameter\\(s\\) not used in any module: bogusGlobal")
+})
+
+test_that("checkParams returns NA when there are no user modules to check", {
+  testInit()
+
+  ## nothing was checked, so neither TRUE ("all found") nor FALSE ("something
+  ## missing") is honest -- see the @return docs
+  sim <- simInit()
+  expect_true(is.na(suppressMessages(checkParams(sim, coreParamsList()))))
+})

--- a/tests/testthat/test-codecheck-helpers.R
+++ b/tests/testthat/test-codecheck-helpers.R
@@ -1,0 +1,124 @@
+## Small pure helpers behind the module code checker.
+
+ccCodetoolsOpts <- SpaDES.core:::.cc_codetoolsOpts
+ccReqdPkgsFromDep <- SpaDES.core:::.cc_reqdPkgsFromDep
+ccOtherModuleParams <- SpaDES.core:::.cc_otherModuleParams
+
+test_that(".cc_codetoolsOpts returns the full defaults when checks are on", {
+  testInit()
+
+  withr::local_options(spades.moduleCodeChecks = TRUE)
+  opts <- ccCodetoolsOpts()
+
+  expect_type(opts, "list")
+  expect_setequal(names(opts),
+                  c("skipWith", "suppressNoLocalFun", "suppressParamUnused",
+                    "suppressPartialMatchArgs", "suppressUndefined"))
+  expect_true(opts$skipWith)
+  expect_true(opts$suppressNoLocalFun)
+  expect_false(opts$suppressParamUnused)
+})
+
+test_that(".cc_codetoolsOpts also returns the defaults when the option is unset", {
+  testInit()
+
+  withr::local_options(spades.moduleCodeChecks = NULL)
+  expect_identical(ccCodetoolsOpts(),
+                   local({
+                     withr::local_options(spades.moduleCodeChecks = TRUE)
+                     ccCodetoolsOpts()
+                   }))
+})
+
+test_that(".cc_codetoolsOpts keeps only recognised names from a list option", {
+  testInit()
+
+  withr::local_options(spades.moduleCodeChecks =
+                         list(skipWith = FALSE, notARealOption = 1))
+  opts <- ccCodetoolsOpts()
+
+  expect_identical(names(opts), "skipWith")
+  expect_false(opts$skipWith)
+})
+
+test_that(".cc_codetoolsOpts returns nothing when checks are switched off", {
+  testInit()
+
+  withr::local_options(spades.moduleCodeChecks = FALSE)
+  expect_identical(ccCodetoolsOpts(), list())
+})
+
+## a real .moduleDeps object -- constructing one by hand fails validity
+sampleDep <- function(tmpdir, module = "randomLandscapes") {
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list(module), paths = list(modulePath = mp))
+  )
+  sim@depends@dependencies[[module]]
+}
+
+test_that(".cc_reqdPkgsFromDep returns an empty frame when a module needs nothing", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  dep <- sampleDep(tmpdir)
+  dep@reqdPkgs <- list()
+  out <- ccReqdPkgsFromDep(dep)
+
+  expect_s3_class(out, "data.frame")
+  expect_identical(NROW(out), 0L)
+  expect_setequal(names(out), c("spec", "pkg", "file", "line"))
+})
+
+test_that(".cc_reqdPkgsFromDep splits a package spec into spec and bare name", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  dep <- sampleDep(tmpdir)
+  dep@reqdPkgs <- list("terra", "data.table (>= 1.14)")
+  out <- ccReqdPkgsFromDep(dep, file = "m.R")
+
+  expect_identical(NROW(out), 2L)
+  expect_true("terra" %in% out$pkg)
+  expect_true("data.table" %in% out$pkg)
+  ## the full spec is kept alongside the bare name
+  expect_true(any(grepl(">=", out$spec)))
+  ## line numbers are unavailable on this path
+  expect_true(all(is.na(out$line)))
+  expect_true(all(out$file == "m.R"))
+})
+
+test_that(".cc_otherModuleParams lists parameters of every module but the current one", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes", "fireSpread"),
+            paths = list(modulePath = mp))
+  )
+
+  out <- ccOtherModuleParams(sim, currentModule = "randomLandscapes")
+
+  expect_type(out, "list")
+  expect_false("randomLandscapes" %in% names(out))
+  expect_true("fireSpread" %in% names(out))
+  expect_true(is.character(out$fireSpread))
+  expect_true(length(out$fireSpread) > 0)
+})
+
+test_that(".cc_otherModuleParams is empty when the sim has only the current module", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+
+  expect_length(ccOtherModuleParams(sim, currentModule = "randomLandscapes"), 0L)
+})

--- a/tests/testthat/test-codecheck-report.R
+++ b/tests/testthat/test-codecheck-report.R
@@ -1,0 +1,169 @@
+## .cc_report() turns a findings data.frame into grouped, printed tables and
+## returns the findings (with a `group` column) invisibly.
+
+mkFinding <- function(...) SpaDES.core:::.cc_finding(...)
+ccReport <- function(...) SpaDES.core:::.cc_report(...)
+emptyFindings <- function() SpaDES.core:::.cc_emptyFindings()
+
+## cli does not write these tables to stdout, so expect_output() sees nothing.
+## Under testthat cli signals them as message conditions, so capture those.
+## Widen cli first so long lines are not wrapped mid-match.
+ccOut <- function(...) {
+  withr::with_options(list(cli.width = 300),
+                      paste(testthat::capture_messages(ccReport(...)),
+                            collapse = "\n"))
+}
+
+test_that(".cc_report reports clean code when there are no findings", {
+  testInit()
+
+  expect_message(ccReport(emptyFindings(), module = "myMod"),
+                 "myMod: module code appears clean")
+})
+
+test_that(".cc_report falls back to a placeholder when no module name is given", {
+  testInit()
+
+  expect_message(ccReport(emptyFindings()), "\\(module\\): module code appears clean")
+})
+
+test_that(".cc_report stays silent on clean code when quiet", {
+  testInit()
+
+  expect_no_message(ccReport(emptyFindings(), module = "myMod", quiet = TRUE))
+})
+
+test_that(".cc_report returns the findings invisibly", {
+  testInit()
+
+  f <- emptyFindings()
+  expect_invisible(ccReport(f, module = "myMod", quiet = TRUE))
+})
+
+test_that(".cc_report tags each finding with its rule group", {
+  testInit()
+
+  f <- rbind(
+    mkFinding("out_declared_unused", "warning", module = "m", name = "a",
+              message = "declared but unused"),
+    mkFinding("param_used_undeclared", "note", module = "m", name = "p",
+              message = "used but undeclared")
+  )
+
+  out <- ccReport(f, module = "m", quiet = TRUE)
+
+  expect_true("group" %in% names(out))
+  expect_identical(out$group, c("outputObjects", "parameters"))
+})
+
+test_that(".cc_report groups unknown rule ids under 'other'", {
+  testInit()
+
+  f <- mkFinding("no_such_rule_id", "note", module = "m", message = "hm")
+
+  out <- ccReport(f, module = "m", quiet = TRUE)
+
+  expect_identical(out$group, "other")
+})
+
+test_that(".cc_report prints the module name, message and rule id", {
+  testInit()
+
+  f <- mkFinding("out_declared_unused", "warning", module = "myMod", name = "a",
+                 message = "declared but never assigned", file = "myMod.R",
+                 line = 12L, col = 3L)
+
+  txt <- ccOut(f, module = "myMod")
+  expect_match(txt, "myMod")
+  expect_match(txt, "declared but never assigned")
+  expect_match(txt, "out_declared_unused", fixed = TRUE)
+})
+
+test_that(".cc_report prints a file:line:col location when there is one", {
+  testInit()
+
+  f <- mkFinding("out_declared_unused", "warning", module = "myMod", name = "a",
+                 message = "some problem", file = "myMod.R", line = 12L, col = 3L)
+
+  expect_match(ccOut(f, module = "myMod"), "myMod.R:12:3", fixed = TRUE)
+})
+
+test_that(".cc_report omits the location when the line is unknown", {
+  testInit()
+
+  f <- mkFinding("out_declared_unused", "warning", module = "myMod", name = "a",
+                 message = "some problem")
+
+  expect_false(grepl(":NA:", ccOut(f, module = "myMod"), fixed = TRUE))
+})
+
+test_that(".cc_report prints the suggestion when one is supplied", {
+  testInit()
+
+  f <- mkFinding("in_no_default", "note", module = "myMod", name = "a",
+                 message = "no default", suggestion = "add a default value")
+
+  expect_match(ccOut(f, module = "myMod"), "add a default value")
+})
+
+test_that(".cc_report renders every severity tag", {
+  testInit()
+
+  for (sev in c("error", "warning", "note", "info")) {
+    f <- mkFinding("out_declared_unused", sev, module = "myMod", name = "a",
+                   message = paste("a", sev, "finding"))
+    expect_match(ccOut(f, module = "myMod"), paste("a", sev, "finding"))
+  }
+})
+
+test_that(".cc_report collapses findings that differ only by object name", {
+  testInit()
+
+  ## same rule, same wording apart from the object's own name -> one header,
+  ## then one line per hit
+  f <- rbind(
+    mkFinding("in_declared_unused", "note", module = "myMod", name = "alpha",
+              message = "input alpha is declared but unused",
+              suggestion = "remove alpha", file = "myMod.R", line = 3L, col = 1L),
+    mkFinding("in_declared_unused", "note", module = "myMod", name = "beta",
+              message = "input beta is declared but unused",
+              suggestion = "remove beta", file = "myMod.R", line = 9L, col = 1L)
+  )
+
+  txt <- ccOut(f, module = "myMod")
+
+  ## the shared header uses the <name> placeholder ...
+  expect_match(txt, "<name>", fixed = TRUE)
+  ## ... and both individual objects still appear, with their own locations
+  expect_match(txt, "alpha")
+  expect_match(txt, "beta")
+  expect_match(txt, "myMod.R:3:1", fixed = TRUE)
+  expect_match(txt, "myMod.R:9:1", fixed = TRUE)
+})
+
+test_that(".cc_report separates findings from different groups", {
+  testInit()
+
+  f <- rbind(
+    mkFinding("out_declared_unused", "warning", module = "myMod", name = "a",
+              message = "an output problem"),
+    mkFinding("param_used_undeclared", "note", module = "myMod", name = "p",
+              message = "a parameter problem")
+  )
+
+  txt <- ccOut(f, module = "myMod")
+
+  expect_match(txt, "outputObjects")
+  expect_match(txt, "parameters")
+  expect_match(txt, "an output problem")
+  expect_match(txt, "a parameter problem")
+})
+
+test_that(".cc_report uses the findings' own module when none is passed", {
+  testInit()
+
+  f <- mkFinding("out_declared_unused", "warning", module = "modFromFinding",
+                 name = "a", message = "some problem")
+
+  expect_match(ccOut(f), "modFromFinding")
+})

--- a/tests/testthat/test-copyModule.R
+++ b/tests/testthat/test-copyModule.R
@@ -1,0 +1,161 @@
+## copyModule(), newModuleCode() and newModuleDocumentation().
+##
+## newModule()/zipModule() are already covered by test-module-template.R, so
+## this file sticks to the parts that were not.
+##
+## NOTE: openModules() and .fileEdit() are deliberately not tested -- they exist
+## to launch an editor (file.edit / RStudio), so exercising them would open
+## windows rather than assert anything.
+
+test_that("copyModule copies a module under a new name", {
+  skip_on_cran()
+  testInit()
+
+  suppressMessages(newModule("origMod", path = tmpdir, open = FALSE))
+  suppressMessages(copyModule("origMod", "copiedMod", path = tmpdir))
+
+  newDir <- file.path(tmpdir, "copiedMod")
+  expect_true(dir.exists(newDir))
+  ## the code file is renamed to match the new module name
+  expect_true(file.exists(file.path(newDir, "copiedMod.R")))
+  expect_false(file.exists(file.path(newDir, "origMod.R")))
+})
+
+test_that("copyModule brings the documentation across, renamed", {
+  skip_on_cran()
+  testInit()
+
+  suppressMessages(newModule("docSrc", path = tmpdir, open = FALSE))
+  suppressMessages(copyModule("docSrc", "docDst", path = tmpdir))
+
+  newDir <- file.path(tmpdir, "docDst")
+  expect_true(file.exists(file.path(newDir, "docDst.Rmd")))
+  expect_false(file.exists(file.path(newDir, "docSrc.Rmd")))
+})
+
+test_that("copyModule creates the standard module subdirectories", {
+  skip_on_cran()
+  testInit()
+
+  suppressMessages(newModule("dirSrc", path = tmpdir, open = FALSE))
+  suppressMessages(copyModule("dirSrc", "dirDst", path = tmpdir))
+
+  newDir <- file.path(tmpdir, "dirDst")
+  expect_true(dir.exists(file.path(newDir, "data")))
+  expect_true(dir.exists(file.path(newDir, "tests")))
+  expect_true(dir.exists(file.path(newDir, "tests", "testthat")))
+})
+
+test_that("copyModule copies files from the module's data directory", {
+  skip_on_cran()
+  testInit()
+
+  suppressMessages(newModule("dataSrc", path = tmpdir, open = FALSE))
+  writeLines("some data", file.path(tmpdir, "dataSrc", "data", "aDataFile.txt"))
+
+  suppressMessages(copyModule("dataSrc", "dataDst", path = tmpdir))
+
+  expect_true(file.exists(file.path(tmpdir, "dataDst", "data", "aDataFile.txt")))
+})
+
+test_that("copyModule copies files from tests/testthat", {
+  skip_on_cran()
+  testInit()
+
+  suppressMessages(newModule("testSrc", path = tmpdir, open = FALSE))
+  ttDir <- checkPath(file.path(tmpdir, "testSrc", "tests", "testthat"), create = TRUE)
+  writeLines("## a module test", file.path(ttDir, "test-something.R"))
+
+  suppressMessages(copyModule("testSrc", "testDst", path = tmpdir))
+
+  expect_true(file.exists(file.path(tmpdir, "testDst", "tests", "testthat",
+                                    "test-something.R")))
+})
+
+test_that("copyModule copies files sitting directly in tests/", {
+  skip_on_cran()
+  testInit()
+
+  ## the "tests" branch used to match "test" (singular), so a file directly in
+  ## tests/ -- e.g. the unitTests.R that newModule(unitTests = TRUE) writes --
+  ## was silently skipped, while tests/testthat/* copied fine
+  suppressMessages(newModule("looseSrc", path = tmpdir, open = FALSE))
+  writeLines("## a loose test file",
+             file.path(tmpdir, "looseSrc", "tests", "aLooseTest.R"))
+
+  suppressMessages(copyModule("looseSrc", "looseDst", path = tmpdir))
+
+  expect_true(file.exists(file.path(tmpdir, "looseDst", "tests", "aLooseTest.R")))
+})
+
+test_that("copyModule creates the target subdirectories regardless of the working directory", {
+  skip_on_cran()
+  testInit()
+
+  ## The existence check used to test a bare relative name against the working
+  ## directory rather than the directory actually being created. testInit()
+  ## sets the working directory to tmpdir, so keep the modules somewhere else
+  ## for the decoy below to be a genuine decoy.
+  modPath <- checkPath(file.path(tmpdir, "mods"), create = TRUE)
+  suppressMessages(newModule("wdSrc", path = modPath, open = FALSE))
+
+  ## an unrelated directory of the same name in the WORKING directory must not
+  ## be mistaken for the target, which lives under modPath
+  decoy <- file.path(getwd(), "wdDst")
+  dir.create(decoy, showWarnings = FALSE)
+  withr::defer(unlink(decoy, recursive = TRUE))
+
+  suppressMessages(copyModule("wdSrc", "wdDst", path = modPath))
+
+  expect_true(dir.exists(file.path(modPath, "wdDst", "data")))
+  expect_true(dir.exists(file.path(modPath, "wdDst", "tests", "testthat")))
+  expect_true(file.exists(file.path(modPath, "wdDst", "wdDst.R")))
+})
+
+test_that("copyModule returns TRUE when every file copied", {
+  skip_on_cran()
+  testInit()
+
+  suppressMessages(newModule("retSrc", path = tmpdir, open = FALSE))
+  res <- suppressMessages(copyModule("retSrc", "retDst", path = tmpdir))
+
+  expect_true(res)
+})
+
+test_that("a copied module's code still parses", {
+  skip_on_cran()
+  testInit()
+
+  suppressMessages(newModule("parseSrc", path = tmpdir, open = FALSE))
+  suppressMessages(copyModule("parseSrc", "parseDst", path = tmpdir))
+
+  f <- file.path(tmpdir, "parseDst", "parseDst.R")
+  expect_true(file.exists(f))
+  expect_silent(parse(f))
+})
+
+test_that("newModuleCode writes the module's .R file", {
+  skip_on_cran()
+  testInit()
+
+  checkPath(file.path(tmpdir, "codeOnly"), create = TRUE)
+  suppressMessages(newModuleCode("codeOnly", path = tmpdir, open = FALSE))
+
+  f <- file.path(tmpdir, "codeOnly", "codeOnly.R")
+  expect_true(file.exists(f))
+
+  src <- paste(readLines(f), collapse = "\n")
+  expect_match(src, "defineModule")
+  expect_match(src, "codeOnly")
+  expect_silent(parse(f))
+})
+
+test_that("newModuleDocumentation writes the module's .Rmd", {
+  skip_on_cran()
+  testInit()
+
+  checkPath(file.path(tmpdir, "docsOnly"), create = TRUE)
+  suppressMessages(newModuleDocumentation("docsOnly", path = tmpdir, open = FALSE))
+
+  expect_true(file.exists(file.path(tmpdir, "docsOnly", "docsOnly.Rmd")))
+})

--- a/tests/testthat/test-debugging.R
+++ b/tests/testthat/test-debugging.R
@@ -1,0 +1,55 @@
+test_that("writeEventInfo writes the current event to a file", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim <- scheduleEvent(sim, 0, "someModule", "someEvent")
+
+  f <- tempfile(fileext = ".txt")
+  writeEventInfo(sim, file = f)
+
+  expect_true(file.exists(f))
+  expect_true(nzchar(paste(readLines(f), collapse = "")))
+})
+
+test_that("writeEventInfo appends when asked and truncates when not", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim <- scheduleEvent(sim, 0, "someModule", "someEvent")
+
+  f <- tempfile(fileext = ".txt")
+  writeEventInfo(sim, file = f, append = FALSE)
+  oneRun <- length(readLines(f))
+
+  writeEventInfo(sim, file = f, append = TRUE)
+  expect_gt(length(readLines(f)), oneRun)
+
+  writeEventInfo(sim, file = f, append = FALSE)
+  expect_identical(length(readLines(f)), oneRun)
+})
+
+test_that("writeRNGInfo writes the RNG stream state", {
+  testInit()
+
+  set.seed(123)  # ensure .Random.seed exists
+  f <- tempfile(fileext = ".txt")
+  writeRNGInfo(file = f)
+
+  expect_true(file.exists(f))
+  txt <- paste(readLines(f), collapse = "\n")
+  expect_match(txt, "Start of new RNG stream")
+  ## all 10 seed elements are written, comma-separated, ending in a period
+  expect_length(strsplit(sub("^.*stream: ", "", sub("\\.$", "", txt)), ", ")[[1]], 10L)
+})
+
+test_that("writeRNGInfo appends when asked", {
+  testInit()
+
+  set.seed(123)
+  f <- tempfile(fileext = ".txt")
+  writeRNGInfo(file = f, append = FALSE)
+  oneRun <- length(readLines(f))
+
+  writeRNGInfo(file = f, append = TRUE)
+  expect_gt(length(readLines(f)), oneRun)
+})

--- a/tests/testthat/test-defineEvent.R
+++ b/tests/testthat/test-defineEvent.R
@@ -1,0 +1,162 @@
+test_that("defineEvent creates a correctly named and shaped event function", {
+  testInit()
+
+  sim <- simInit()
+  e <- new.env(parent = globalenv())
+
+  defineEvent(sim, "grow", moduleName = "m1", code = { sim$size <- sim$size + 1 },
+              envir = e)
+
+  expect_true(exists("doEvent.m1.grow", envir = e, inherits = FALSE))
+  fn <- get("doEvent.m1.grow", envir = e)
+  expect_true(is.function(fn))
+  expect_identical(names(formals(fn)), c("sim", "eventTime", "eventType", "priority"))
+})
+
+test_that("defineEvent defaults eventName to 'init'", {
+  testInit()
+
+  sim <- simInit()
+  e <- new.env(parent = globalenv())
+
+  defineEvent(sim, moduleName = "m1", code = { sim }, envir = e)
+
+  expect_true(exists("doEvent.m1.init", envir = e, inherits = FALSE))
+})
+
+test_that("defineEvent leaves the code unevaluated until the event runs", {
+  testInit()
+
+  sim <- simInit()
+  e <- new.env(parent = globalenv())
+
+  # if `code` were evaluated at definition time, this would error immediately
+  defineEvent(sim, "boom", moduleName = "m1",
+              code = { stop("this code must not run at definition time") },
+              envir = e)
+
+  expect_true(exists("doEvent.m1.boom", envir = e, inherits = FALSE))
+  expect_error(get("doEvent.m1.boom", envir = e)(sim), "must not run at definition time")
+})
+
+test_that("the generated event function runs the code and returns the sim", {
+  testInit()
+
+  sim <- simInit()
+  sim$size <- 1
+  e <- new.env(parent = globalenv())
+
+  defineEvent(sim, "grow", moduleName = "m1", code = { sim$size <- sim$size + 1 },
+              envir = e)
+
+  out <- get("doEvent.m1.grow", envir = e)(sim)
+  expect_s4_class(out, "simList")
+  expect_identical(out$size, 2)
+})
+
+test_that("defineEvent appends a return(sim) so an event need not return it explicitly", {
+  testInit()
+
+  sim <- simInit()
+  sim$touched <- FALSE
+  e <- new.env(parent = globalenv())
+
+  # note: no `return(sim)` and no trailing `sim` in the user's code
+  defineEvent(sim, "quiet", moduleName = "m1", code = { sim$touched <- TRUE },
+              envir = e)
+
+  out <- get("doEvent.m1.quiet", envir = e)(sim)
+  expect_s4_class(out, "simList")
+  expect_true(out$touched)
+})
+
+test_that("defineEvent records the event function's envir and digest on the sim", {
+  testInit()
+
+  sim <- simInit()
+  e <- new.env(parent = globalenv())
+
+  defineEvent(sim, "grow", moduleName = "m1", code = { sim }, envir = e)
+
+  slotName <- SpaDES.core:::eventFnElementEnvir()
+  registry <- sim@.xData[[slotName]]
+
+  expect_true(is.environment(registry))
+  expect_true("doEvent.m1.grow" %in% ls(registry))
+
+  entry <- registry[["doEvent.m1.grow"]]
+  expect_identical(entry$envir, e)
+  expect_true(is.character(entry$digest))
+  expect_true(nzchar(entry$digest))
+})
+
+test_that("defineEvent registers each event separately for the same module", {
+  testInit()
+
+  sim <- simInit()
+  e <- new.env(parent = globalenv())
+
+  defineEvent(sim, "init", moduleName = "m1", code = { sim }, envir = e)
+  defineEvent(sim, "grow", moduleName = "m1", code = { sim }, envir = e)
+
+  expect_setequal(ls(e), c("doEvent.m1.init", "doEvent.m1.grow"))
+
+  registry <- sim@.xData[[SpaDES.core:::eventFnElementEnvir()]]
+  expect_true(all(c("doEvent.m1.init", "doEvent.m1.grow") %in% ls(registry)))
+})
+
+test_that("defineEvent returns the sim invisibly", {
+  testInit()
+
+  sim <- simInit()
+  e <- new.env(parent = globalenv())
+
+  expect_invisible(defineEvent(sim, "grow", moduleName = "m1", code = { sim }, envir = e))
+
+  out <- defineEvent(sim, "grow2", moduleName = "m1", code = { sim }, envir = e)
+  expect_s4_class(out, "simList")
+})
+
+test_that("events defined with defineEvent run under spades()", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"))
+
+  defineEvent(sim, "init", moduleName = "counter", code = {
+    sim$n <- 0L
+    sim <- scheduleEvent(sim, time(sim), "counter", "tick")
+  })
+
+  defineEvent(sim, "tick", moduleName = "counter", code = {
+    sim$n <- sim$n + 1L
+    sim <- scheduleEvent(sim, time(sim) + 1, "counter", "tick")
+  })
+
+  sim <- scheduleEvent(sim, 0, "counter", "init")
+  expect_true("init" %in% events(sim)$eventType)
+
+  out <- suppressMessages(spades(sim))
+
+  expect_s4_class(out, "simList")
+  expect_identical(out$n, 3L)  # ticks at t = 0, 1, 2
+  expect_true(all(c("init", "tick") %in% completed(out)$eventType))
+})
+
+test_that("defineEvent registers the event even when a module environment exists", {
+  ## Regression guard: placement into sim[[dotMods]][[moduleName]] is not
+  ## implemented yet (it needs the .parse* integration). Until it is, the
+  ## presence of a module environment must not stop the event being registered,
+  ## or the function is defined somewhere nothing can find it.
+  testInit()
+
+  sim <- simInit()
+  sim[[SpaDES.core:::dotMods]][["m1"]] <- new.env(parent = emptyenv())
+  e <- new.env(parent = globalenv())
+
+  defineEvent(sim, "grow", moduleName = "m1", code = { sim }, envir = e)
+
+  registry <- sim@.xData[[SpaDES.core:::eventFnElementEnvir()]]
+  expect_true("doEvent.m1.grow" %in% ls(registry))
+  expect_identical(registry[["doEvent.m1.grow"]]$envir, e)
+})

--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -1,0 +1,33 @@
+test_that("deprecated functions warn and point at their new package", {
+  testInit()
+
+  ## `experiment` moved to SpaDES.project; the rest to SpaDES.experiment
+  expect_warning(experiment(), "SpaDES\\.project")
+  for (fn in list(experiment2, POM, simInitAndExperiment)) {
+    expect_warning(fn(), "SpaDES\\.experiment")
+  }
+})
+
+test_that("the deprecation message names the function and how to install it", {
+  testInit()
+
+  w <- tryCatch(experiment(), warning = function(w) conditionMessage(w))
+  expect_match(w, "^experiment has been moved to SpaDES\\.project\\.")
+  expect_match(w, "install_github('PredictiveEcology/SpaDES.project@development')", fixed = TRUE)
+})
+
+test_that("loadPackages is deprecated in favour of Require", {
+  testInit()
+
+  expect_warning(SpaDES.core:::loadPackages(), "Require")
+})
+
+test_that(".messageDeprecatedFn builds both the branch and non-branch install hints", {
+  testInit()
+
+  msg <- SpaDES.core:::.messageDeprecatedFn("someFn", newPackage = "SomePkg")
+  expect_match(msg, "someFn has been moved to SomePkg")
+  expect_match(msg, "PredictiveEcology/SomePkg@development", fixed = TRUE)
+  expect_match(msg, "PredictiveEcology/SomePkg'", fixed = TRUE)
+  expect_match(msg, " or ", fixed = TRUE)
+})

--- a/tests/testthat/test-misc-methods.R
+++ b/tests/testthat/test-misc-methods.R
@@ -1,0 +1,142 @@
+## Small helpers in misc-methods.R: classFilter(), rndstr(), the empty
+## input/output file tables, moduleCodeFiles() and the defunct updateList().
+
+test_that("classFilter keeps only objects of the included class", {
+  testInit()
+
+  e <- new.env()
+  e$aNumber <- 1.5
+  e$aCharacter <- "x"
+  e$aList <- list(1, 2)
+
+  out <- classFilter(ls(e), include = "numeric", exclude = NA_character_, envir = e)
+
+  expect_identical(out, "aNumber")
+})
+
+test_that("classFilter treats integers as numeric", {
+  testInit()
+
+  e <- new.env()
+  e$anInteger <- 1L
+  e$aCharacter <- "x"
+
+  out <- classFilter(ls(e), include = "numeric", exclude = NA_character_, envir = e)
+
+  expect_identical(out, "anInteger")
+})
+
+test_that("classFilter drops objects of the excluded class", {
+  testInit()
+
+  e <- new.env()
+  e$aNumber <- 1.5
+  e$anInteger <- 1L
+
+  out <- classFilter(ls(e), include = "numeric", exclude = "integer", envir = e)
+
+  expect_identical(out, "aNumber")
+})
+
+test_that("classFilter returns nothing when no object matches", {
+  testInit()
+
+  e <- new.env()
+  e$aCharacter <- "x"
+
+  expect_length(classFilter(ls(e), include = "numeric", exclude = NA_character_,
+                            envir = e), 0L)
+})
+
+test_that("rndstr produces n strings of the requested length", {
+  testInit()
+
+  out <- rndstr(n = 4, len = 6)
+
+  expect_length(out, 4L)
+  expect_true(all(nchar(out) == 6L))
+  expect_type(out, "character")
+})
+
+test_that("rndstr honours characterFirst", {
+  testInit()
+
+  set.seed(123)
+  withFirst <- rndstr(n = 20, len = 5, characterFirst = TRUE)
+  expect_true(all(grepl("^[A-Za-z]", withFirst)))
+
+  ## characterFirst = FALSE may start with a digit or a letter, so just check
+  ## the shape holds
+  noFirst <- rndstr(n = 20, len = 5, characterFirst = FALSE)
+  expect_true(all(nchar(noFirst) == 5L))
+})
+
+test_that("rndstr defaults n and len when either is missing", {
+  testInit()
+
+  expect_length(rndstr(n = 3), 3L)
+  expect_true(all(nchar(rndstr(len = 4)) == 4L))
+  expect_length(rndstr(), 1L)
+})
+
+test_that("rndstr rejects non-positive n or len", {
+  testInit()
+
+  expect_error(rndstr(n = 0, len = 3), "requires n > 0 and len > 0")
+  expect_error(rndstr(n = 3, len = 0), "requires n > 0 and len > 0")
+})
+
+test_that("rndstr is reproducible under a fixed seed", {
+  testInit()
+
+  set.seed(42); a <- rndstr(n = 5, len = 8)
+  set.seed(42); b <- rndstr(n = 5, len = 8)
+
+  expect_identical(a, b)
+})
+
+test_that(".fileTableIn returns an empty input table with the expected columns", {
+  testInit()
+
+  ft <- SpaDES.core:::.fileTableIn()
+
+  expect_s3_class(ft, "data.frame")
+  expect_identical(NROW(ft), 0L)
+  expect_true(all(c("file", "fun", "package", "objectName", "loadTime", "loaded") %in%
+                    names(ft)))
+})
+
+test_that(".fileTableOut returns an empty output table with the expected columns", {
+  testInit()
+
+  ft <- SpaDES.core:::.fileTableOut()
+
+  expect_s3_class(ft, "data.frame")
+  expect_identical(NROW(ft), 0L)
+  expect_true(all(c("file", "fun", "package", "objectName", "saveTime", "saved") %in%
+                    names(ft)))
+})
+
+test_that("the cached empty input table matches a fresh one", {
+  testInit()
+
+  expect_identical(SpaDES.core:::.fileTableInCols, colnames(SpaDES.core:::.fileTableIn()))
+})
+
+test_that("moduleCodeFiles finds a module's R files", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  files <- SpaDES.core:::moduleCodeFiles(list(modulePath = mp), "randomLandscapes")
+
+  expect_type(files, "character")
+  expect_true(length(files) > 0)
+  expect_true(any(grepl("randomLandscapes\\.R$", files)))
+})
+
+test_that("updateList is defunct in favour of Require::modifyList2", {
+  testInit()
+
+  expect_error(SpaDES.core:::updateList(list(a = 1), list(b = 2)), "defunct")
+})

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -1,0 +1,152 @@
+## The progress bar module: newProgressBar()/setProgressBar() and the
+## doEvent.progress() event handler.
+##
+## These touch .pkgEnv$.pb, which is package-global, so each test restores it.
+
+newProgressBar <- SpaDES.core:::newProgressBar
+setProgressBar <- SpaDES.core:::setProgressBar
+doEvent.progress <- SpaDES.core:::doEvent.progress
+pkgEnv <- SpaDES.core:::.pkgEnv
+
+## newProgressBar()/setProgressBar() probe for tcltk; on a headless machine the
+## first load warns "no DISPLAY variable so Tk is not available". Trigger it
+## once here so it is not attributed to whichever test happens to run first.
+suppressWarnings(requireNamespace("tcltk", quietly = TRUE))
+
+## save/restore .pkgEnv$.pb around a test
+localProgressBar <- function(envir = parent.frame()) {
+  had <- exists(".pb", envir = pkgEnv)
+  old <- if (had) get(".pb", envir = pkgEnv)
+  withr::defer({
+    if (had) {
+      assign(".pb", old, envir = pkgEnv)
+    } else if (exists(".pb", envir = pkgEnv)) {
+      rm(".pb", envir = pkgEnv)
+    }
+  }, envir = envir)
+}
+
+## a sim with real module paths -- P(sim, module = ".progress") resolves them
+progressSim <- function(tmpdir, type = "text", interval = 1, end = 2) {
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = end, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+  sim@params[[".progress"]] <- list(type = type, interval = interval)
+  sim
+}
+
+test_that("newProgressBar creates a text progress bar", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+  localProgressBar()
+
+  sim <- progressSim(tmpdir)
+  invisible(capture.output(newProgressBar(sim)))
+
+  expect_true(exists(".pb", envir = pkgEnv))
+  expect_s3_class(get(".pb", envir = pkgEnv), "txtProgressBar")
+})
+
+test_that("newProgressBar replaces an existing bar", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+  localProgressBar()
+
+  sim <- progressSim(tmpdir)
+  invisible(capture.output(newProgressBar(sim)))
+  first <- get(".pb", envir = pkgEnv)
+
+  invisible(capture.output(newProgressBar(sim)))
+  second <- get(".pb", envir = pkgEnv)
+
+  expect_s3_class(second, "txtProgressBar")
+  expect_false(identical(first, second))
+})
+
+test_that("setProgressBar advances the bar to the current sim time", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+  localProgressBar()
+
+  sim <- progressSim(tmpdir)
+  invisible(capture.output(newProgressBar(sim)))
+
+  sim@simtimes[["current"]] <- end(sim, "second") / 2
+
+  ## assert the bar advanced, not that the call was silent -- under covr this
+  ## code path emits messages it does not emit in a plain run
+  before <- utils::getTxtProgressBar(get(".pb", envir = pkgEnv))
+  invisible(capture.output(suppressMessages(setProgressBar(sim))))
+  after <- utils::getTxtProgressBar(get(".pb", envir = pkgEnv))
+
+  expect_s3_class(get(".pb", envir = pkgEnv), "txtProgressBar")
+  expect_gt(after, before)
+})
+
+test_that("the shiny progress bar is explicitly not implemented", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+  localProgressBar()
+
+  sim <- progressSim(tmpdir, type = "shiny")
+
+  expect_error(newProgressBar(sim), "shiny progress bar not yet implemented")
+
+  ## setProgressBar needs an existing bar before it reaches the shiny branch
+  sim2 <- progressSim(tmpdir, type = "text")
+  invisible(capture.output(newProgressBar(sim2)))
+  sim2@params[[".progress"]] <- list(type = "shiny", interval = 1)
+  expect_error(setProgressBar(sim2), "shiny progress bar not yet implemented")
+})
+
+test_that("doEvent.progress init disables the bar when non-interactive", {
+  skip_on_cran()
+  skip_if(interactive(), "this asserts the non-interactive branch")
+  testInit(sampleModReqdPkgs)
+  localProgressBar()
+
+  sim <- progressSim(tmpdir)
+  nEventsBefore <- NROW(events(sim))
+
+  out <- doEvent.progress(sim, eventTime = 0, eventType = "init")
+
+  expect_s4_class(out, "simList")
+  ## the non-interactive branch installs the all-NA template ...
+  expect_true(all(is.na(unlist(P(out, module = ".progress")))))
+  ## ... and therefore schedules no progress events
+  expect_identical(NROW(events(out)), nEventsBefore)
+})
+
+test_that("doEvent.progress set schedules the next update one interval later", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+  localProgressBar()
+
+  sim <- progressSim(tmpdir, interval = 1)
+  invisible(capture.output(newProgressBar(sim)))
+
+  out <- invisible(capture.output(
+    sim2 <- doEvent.progress(sim, eventTime = 0, eventType = "set")
+  ))
+
+  scheduled <- events(sim2)[events(sim2)$moduleName == "progress", ]
+  expect_true(NROW(scheduled) >= 1)
+  expect_true("set" %in% scheduled$eventType)
+})
+
+test_that("doEvent.progress warns on an unknown event type", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+  localProgressBar()
+
+  sim <- progressSim(tmpdir)
+  ## the warning message reads from current(sim), so give it a current event
+  sim <- scheduleEvent(sim, 0, "progress", "bogusType")
+  current(sim) <- events(sim)[events(sim)$moduleName == "progress", ][1, ]
+
+  expect_warning(doEvent.progress(sim, eventTime = 0, eventType = "bogusType"),
+                 "Undefined event type")
+})

--- a/tests/testthat/test-saveLoadSimList.R
+++ b/tests/testthat/test-saveLoadSimList.R
@@ -1,0 +1,355 @@
+## saveSimList() / loadSimList() round trips, file formats, and the deprecated
+## argument handling.
+
+simToSave <- function(end = 2) {
+  sim <- simInit(times = list(start = 0, end = end, timeunit = "year"))
+  sim$anInteger <- 1:5
+  sim$aCharacter <- "hello"
+  sim$aList <- list(a = 1, b = "two")
+  sim <- scheduleEvent(sim, 1, "someModule", "someEvent")
+  sim
+}
+
+expectSameSim <- function(out, orig) {
+  expect_s4_class(out, "simList")
+  expect_identical(out$anInteger, orig$anInteger)
+  expect_identical(out$aCharacter, orig$aCharacter)
+  expect_identical(out$aList, orig$aList)
+  expect_identical(as.numeric(end(out)), as.numeric(end(orig)))
+  expect_identical(timeunit(out), timeunit(orig))
+}
+
+test_that("saveSimList writes an .rds and loadSimList reads it back", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simToSave()
+  f <- file.path(tmpdir, "sim.rds")
+
+  suppressMessages(saveSimList(sim, f))
+  expect_true(file.exists(f))
+
+  out <- suppressMessages(loadSimList(f))
+  expectSameSim(out, sim)
+})
+
+test_that("saveSimList writes a .qs2 and loadSimList reads it back", {
+  skip_on_cran()
+  skip_if_not_installed("qs2")
+  testInit()
+
+  sim <- simToSave()
+  f <- file.path(tmpdir, "sim.qs2")
+
+  suppressMessages(saveSimList(sim, f))
+  expect_true(file.exists(f))
+
+  out <- suppressMessages(loadSimList(f))
+  expectSameSim(out, sim)
+})
+
+test_that("a round trip preserves the event queue", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simToSave()
+  f <- file.path(tmpdir, "sim.rds")
+  suppressMessages(saveSimList(sim, f))
+  out <- suppressMessages(loadSimList(f))
+
+  expect_true("someModule" %in% events(out)$moduleName)
+  expect_identical(NROW(events(out)), NROW(events(sim)))
+})
+
+test_that("saveSimList rejects an unsupported file extension", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simToSave()
+  expect_error(saveSimList(sim, file.path(tmpdir, "sim.txt")))
+})
+
+test_that("loadSimList rejects an unsupported file extension", {
+  skip_on_cran()
+  testInit()
+
+  expect_error(loadSimList(file.path(tmpdir, "sim.txt")))
+})
+
+test_that("saveSimList accepts the sim by name from an environment", {
+  skip_on_cran()
+  testInit()
+
+  e <- new.env()
+  e$mySim <- simToSave()
+  f <- file.path(tmpdir, "sim.rds")
+
+  suppressMessages(saveSimList("mySim", f, envir = e))
+  expect_true(file.exists(f))
+
+  out <- suppressMessages(loadSimList(f))
+  expectSameSim(out, e$mySim)
+})
+
+test_that("saveSimList with files = FALSE still round-trips the objects", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simToSave()
+  f <- file.path(tmpdir, "sim.rds")
+
+  suppressMessages(saveSimList(sim, f, files = FALSE))
+  out <- suppressMessages(loadSimList(f))
+
+  expectSameSim(out, sim)
+})
+
+test_that("the deprecated fileBackend argument warns", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simToSave()
+  expect_warning(saveSimList(sim, file.path(tmpdir, "sim.rds"), fileBackend = 0),
+                 "fileBackend argument is deprecated")
+})
+
+test_that("the deprecated filebackedDir argument warns", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simToSave()
+  expect_warning(saveSimList(sim, file.path(tmpdir, "sim.rds"), filebackedDir = "x"),
+                 "filebackedDir is deprecated")
+})
+
+test_that("the misnamed fileBackedDir argument is normalised, not an error", {
+  skip_on_cran()
+  testInit()
+
+  ## this used to fail with "object 'filebackedDir' not found": the cleanup
+  ## block referred to a name that is not a formal of saveSimList()
+  sim <- simToSave()
+  expect_warning(saveSimList(sim, file.path(tmpdir, "sim.rds"), fileBackedDir = "x"),
+                 "filebackedDir is deprecated")
+})
+
+test_that("loadSimList can override the sim's paths", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simToSave()
+  f <- file.path(tmpdir, "sim.rds")
+  suppressMessages(saveSimList(sim, f))
+
+  newOut <- checkPath(file.path(tmpdir, "reloadedOutputs"), create = TRUE)
+  out <- suppressMessages(loadSimList(f, paths = list(outputPath = newOut)))
+
+  expect_s4_class(out, "simList")
+  expect_true(any(grepl("reloadedOutputs", unlist(paths(out)))))
+})
+
+test_that("a sim with modules round-trips its metadata", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  ## NOTE: this deliberately stops short of running the reloaded sim.
+  ## saveSimList()/loadSimList() does not currently restore a module's
+  ## functions -- .mods$<module> comes back holding only `mod` and `Par`, so
+  ## spades(loadSimList(f)) fails with "object 'doEvent.<module>' not found".
+  ## saveSimList() does bundle the module source files, so the intent looks to
+  ## be that load re-parses them; that is not implemented. Asserting either
+  ## runnability (fails) or the stripped state (cements the gap) would be
+  ## wrong, so this asserts only the metadata that genuinely survives.
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+  f <- file.path(tmpdir, "withModules.rds")
+  suppressMessages(saveSimList(sim, f))
+
+  out <- suppressMessages(loadSimList(f))
+
+  expect_s4_class(out, "simList")
+  expect_true("randomLandscapes" %in% unlist(modules(out)))
+  expect_identical(as.numeric(end(out)), as.numeric(end(sim)))
+  expect_true(NROW(events(out)) > 0)
+})
+
+test_that("a file-backed raster survives a save/load round trip", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit("terra")
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+
+  ## a raster written to disk, so .dealWithRasterBackends has work to do
+  tf <- file.path(tmpdir, "aRaster.tif")
+  r <- terra::rast(nrows = 10, ncols = 10, vals = seq_len(100))
+  terra::writeRaster(r, tf, overwrite = TRUE)
+  sim$aRaster <- terra::rast(tf)
+
+  f <- file.path(tmpdir, "withRaster.rds")
+  suppressMessages(saveSimList(sim, f))
+
+  out <- suppressMessages(loadSimList(f))
+
+  expect_s4_class(out, "simList")
+  expect_true(inherits(out$aRaster, "SpatRaster"))
+  expect_identical(terra::ncell(out$aRaster), terra::ncell(r))
+  expect_equal(terra::values(out$aRaster), terra::values(r))
+})
+
+## ---- the two ways to use saveSimList() ---------------------------------
+##
+## 1. PORTABLE: save everything -- objects, metadata and the files behind
+##    file-backed objects -- so the simulation can be moved elsewhere.
+##    `projectPath` is the root everything is stored relative to.
+##
+## 2. IN PLACE (metadata only): save the information but not the file bundle,
+##    on the assumption the user still has the original paths. Reload and use
+##    `outputs(sim)` / `outputPath(sim)` to find what the run wrote. This is
+##    the practical choice when a run holds far too many objects to bundle.
+
+test_that("mode 1 (portable): saveSimList bundles file-backed objects into an archive", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  skip_if_not_installed("archive")
+  testInit("terra")
+
+  proj <- checkPath(file.path(tmpdir, "projPortable"), create = TRUE)
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+
+  tf <- file.path(proj, "r.tif")
+  suppressWarnings(terra::writeRaster(
+    terra::rast(nrows = 20, ncols = 20, vals = seq_len(400)), tf, overwrite = TRUE))
+  sim$r <- terra::rast(tf)
+
+  ## passing projectPath must not error -- it used to, for any sim holding a
+  ## file-backed object, because the archiver was not run from projectPath
+  expect_no_error(
+    suppressMessages(saveSimList(sim, file.path(proj, "s.rds"), projectPath = proj))
+  )
+
+  made <- dir(proj, pattern = "^s\\.", full.names = TRUE)
+  expect_length(made, 1L)
+
+  ## both the simList and the raster's backing file are in the archive
+  entries <- archive::archive(made)$path
+  expect_true(any(grepl("s\\.rds$", entries)))
+  expect_true(any(grepl("r\\.tif$", entries)))
+})
+
+test_that("mode 1 (portable): saving does not leave the working directory moved", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit("terra")
+
+  proj <- checkPath(file.path(tmpdir, "projWd"), create = TRUE)
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  tf <- file.path(proj, "r.tif")
+  suppressWarnings(terra::writeRaster(
+    terra::rast(nrows = 10, ncols = 10, vals = seq_len(100)), tf, overwrite = TRUE))
+  sim$r <- terra::rast(tf)
+
+  before <- getwd()
+  suppressMessages(saveSimList(sim, file.path(proj, "s.rds"), projectPath = proj))
+  expect_identical(getwd(), before)
+})
+
+test_that("mode 2 (in place): a metadata save reloads the outputs manifest", {
+  skip_on_cran()
+  testInit()
+
+  proj <- checkPath(file.path(tmpdir, "projInPlace"), create = TRUE)
+  outp <- checkPath(file.path(proj, "outputs"), create = TRUE)
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"),
+                 paths = list(outputPath = outp))
+  sim$bigObject <- 1:10
+  outputs(sim) <- data.frame(objectName = "bigObject", saveTime = 0,
+                             stringsAsFactors = FALSE)
+  ran <- suppressMessages(spades(sim))
+
+  f <- file.path(proj, "meta.rds")
+  suppressMessages(saveSimList(ran, f, projectPath = proj, files = FALSE))
+
+  back <- suppressMessages(loadSimList(f, projectPath = proj))
+
+  ## the point of this mode: the manifest of what the run wrote comes back,
+  ## pointing at files that are still on disk where the run left them
+  expect_identical(NROW(outputs(back)), 1L)
+  expect_identical(outputs(back)$objectName, "bigObject")
+  expect_true(all(file.exists(outputs(back)$file)))
+  expect_true(any(grepl("outputs", outputPath(back))))
+
+  ## and those files are loadable by the user, which is the whole workflow
+  reloaded <- readRDS(outputs(back)$file[1])
+  expect_identical(reloaded, 1:10)
+})
+
+test_that("mode 2 (in place): a metadata save is much smaller than a bundled one", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit("terra")
+
+  proj <- checkPath(file.path(tmpdir, "projSize"), create = TRUE)
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  tf <- file.path(proj, "big.tif")
+  suppressWarnings(terra::writeRaster(
+    terra::rast(nrows = 300, ncols = 300, vals = runif(90000)), tf, overwrite = TRUE))
+  sim$r <- terra::rast(tf)
+
+  bundled <- file.path(proj, "bundled.rds")
+  suppressMessages(saveSimList(sim, bundled, projectPath = proj))
+  bundledFile <- dir(proj, pattern = "^bundled\\.", full.names = TRUE)[1]
+
+  metaOnly <- file.path(proj, "metaOnly.rds")
+  suppressMessages(saveSimList(sim, metaOnly, projectPath = proj, files = FALSE))
+
+  expect_true(file.exists(bundledFile))
+  expect_true(file.exists(metaOnly))
+  expect_lt(file.size(metaOnly), file.size(bundledFile))
+})
+
+test_that("mode 1 (portable): a sim moved to a new location keeps its file-backed objects", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  skip_if_not_installed("archive")
+  testInit("terra")
+
+  ## The wrap machinery re-roots a file-backed object by recording WHICH named
+  ## path it sits under (relToWhere) plus its name relative to that path. So a
+  ## portable save requires the backing file to live under one of the sim's
+  ## paths -- here outputPath. A file outside every named path gets an empty
+  ## relToWhere and cannot be re-rooted; see the note in the test below.
+  projA <- checkPath(file.path(tmpdir, "projA"), create = TRUE)
+  outp <- checkPath(file.path(projA, "outputs"), create = TRUE)
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"),
+                 paths = list(outputPath = outp,
+                              cachePath = file.path(projA, "cache")))
+  tf <- file.path(outp, "r.tif")
+  suppressWarnings(terra::writeRaster(
+    terra::rast(nrows = 20, ncols = 20, vals = seq_len(400)), tf, overwrite = TRUE))
+  sim$r <- terra::rast(tf)
+
+  suppressMessages(saveSimList(sim, file.path(projA, "s.rds"), projectPath = projA))
+  made <- dir(projA, pattern = "^s\\.", full.names = TRUE)[1]
+
+  ## the archive keeps the file under its named-path directory
+  expect_true(any(grepl("outputs/r\\.tif$", archive::archive(made)$path)))
+
+  ## move the archive somewhere else and destroy the original entirely
+  projB <- checkPath(file.path(tmpdir, "projB"), create = TRUE)
+  file.copy(made, file.path(projB, basename(made)))
+  unlink(projA, recursive = TRUE)
+
+  out <- suppressMessages(loadSimList(file.path(projB, basename(made)),
+                                      projectPath = projB))
+
+  expect_s4_class(out, "simList")
+  expect_true(inherits(out$r, "SpatRaster"))
+  expect_equal(as.numeric(terra::values(out$r)), as.numeric(seq_len(400)))
+})

--- a/tests/testthat/test-scheduleConditionalEvent.R
+++ b/tests/testthat/test-scheduleConditionalEvent.R
@@ -1,0 +1,281 @@
+## scheduleConditionalEvent() -- argument validation and the condition forms.
+
+condSim <- function(end = 5) {
+  simInit(times = list(start = 0, end = end, timeunit = "year"))
+}
+
+test_that("scheduleConditionalEvent demands a simList", {
+  testInit()
+
+  expect_error(
+    scheduleConditionalEvent(list(), condition = quote(TRUE),
+                             moduleName = "m", eventType = "e"),
+    "sim must be a simList"
+  )
+})
+
+test_that("scheduleConditionalEvent rejects a non-numeric minEventTime", {
+  testInit()
+
+  expect_error(
+    scheduleConditionalEvent(condSim(), condition = quote(time(sim) > 1),
+                             moduleName = "m", eventType = "e",
+                             minEventTime = "soon"),
+    "Invalid or missing minEventTime"
+  )
+})
+
+test_that("scheduleConditionalEvent rejects a non-numeric maxEventTime", {
+  testInit()
+
+  expect_error(
+    scheduleConditionalEvent(condSim(), condition = quote(time(sim) > 1),
+                             moduleName = "m", eventType = "e",
+                             maxEventTime = "later"),
+    "Invalid or missing maxEventTime"
+  )
+})
+
+test_that("scheduleConditionalEvent rejects non-character eventType and moduleName", {
+  testInit()
+
+  expect_error(
+    scheduleConditionalEvent(condSim(), condition = quote(time(sim) > 1),
+                             moduleName = "m", eventType = 99),
+    "eventType must be a character"
+  )
+  expect_error(
+    scheduleConditionalEvent(condSim(), condition = quote(time(sim) > 1),
+                             moduleName = 99, eventType = "e"),
+    "moduleName must be a character"
+  )
+})
+
+test_that("scheduleConditionalEvent rejects a non-numeric eventPriority", {
+  testInit()
+
+  expect_error(
+    scheduleConditionalEvent(condSim(), condition = quote(time(sim) > 1),
+                             moduleName = "m", eventType = "e",
+                             eventPriority = "high"),
+    "eventPriority must be a numeric"
+  )
+})
+
+test_that("scheduleConditionalEvent rejects a condition that is not a call, string or expression", {
+  testInit()
+
+  expect_error(
+    scheduleConditionalEvent(condSim(), condition = 42,
+                             moduleName = "m", eventType = "e"),
+    "condition must be a character string or call or expression"
+  )
+})
+
+test_that("scheduleConditionalEvent warns on an empty condition", {
+  testInit()
+
+  expect_warning(
+    scheduleConditionalEvent(condSim(), condition = NULL,
+                             moduleName = "m", eventType = "e"),
+    "Invalid or missing condition"
+  )
+})
+
+test_that("scheduleConditionalEvent accepts a call, a string and an expression", {
+  testInit()
+
+  forms <- list(quote(time(sim) > 1), "time(sim) > 1", expression(time(sim) > 1))
+
+  for (cond in forms) {
+    sim <- scheduleConditionalEvent(condSim(), condition = cond,
+                                    moduleName = "m", eventType = "e")
+    ce <- conditionalEvents(sim)
+    expect_identical(NROW(ce), 1L)
+    expect_identical(ce$moduleName, "m")
+    expect_identical(ce$eventType, "e")
+  }
+})
+
+test_that("scheduleConditionalEvent records min and max event times", {
+  testInit()
+
+  sim <- scheduleConditionalEvent(condSim(end = 10), condition = quote(time(sim) > 1),
+                                  moduleName = "m", eventType = "e",
+                                  minEventTime = 2, maxEventTime = 6)
+  ce <- conditionalEvents(sim)
+
+  expect_identical(as.numeric(ce$minEventTime), 2)
+  expect_identical(as.numeric(ce$maxEventTime), 6)
+})
+
+test_that("scheduleConditionalEvent appends further events to the queue", {
+  testInit()
+
+  sim <- condSim(end = 10)
+  sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) > 1),
+                                  moduleName = "modA", eventType = "a",
+                                  minEventTime = 1)
+  sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) > 2),
+                                  moduleName = "modB", eventType = "b",
+                                  minEventTime = 2)
+
+  ce <- conditionalEvents(sim)
+  expect_identical(NROW(ce), 2L)
+  expect_setequal(ce$moduleName, c("modA", "modB"))
+})
+
+test_that("scheduleConditionalEvent orders the queue by minEventTime", {
+  testInit()
+
+  ## add the later event first, so the queue must be re-sorted
+  sim <- condSim(end = 10)
+  sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) > 5),
+                                  moduleName = "later", eventType = "b",
+                                  minEventTime = 5)
+  sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) > 1),
+                                  moduleName = "earlier", eventType = "a",
+                                  minEventTime = 1)
+
+  ce <- conditionalEvents(sim)
+  expect_identical(NROW(ce), 2L)
+  expect_false(is.unsorted(as.numeric(ce$minEventTime)))
+})
+
+## ---- firing semantics, driven through spades() -------------------------
+##
+## NOTE: defineEvent() clears the event function's enclosing environment (its
+## parent is the SpaDES.core namespace), so event code cannot see locals of a
+## helper that built the sim. Anything the code needs must live on the sim, and
+## the rest is written as literals.
+
+test_that("a conditional event fires when minEventTime is not zero", {
+  skip_on_cran()
+  testInit()
+
+  ## minEventTime/maxEventTime are stored in seconds; comparing them against
+  ## time(sim), which is in the sim's timeunit, meant these never fired at all
+  sim <- simInit(times = list(start = 0, end = 6, timeunit = "year"))
+  sim$fired <- 0L
+  defineEvent(sim, "condEv", moduleName = "cm", code = { sim$fired <- sim$fired + 1L })
+  defineEvent(sim, "filler", moduleName = "cm", code = {
+    sim <- scheduleEvent(sim, time(sim) + 1, "cm", "filler")
+  })
+  sim <- scheduleEvent(sim, 0, "cm", "filler")
+  sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) >= 0),
+                                  moduleName = "cm", eventType = "condEv",
+                                  minEventTime = 2, maxEventTime = 5)
+
+  out <- suppressMessages(spades(sim))
+
+  expect_identical(out$fired, 1L)
+  expect_false(exists("._conditionalEvents", envir = out, inherits = FALSE))
+})
+
+test_that("a conditional event does not fire past its maxEventTime", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 6, timeunit = "year"))
+  sim$fired <- 0L
+  defineEvent(sim, "condEv", moduleName = "cm", code = { sim$fired <- sim$fired + 1L })
+  defineEvent(sim, "filler", moduleName = "cm", code = {
+    sim <- scheduleEvent(sim, time(sim) + 1, "cm", "filler")
+  })
+  sim <- scheduleEvent(sim, 0, "cm", "filler")
+  ## window opens after the sim has already ended
+  sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) >= 0),
+                                  moduleName = "cm", eventType = "condEv",
+                                  minEventTime = 10, maxEventTime = 12)
+
+  out <- suppressMessages(spades(sim))
+
+  expect_identical(out$fired, 0L)
+})
+
+test_that("a conditional event never runs twice in a row", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 3, timeunit = "year"))
+  sim$fired <- 0L
+  ## re-arms itself every run, which previously looped forever at one timestep
+  defineEvent(sim, "condEv", moduleName = "cm", code = {
+    sim$fired <- sim$fired + 1L
+    if (sim$fired < 8L)
+      sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) >= 0),
+                                      moduleName = "cm", eventType = "condEv",
+                                      minEventTime = 0, maxEventTime = 3)
+  })
+  defineEvent(sim, "filler", moduleName = "cm", code = {
+    sim <- scheduleEvent(sim, time(sim) + 1, "cm", "filler")
+  })
+  sim <- scheduleEvent(sim, 0, "cm", "filler")
+  sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) >= 0),
+                                  moduleName = "cm", eventType = "condEv",
+                                  minEventTime = 0, maxEventTime = 3)
+
+  out <- suppressMessages(spades(sim))
+  cmp <- completed(out)
+  ev <- paste0(cmp$moduleName, ".", cmp$eventType)
+
+  expect_gt(out$fired, 0L)
+  backToBack <- sum(ev[-1] == "cm.condEv" & ev[-length(ev)] == "cm.condEv")
+  expect_identical(backToBack, 0L)
+})
+
+test_that("a conditional event jumps the queue and runs at the current time", {
+  skip_on_cran()
+  testInit()
+
+  ## a conditional event does not wait its turn: once its condition is true it
+  ## is scheduled at the current time, which puts it at the head of the queue
+  ## ahead of work already scheduled for later
+  sim <- simInit(times = list(start = 0, end = 5, timeunit = "year"))
+  sim$firedAt <- numeric(0)
+  defineEvent(sim, "condEv", moduleName = "cm", code = {
+    sim$firedAt <- c(sim$firedAt, as.numeric(time(sim)))
+  })
+  defineEvent(sim, "later", moduleName = "cm", code = { sim })
+  defineEvent(sim, "trigger", moduleName = "cm", code = { sim$ready <- TRUE })
+
+  for (tt in c(2, 3, 4)) sim <- scheduleEvent(sim, tt, "cm", "later")
+  sim <- scheduleEvent(sim, 1, "cm", "trigger")
+  sim$ready <- FALSE
+  sim <- scheduleConditionalEvent(sim, condition = quote(isTRUE(sim$ready)),
+                                  moduleName = "cm", eventType = "condEv",
+                                  minEventTime = 0, maxEventTime = 5)
+
+  out <- suppressMessages(spades(sim))
+  cmp <- completed(out)
+  ev <- paste0(cmp$moduleName, ".", cmp$eventType)
+
+  ## it ran at t = 1, the moment the condition became true ...
+  expect_identical(out$firedAt, 1)
+  ## ... i.e. immediately after the trigger and before the t = 2 event
+  expect_identical(which(ev == "cm.condEv"), which(ev == "cm.trigger") + 1L)
+})
+
+test_that("a conditional event whose condition stays false never fires", {
+  skip_on_cran()
+  testInit()
+
+  ## a false condition leaves the entry armed, re-checked after every event
+  sim <- simInit(times = list(start = 0, end = 3, timeunit = "year"))
+  sim$fired <- 0L
+  defineEvent(sim, "condEv", moduleName = "cm", code = { sim$fired <- sim$fired + 1L })
+  defineEvent(sim, "filler", moduleName = "cm", code = {
+    sim <- scheduleEvent(sim, time(sim) + 1, "cm", "filler")
+  })
+  sim <- scheduleEvent(sim, 0, "cm", "filler")
+  sim <- scheduleConditionalEvent(sim, condition = quote(isTRUE(sim$neverSet)),
+                                  moduleName = "cm", eventType = "condEv",
+                                  minEventTime = 0, maxEventTime = 3)
+
+  out <- suppressMessages(spades(sim))
+
+  expect_identical(out$fired, 0L)
+  ## still armed, waiting for a condition that never came true
+  expect_true(exists("._conditionalEvents", envir = out, inherits = FALSE))
+  expect_length(out$._conditionalEvents, 1L)
+})

--- a/tests/testthat/test-setupDebugger.R
+++ b/tests/testthat/test-setupDebugger.R
@@ -1,0 +1,99 @@
+## setupDebugger() is internal; these drive it directly rather than through spades(),
+## which only ever calls it with a list (see `useLoggingPkg <- is.list(debug)`).
+
+setupDebugger <- SpaDES.core:::setupDebugger
+
+test_that("setupDebugger passes FALSE straight through", {
+  testInit()
+
+  expect_false(setupDebugger(debug = FALSE))
+})
+
+test_that("setupDebugger with no argument returns the spades.debug option untouched", {
+  testInit()
+
+  withr::local_options(list(spades.debug = 42))
+  expect_identical(setupDebugger(), 42)
+})
+
+test_that("setupDebugger returns the list's `debug` element when one is given", {
+  testInit()
+  skip_if_not_installed("logging")
+  withr::defer(logging::logReset())
+
+  expect_identical(setupDebugger(debug = list(debug = 2)), 2)
+})
+
+test_that("setupDebugger defaults to debug level 1 when the list has no `debug` element", {
+  testInit()
+  skip_if_not_installed("logging")
+  withr::defer(logging::logReset())
+
+  expect_identical(setupDebugger(debug = list(console = list(level = "INFO"))), 1)
+})
+
+test_that("setupDebugger rejects an unnamed list", {
+  testInit()
+  skip_if_not_installed("logging")
+  withr::defer(logging::logReset())
+
+  expect_error(setupDebugger(debug = list(1, 2)), "named list")
+})
+
+test_that("setupDebugger rejects a `console` element that is not a list", {
+  testInit()
+  skip_if_not_installed("logging")
+  withr::defer(logging::logReset())
+
+  expect_error(setupDebugger(debug = list(console = "DEBUG")),
+               "not a list")
+})
+
+test_that("setupDebugger adds a console handler for a non-INFO level", {
+  testInit()
+  skip_if_not_installed("logging")
+  withr::defer(logging::logReset())
+
+  logging::logReset()
+  setupDebugger(debug = list(console = list(level = "DEBUG")))
+
+  expect_true(any(grepl("writeToConsole", names(logging::getLogger()[["handlers"]]))))
+})
+
+test_that("setupDebugger leaves the console alone at INFO level", {
+  testInit()
+  skip_if_not_installed("logging")
+  withr::defer(logging::logReset())
+
+  logging::logReset()
+  setupDebugger(debug = list(console = list(level = "INFO")))
+
+  expect_false(any(grepl("writeToConsole", names(logging::getLogger()[["handlers"]]))))
+})
+
+test_that("setupDebugger adds a file handler and writes a banner to the log file", {
+  testInit()
+  skip_if_not_installed("logging")
+  withr::defer(logging::logReset())
+
+  logging::logReset()
+  logFile <- tempfile(fileext = ".txt")
+
+  setupDebugger(debug = list(file = list(file = logFile, level = "INFO")))
+
+  expect_true(any(grepl("writeToFile", names(logging::getLogger()[["handlers"]]))))
+  expect_true(file.exists(logFile))
+  expect_match(paste(readLines(logFile), collapse = "\n"), "#####")
+})
+
+test_that("setupDebugger's file handler defaults its level when none is supplied", {
+  testInit()
+  skip_if_not_installed("logging")
+  withr::defer(logging::logReset())
+
+  logging::logReset()
+  logFile <- tempfile(fileext = ".txt")
+
+  expect_identical(setupDebugger(debug = list(file = list(file = logFile))), 1)
+  expect_true(file.exists(logFile))
+})

--- a/tests/testthat/test-simList-accessors-sweep.R
+++ b/tests/testthat/test-simList-accessors-sweep.R
@@ -1,0 +1,321 @@
+## A sweep over the simList accessors and their replacement counterparts.
+## Deliberately table-driven: these are many small methods, each with only a
+## line or two of body, and covering them one test_that() at a time would be
+## mostly boilerplate.
+
+test_that("path accessors round-trip through their replacement methods", {
+  testInit()
+
+  sim <- simInit()
+
+  pathAccessors <- c("cachePath", "outputPath", "rasterPath", "scratchPath",
+                     "terraPath", "modulePath", "inputPath")
+
+  for (a in pathAccessors) {
+    getter <- get(a)
+    setter <- get(paste0(a, "<-"))
+
+    orig <- getter(sim)
+    expect_true(is.character(orig), info = a)
+
+    newVal <- file.path(tempdir(), paste0("swept-", a))
+    sim <- setter(sim, value = newVal)
+
+    expect_true(any(grepl(paste0("swept-", a), getter(sim))), info = a)
+  }
+})
+
+test_that("paths() returns all the individual paths", {
+  testInit()
+
+  sim <- simInit()
+  p <- paths(sim)
+
+  expect_true(is.list(p))
+  expect_true(all(c("modulePath", "inputPath", "outputPath", "cachePath") %in% names(p)))
+  expect_identical(normPath(p$outputPath), normPath(outputPath(sim)))
+})
+
+test_that("paths<- sets the paths as a group", {
+  testInit()
+
+  sim <- simInit()
+  newOut <- file.path(tempdir(), "sweptGroupOutputs")
+  paths(sim) <- list(outputPath = newOut)
+
+  expect_true(any(grepl("sweptGroupOutputs", outputPath(sim))))
+})
+
+test_that("checkpoint and progress scalars round-trip", {
+  testInit()
+
+  sim <- simInit()
+
+  checkpointFile(sim) <- "chk.rds"
+  expect_identical(basename(checkpointFile(sim)), "chk.rds")
+
+  checkpointInterval(sim) <- 5
+  expect_identical(as.numeric(checkpointInterval(sim)), 5)
+
+  progressInterval(sim) <- 2
+  expect_identical(as.numeric(progressInterval(sim)), 2)
+
+  progressType(sim) <- "text"
+  expect_identical(progressType(sim), "text")
+})
+
+test_that("globals and its G alias are the same accessor", {
+  testInit()
+
+  sim <- simInit()
+
+  globals(sim) <- list(aGlobal = 42)
+  expect_identical(globals(sim)$aGlobal, 42)
+  expect_identical(G(sim)$aGlobal, 42)
+
+  G(sim) <- list(aGlobal = 43)
+  expect_identical(globals(sim)$aGlobal, 43)
+})
+
+test_that("objs and objs<- read and write the sim environment", {
+  testInit()
+
+  sim <- simInit()
+  objs(sim) <- list(anObject = 1:3)
+
+  expect_true("anObject" %in% names(objs(sim)))
+  expect_identical(objs(sim)$anObject, 1:3)
+  expect_identical(sim$anObject, 1:3)
+})
+
+test_that("envir and envir<- expose the sim environment", {
+  testInit()
+
+  sim <- simInit()
+  expect_true(is.environment(envir(sim)))
+
+  e <- new.env()
+  e$fromNewEnv <- "yes"
+  envir(sim) <- e
+  expect_identical(sim$fromNewEnv, "yes")
+})
+
+test_that("times and its component accessors round-trip", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 10, timeunit = "year"))
+
+  tt <- times(sim)
+  expect_true(all(c("current", "start", "end", "timeunit") %in% names(tt)))
+
+  end(sim) <- 20
+  expect_identical(as.numeric(end(sim)), 20)
+
+  start(sim) <- 2
+  expect_identical(as.numeric(start(sim)), 2)
+
+  time(sim) <- 3
+  expect_identical(as.numeric(time(sim)), 3)
+
+  timeunit(sim) <- "day"
+  expect_identical(timeunit(sim), "day")
+})
+
+test_that("times<- sets all three times at once", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 10, timeunit = "year"))
+  times(sim) <- list(current = 1, start = 1, end = 5, timeunit = "year")
+
+  expect_identical(as.numeric(start(sim)), 1)
+  expect_identical(as.numeric(end(sim)), 5)
+})
+
+test_that("events, current and completed expose the event queues", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim <- scheduleEvent(sim, 0, "someModule", "someEvent")
+
+  expect_true(is.data.frame(events(sim)) || data.table::is.data.table(events(sim)))
+  expect_true("someModule" %in% events(sim)$moduleName)
+
+  expect_true(NROW(completed(sim)) == 0)
+
+  cur <- current(sim)
+  expect_true(NROW(cur) == 0 || is.data.frame(cur))
+})
+
+test_that("current<- sets the current event", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim <- scheduleEvent(sim, 0, "someModule", "someEvent")
+
+  ## events() is priority-sorted, so pick our row explicitly rather than row 1
+  ours <- events(sim)[events(sim)$moduleName == "someModule", ][1, ]
+  current(sim) <- ours
+  expect_true("someModule" %in% current(sim)$moduleName)
+})
+
+test_that("params and parameters expose module parameters", {
+  testInit()
+
+  sim <- simInit()
+
+  params(sim) <- list(myMod = list(aParam = 7))
+  expect_identical(params(sim)$myMod$aParam, 7)
+
+  ## parameters() reports declared module metadata; with no modules loaded
+  ## there is none, so it is NULL
+  expect_null(parameters(sim))
+})
+
+test_that("P and P<- read and write a module's parameters", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  ## P.simList resolves the module directory, so this needs a real module
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+
+  allP <- P(sim, module = "randomLandscapes")
+  expect_true("nx" %in% names(allP))
+  expect_identical(P(sim, param = "nx", module = "randomLandscapes"), allP$nx)
+
+  P(sim, param = "nx", module = "randomLandscapes") <- 42
+  expect_identical(P(sim, param = "nx", module = "randomLandscapes"), 42)
+})
+
+test_that("inputs and outputs round-trip", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+
+  expect_true(is.data.frame(inputs(sim)))
+  expect_true(is.data.frame(outputs(sim)))
+
+  f <- tempfile(fileext = ".rds")
+  outputs(sim) <- data.frame(objectName = "anObject", file = f,
+                             saveTime = 0, stringsAsFactors = FALSE)
+
+  expect_true("anObject" %in% outputs(sim)$objectName)
+})
+
+test_that("inputArgs reports the arguments used to build the sim", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  expect_true(is.list(inputArgs(sim)) || is.null(inputArgs(sim)))
+})
+
+test_that("modules and depends expose the loaded modules", {
+  testInit()
+
+  sim <- simInit()
+  expect_true(is.list(modules(sim)) || is.character(modules(sim)))
+  expect_s4_class(depends(sim), ".simDeps")
+})
+
+test_that("conditionalEvents lists events scheduled on a condition", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 5, timeunit = "year"))
+
+  ## no conditional events yet
+  expect_true(NROW(conditionalEvents(sim)) == 0)
+
+  sim <- scheduleConditionalEvent(sim, condition = quote(time(sim) > 2),
+                                  moduleName = "someModule",
+                                  eventType = "conditionalEvent")
+
+  expect_true(NROW(conditionalEvents(sim)) >= 1)
+  expect_true("someModule" %in% conditionalEvents(sim)$moduleName)
+})
+
+test_that("elapsedTime summarises event timings after a run", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+  out <- suppressMessages(spades(sim))
+
+  byEvent <- elapsedTime(out)
+  expect_true(NROW(byEvent) > 0)
+
+  byModule <- elapsedTime(out, byEvent = FALSE)
+  expect_true(NROW(byModule) > 0)
+  expect_true(NROW(byModule) <= NROW(byEvent))
+
+  inSecs <- elapsedTime(out, units = "secs")
+  expect_true(NROW(inSecs) > 0)
+})
+
+test_that("moduleObjects reports a module's declared inputs and outputs", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+
+  mo <- moduleObjects(module = "randomLandscapes", path = mp)
+
+  expect_true(is.data.frame(mo))
+  expect_true(NROW(mo) > 0)
+  expect_true(all(c("objectName", "module", "type", "objectClass") %in% names(mo)))
+  expect_setequal(unique(mo$type), c("input", "output"))
+})
+
+test_that("moduleObjects works from a simList too", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+
+  mo <- moduleObjects(sim, module = "randomLandscapes")
+  expect_true(is.data.frame(mo))
+  expect_true(NROW(mo) > 0)
+})
+
+test_that("metadata accessors read a module's declared metadata", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+
+  expect_true(is.list(reqdPkgs(sim)) || is.character(reqdPkgs(sim)))
+  expect_true(is.list(documentation(sim)) || is.character(documentation(sim)) ||
+                is.null(documentation(sim)))
+  expect_true(is.list(citation(sim)) || is.character(citation(sim)) ||
+                inherits(citation(sim), "citation"))
+  expect_true(is.character(packages(sim)) || is.list(packages(sim)) ||
+                is.null(packages(sim)))
+})
+
+test_that("reqdPkgs can be read straight from a module on disk", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  rp <- reqdPkgs(module = "randomLandscapes", modulePath = mp)
+
+  expect_true(is.list(rp) || is.character(rp))
+})

--- a/tests/testthat/test-simList-show.R
+++ b/tests/testthat/test-simList-show.R
@@ -1,0 +1,192 @@
+## The `show` method for simList prints a fixed set of sections. These assert
+## that each section carries its actual content -- names AND values -- not just
+## that a heading was printed.
+
+showLines <- function(x) capture.output(show(x))
+
+## text of one ">> <name>:" section, up to the next section heading
+showSection <- function(out, name) {
+  heads <- grep("^>>", out)
+  i <- grep(paste0("^>> ", name), out)
+  expect_length(i, 1L)
+  nxt <- heads[heads > i]
+  to <- if (length(nxt)) nxt[1] - 1L else length(out)
+  paste(out[(i + 1L):to], collapse = "\n")
+}
+
+modSim <- function(tmpdir, end = 1) {
+  mp <- getSampleModules(tmpdir)
+  suppressMessages(
+    simInit(times = list(start = 0, end = end, timeunit = "year"),
+            modules = list("randomLandscapes"),
+            paths = list(modulePath = mp))
+  )
+}
+
+test_that("show prints every section of a simList", {
+  testInit()
+
+  out <- showLines(simInit())
+
+  expect_setequal(
+    grep("^>>", out, value = TRUE),
+    c(">> Simulation dependencies:", ">> Simulation times:", ">> Modules:",
+      ">> Objects Loaded:", ">> Objects stored:", ">> Parameters:",
+      ">> Completed Events:", ">> Current Event:", ">> Scheduled Events:")
+  )
+})
+
+test_that("show works on a bare simList", {
+  testInit()
+
+  expect_silent(out <- showLines(new("simList")))
+  expect_true(any(grepl(">> Simulation times:", out)))
+})
+
+test_that("print dispatches to the show method", {
+  testInit()
+
+  sim <- simInit()
+  expect_identical(capture.output(print(sim)), showLines(sim))
+})
+
+test_that("show points the user at depends() for module dependencies", {
+  testInit()
+
+  txt <- showSection(showLines(simInit()), "Simulation dependencies")
+  expect_match(txt, "depends(sim)", fixed = TRUE)
+})
+
+test_that("show reports the actual start, end, current and timeunit", {
+  testInit()
+
+  sim <- simInit(times = list(start = 2, end = 7, timeunit = "day"))
+  txt <- showSection(showLines(sim), "Simulation times")
+
+  ## column labels ...
+  expect_match(txt, "current")
+  expect_match(txt, "start")
+  expect_match(txt, "end")
+  ## ... and the values themselves, on one row
+  valueRow <- grep("day", strsplit(txt, "\n")[[1]], value = TRUE)
+  expect_length(valueRow, 1L)
+  expect_match(valueRow, "\\b2\\b")
+  expect_match(valueRow, "\\b7\\b")
+})
+
+test_that("show lists each loaded module with its timeunit", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  txt <- showSection(showLines(modSim(tmpdir)), "Modules")
+
+  expect_match(txt, "Name")
+  expect_match(txt, "Timeunit")
+  ## the module and its timeunit must appear together on one row
+  modRow <- grep("randomLandscapes", strsplit(txt, "\n")[[1]], value = TRUE)
+  expect_length(modRow, 1L)
+  expect_match(modRow, "year")
+})
+
+test_that("show lists stored objects with their names and types", {
+  testInit()
+
+  sim <- simInit()
+  sim$anEagerObject <- 1:5
+  sim$aCharacterObject <- "hello"
+
+  txt <- showSection(showLines(sim), "Objects stored")
+
+  ## ls.str() prints "name : type spec", so both name and type must show
+  expect_match(txt, "anEagerObject")
+  expect_match(txt, "int")
+  expect_match(txt, "aCharacterObject")
+  expect_match(txt, "chr")
+})
+
+test_that("show flags lazily bound objects by name, separately from eager ones", {
+  testInit()
+
+  sim <- simInit()
+  sim$anEagerObject <- 1:5
+  delayedAssign("aLazyObject", 1:5, assign.env = envir(sim))
+
+  txt <- showSection(showLines(sim), "Objects stored")
+
+  lazyLine <- grep("Lazy (not yet loaded)", strsplit(txt, "\n")[[1]],
+                   fixed = TRUE, value = TRUE)
+  expect_length(lazyLine, 1L)
+  expect_match(lazyLine, "aLazyObject")
+  ## the eager object must NOT be on the lazy line
+  expect_false(grepl("anEagerObject", lazyLine, fixed = TRUE))
+  ## but must still be listed
+  expect_match(txt, "anEagerObject")
+})
+
+test_that("show prints each parameter's module, name and value together", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  txt <- showSection(showLines(modSim(tmpdir)), "Parameters")
+  rows <- strsplit(txt, "\n")[[1]]
+
+  expect_match(txt, "Module")
+  expect_match(txt, "Parameter")
+  expect_match(txt, "Value")
+
+  ## a known parameter of the sample module, with its declared default
+  nxRow <- grep("\\bnx\\b", rows, value = TRUE)
+  expect_length(nxRow, 1L)
+  expect_match(nxRow, "randomLandscapes")
+  expect_match(nxRow, "100")
+
+  stackRow <- grep("stackName", rows, value = TRUE)
+  expect_length(stackRow, 1L)
+  expect_match(stackRow, "landscape")
+
+  ## the .progress core module is deliberately filtered out of this table
+  expect_false(any(grepl("\\.progress", rows)))
+})
+
+test_that("show reports scheduled events with module, type and time", {
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim <- scheduleEvent(sim, 0, "someModule", "someEvent")
+
+  txt <- showSection(showLines(sim), "Scheduled Events")
+  ourRow <- grep("someModule", strsplit(txt, "\n")[[1]], value = TRUE)
+
+  expect_length(ourRow, 1L)
+  expect_match(ourRow, "someEvent")
+})
+
+test_that("show reports completed events with their modules and types after a run", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  out <- suppressMessages(spades(modSim(tmpdir)))
+  txt <- showSection(showLines(out), "Completed Events")
+  rows <- strsplit(txt, "\n")[[1]]
+
+  expect_match(txt, "moduleName")
+  expect_match(txt, "eventType")
+
+  ## the module actually ran its init, and that is visible here
+  initRow <- grep("randomLandscapes.*\\binit\\b", rows, value = TRUE)
+  expect_gte(length(initRow), 1L)
+
+  ## and the completed table shown matches what completed() holds
+  expect_true(all(unique(completed(out)$moduleName) |>
+                    vapply(function(m) any(grepl(m, rows)), logical(1))))
+})
+
+test_that("show reports an empty scheduled-events queue once the run is done", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  out <- suppressMessages(spades(modSim(tmpdir)))
+  txt <- showSection(showLines(out), "Scheduled Events")
+
+  expect_match(txt, "0 rows")
+})

--- a/tests/testthat/test-times-conversion.R
+++ b/tests/testthat/test-times-conversion.R
@@ -1,0 +1,244 @@
+## Unit arithmetic in times.R: inSeconds(), convertTimeunit(), checkTimeunit(),
+## and the min/max timeunit accessors.
+
+inSeconds <- SpaDES.core:::inSeconds
+convertTimeunit <- SpaDES.core:::convertTimeunit
+.getTU <- SpaDES.core:::.getTU
+
+test_that("inSeconds knows every built-in time unit, singular and plural", {
+  testInit()
+
+  e <- new.env()
+  expect_identical(as.numeric(inSeconds("second", e)), 1)
+  expect_identical(as.numeric(inSeconds("seconds", e)), 1)
+  expect_identical(as.numeric(inSeconds("hour", e)), as.numeric(inSeconds("hours", e)))
+  expect_identical(as.numeric(inSeconds("day", e)), as.numeric(inSeconds("days", e)))
+  expect_identical(as.numeric(inSeconds("week", e)), as.numeric(inSeconds("weeks", e)))
+  expect_identical(as.numeric(inSeconds("month", e)), as.numeric(inSeconds("months", e)))
+  expect_identical(as.numeric(inSeconds("year", e)), as.numeric(inSeconds("years", e)))
+})
+
+test_that("inSeconds orders the units correctly", {
+  testInit()
+
+  e <- new.env()
+  secs <- vapply(c("second", "hour", "day", "week", "month", "year"),
+                 function(u) as.numeric(inSeconds(u, e)), numeric(1))
+  expect_false(is.unsorted(secs))
+})
+
+test_that("inSeconds resolves a user-defined unit from the environment", {
+  testInit()
+
+  e <- new.env()
+  e$dfortnight <- function(x) x * 60 * 60 * 24 * 14
+
+  expect_identical(as.numeric(inSeconds("fortnight", e)), 1209600)
+})
+
+test_that("inSeconds treats a missing or NA unit as zero", {
+  testInit()
+
+  e <- new.env()
+  expect_identical(as.numeric(inSeconds(NA_character_, e)), 0)
+  expect_identical(as.numeric(inSeconds(NULL, e)), 0)
+})
+
+test_that("inSeconds rejects a non-character unit", {
+  testInit()
+
+  expect_error(inSeconds(1, new.env()), "unit must be a character")
+})
+
+test_that("checkTimeunit accepts the built-in units", {
+  testInit()
+
+  e <- new.env()
+  expect_true(all(checkTimeunit("year", e)))
+  expect_true(all(checkTimeunit(c("year", "day"), e)))
+})
+
+test_that("checkTimeunit rejects an unknown unit, with a warning", {
+  testInit()
+
+  e <- new.env()
+  expect_warning(res <- checkTimeunit("bogus", e), "unknown timeunit provided")
+  expect_false(all(res))
+})
+
+test_that("checkTimeunit reports per-unit results for a vector", {
+  testInit()
+
+  e <- new.env()
+  suppressWarnings(res <- checkTimeunit(c("year", "bogus"), e))
+  expect_identical(unname(res), c(TRUE, FALSE))
+})
+
+test_that("checkTimeunit accepts a user-defined unit function", {
+  testInit()
+
+  e <- new.env()
+  e$dfortnight <- function(x) x * 60 * 60 * 24 * 14
+  expect_true(all(checkTimeunit("fortnight", e)))
+})
+
+test_that("convertTimeunit converts between units", {
+  testInit()
+
+  e <- new.env()
+  oneYear <- 1
+  attr(oneYear, "unit") <- "year"
+
+  inSecs <- convertTimeunit(oneYear, "second", e)
+  expect_identical(attr(inSecs, "unit"), "second")
+  expect_identical(as.numeric(inSecs), as.numeric(inSeconds("year", e)))
+})
+
+test_that("convertTimeunit round-trips", {
+  testInit()
+
+  e <- new.env()
+  t0 <- 3
+  attr(t0, "unit") <- "day"
+
+  there <- convertTimeunit(t0, "second", e)
+  back <- convertTimeunit(there, "day", e)
+
+  expect_equal(as.numeric(back), 3)
+  expect_identical(attr(back, "unit"), "day")
+})
+
+test_that("convertTimeunit is a no-op when the unit already matches", {
+  testInit()
+
+  e <- new.env()
+  t0 <- 5
+  attr(t0, "unit") <- "year"
+
+  out <- convertTimeunit(t0, "year", e)
+  expect_identical(as.numeric(out), 5)
+  expect_identical(attr(out, "unit"), "year")
+})
+
+test_that("convertTimeunit converts between two non-second units", {
+  testInit()
+
+  ## Values below .pkgEnv$nUnitConversions take a lookup-table fast path and
+  ## larger ones do not, so exercise both. Expectations come from inSeconds()
+  ## rather than assuming a week is 7 days -- in SpaDES a week is a year/52,
+  ## i.e. ~7.024 days.
+  e <- new.env()
+
+  for (v in c(14, 20000)) {          # fast path, then slow path
+    t0 <- v
+    attr(t0, "unit") <- "day"
+
+    out <- convertTimeunit(t0, "week", e)
+    expected <- v * as.numeric(inSeconds("day", e)) / as.numeric(inSeconds("week", e))
+    expect_equal(as.numeric(out), expected, tolerance = 1e-5)
+    expect_identical(attr(out, "unit"), "week")
+  }
+})
+
+test_that("convertTimeunit agrees across the lookup-table boundary", {
+  testInit()
+
+  ## the fast path (small whole numbers) must give the same answer as the
+  ## general arithmetic, for every pair of units
+  e <- new.env()
+  units <- c("year", "month", "week", "day", "hour", "second")
+
+  for (from in units) {
+    for (to in units) {
+      t0 <- 3
+      attr(t0, "unit") <- from
+      out <- convertTimeunit(t0, to, e)
+      expected <- 3 * as.numeric(inSeconds(from, e)) / as.numeric(inSeconds(to, e))
+      expect_equal(as.numeric(out), expected, tolerance = 1e-5,
+                   info = paste(from, "->", to))
+      expect_identical(attr(out, "unit"), to, info = paste(from, "->", to))
+    }
+  }
+})
+
+test_that("convertTimeunit converts to and from seconds, the shape simtimes rely on", {
+  testInit()
+
+  ## the fast path reads a lookup table that zzz.R rounds to whole seconds, so
+  ## results can differ from the exact product by well under a second
+  e <- new.env()
+  for (u in c("year", "month", "week", "day", "hour")) {
+    t0 <- 3
+    attr(t0, "unit") <- u
+    toSecs <- convertTimeunit(t0, "second", e)
+    expect_identical(attr(toSecs, "unit"), "second")
+    expect_equal(as.numeric(toSecs), 3 * as.numeric(inSeconds(u, e)),
+                 tolerance = 1e-6)
+
+    backAgain <- convertTimeunit(toSecs, u, e)
+    expect_equal(as.numeric(backAgain), 3, tolerance = 1e-6)
+  }
+})
+
+test_that("end() and start() convert the sim's times into any unit", {
+  testInit()
+
+  e <- new.env()
+  sim <- simInit(times = list(start = 0, end = 3, timeunit = "year"))
+  yearSecs <- as.numeric(inSeconds("year", e))
+
+  for (u in c("year", "month", "week", "day", "second")) {
+    expect_equal(as.numeric(end(sim, u)), 3 * yearSecs / as.numeric(inSeconds(u, e)),
+                 tolerance = 1e-6)
+  }
+})
+
+test_that("convertTimeunit assumes seconds when the time carries no unit", {
+  testInit()
+
+  e <- new.env()
+  out <- convertTimeunit(60, "second", e)
+  expect_identical(attr(out, "unit"), "second")
+})
+
+test_that("convertTimeunit validates its arguments", {
+  testInit()
+
+  e <- new.env()
+  expect_error(convertTimeunit(1, 1, e), "unit must be a character")
+  expect_error(convertTimeunit("x", "second", e), "time must be a numeric")
+  expect_error(convertTimeunit(1, "second", "notAnEnv"), "envir must be an environment")
+})
+
+test_that(".getTU resolves a unit function from the sim environment or the package", {
+  testInit()
+
+  e <- new.env()
+  expect_identical(as.numeric(.getTU("year", e)), as.numeric(dyear(1)))
+
+  e$dfortnight <- function(x) x * 60 * 60 * 24 * 14
+  expect_true(is.function(.getTU("fortnight", e)))
+})
+
+test_that("min/maxTimeunit fall back sensibly when no module declares a timeunit", {
+  testInit()
+
+  sim <- simInit()
+  expect_identical(minTimeunit(sim), "second")
+  expect_identical(maxTimeunit(sim), NA_character_)
+})
+
+test_that("min/maxTimeunit pick the smallest and largest module timeunit", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(
+    simInit(times = list(start = 0, end = 1, timeunit = "year"),
+            modules = list("randomLandscapes", "fireSpread"),
+            paths = list(modulePath = mp))
+  )
+
+  expect_true(is.character(minTimeunit(sim)))
+  expect_true(is.character(maxTimeunit(sim)))
+})


### PR DESCRIPTION
Raises test coverage from **60.98% to 75.99%** and fixes the twelve defects that writing those tests uncovered.

Addresses #387; found #388 and #389 along the way.

## Why

Moving `reproducible` from ~65% to ~80% surfaced real bugs, so this was never about the percentage. That held up here too: **every block of untested code opened contained at least one genuine problem**, including a feature that has apparently never worked and an infinite loop that would hang any simulation using it.

## Approach

- File-by-file scan of the uncovered lines, sorted into easy / medium / hard by what it actually takes to reach them.
- **Tests first.** Before asserting anything: *is this the behaviour we want, or would the test simply cement a bug?* Where that was unclear, the behaviour was left unasserted and raised for discussion instead of encoded — see the notes in `test-saveLoadSimList.R` and `test-copyModule.R`.
- Code changes were discussed before being made, except unambiguous crashes.

## Bugs fixed

### `scheduleConditionalEvent()` — three independent defects

The first two mean the feature only ever worked with `minEventTime = 0`.

| | |
|---|---|
| **never fired** | `minEventTime`/`maxEventTime` are stored in seconds but were compared against `time(sim)`, which is in the sim's timeunit — i.e. `0 >= 63115200`. Any non-zero `minEventTime` meant the event never fired at all. |
| **infinite loop** | Nothing stopped a conditional event re-firing in the check that runs immediately after its own execution, so one that re-armed itself ran back-to-back forever at a single timestep, starving the queue. |
| **crash** | The armed-conditions list was sorted on `x$eventTime` — a field conditional events do not have — so adding one that sorted before an existing entry died with `argument 1 is not a vector`. |

A conditional event still jumps the queue and may run immediately once true; the new guard only stops it running twice in a row.

### `saveSimList()` / `loadSimList()`

- Passing `projectPath` failed for **any** simList holding a file-backed object: `archiveWrite()` received paths relative to `projectPath` but never ran from there (#389).
- `projectPath` is now an anchor when wrapping file-backed objects, so one living under it — but under none of the sim's named paths — is re-rooted on load instead of silently becoming `NULL`. Added only when it differs from `getwd()`, since `reproducible` already appends `getwd()` and duplicate anchors make the winning name order-dependent.
- `fileBackedDir =` errored with `object 'filebackedDir' not found` instead of being normalised.

### Others

- `writeRNGInfo()` wrote only `"."` — all three `cat()` calls honoured `append`, so each truncated the previous.
- `writeEventInfo()` computed `normPath(file)` then wrote to the raw `file`.
- Every deprecation message read *"has been moved to ."* with an empty install URL — the package name bound to `.Deprecated()`'s own `new` argument.
- `defineEvent()` defined event functions it then refused to register.
- `convertTimeunit()`'s lookup-table fast path returned seconds but dropped the unit attribute, mislabelling any non-second target.
- `checkParams()` returned `FALSE` when nothing was checked; now `NA`.
- `copyModule()` tested `dir.exists(to)` against the working directory while creating `file.path(path, to)`; and matched `"test"` for a directory named `tests`, so a file directly in `tests/` (e.g. `unitTests.R`) was never copied.

## Coverage

| file | before | after |
|---|---|---|
| `R/codecheck-report.R` | 0.0 | **100.0** |
| `R/spades-core-deprecated.R` | 0.0 | **100.0** |
| `R/debugging.R` | 0.0 | **100.0** |
| `R/checkpoint.R` | 11.6 | 79.6 |
| `R/times.R` | 50.0 | 92.1 |
| `R/misc-methods.R` | 51.9 | 92.5 |
| `R/simList-accessors.R` | 49.2 | 84.5 |
| `R/simulation-spades.R` | 48.0 | 80.7 |
| `R/check.R` | 59.1 | 82.2 |
| `R/saveLoadSimList.R` | 35.9 | 60.8 |

## Also

- `?saveSimList` gains a **"Two ways to use this"** section and runnable examples — portable (bundle everything and move it) versus in place (metadata only; files stay where the run left them). There were no examples before.
- `inCovr()` helper in `helper-initTests.R`. The covr-sensitive assertions in `test-cache.R`/`test-1memory.R` were guarded on `USING_COVR`, which the GitHub workflow sets but covr does not — so a bare local `covr::package_coverage()` run left them armed and failing. `inCovr()` also consults `covr::in_covr()`, which reads `R_COVR`.

## Not fixed here

- A reloaded `simList` still cannot be run: module functions are stripped and never re-parsed (#388).
- A file-backed object outside every named path is still silently mis-rooted (#389).

## Note for the 3.2.0 release

These changes land after the `52b83515` release-prep commit, so 3.2.0 needs a fresh `R CMD check --as-cran` and a `NEWS.md` entry covering them before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCsUDsBLinupG53MMooAfA