### PR TITLE
ci: install the Suggests the tests gate on, so coverage reflects the suite

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,3 +15,23 @@ jobs:
   test-coverage:
     uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@main
     secrets: inherit
+    with:
+      # Suggests that tests gate on with skip_if_not_installed(). Without them
+      # the tests silently SKIP and the reported coverage understates what the
+      # suite actually exercises: the full suite is ~1760 assertions, CI was
+      # running ~1040, and files whose tests need these read near 0% (e.g.
+      # progress.R 9.7%, checkpoint.R 11.4%) despite being well covered.
+      # `dependencies: "all"` alone did not pull these in.
+      extra-packages: |
+        any::CircStats
+        any::DiagrammeR
+        any::archive
+        any::future.callr
+        any::httr
+        any::httr2
+        any::logging
+        any::qs2
+        any::raster
+        any::roxygen2
+        any::sf
+        any::xmlparsedata


### PR DESCRIPTION
## The problem

The coverage job runs **~1040** of the suite's **~1760** assertions. 110 tests call `skip_if_not_installed()` on `Suggests` that are not installed in that environment, so they silently skip:

| missing | tests skipped |
|---|---|
| xmlparsedata | 26 |
| logging | 9 |
| archive | 5 |
| httr / httr2 / raster / roxygen2 | 8 |
| (plus the `nosuggests` R-CMD-check leg, which is deliberate) | |

The reusable workflow already passes `dependencies: "all"`, so these appear in pak's resolution — they just are not installed.

## Why it matters

The codecov number understates what the suite actually exercises. Files whose tests need these packages read near zero on CI while being well covered locally:

| file | CI | local |
|---|---|---|
| `R/progress.R` | 9.7% | 54.2% |
| `R/checkpoint.R` | 11.4% | 79.6% |
| `R/plotting.R` | 0.0% | 41.2% |
| **overall** | **67.3%** | **76.1%** |

Same commit, same tests. The gap is entirely tests that CI never runs.

## The change

Name the packages explicitly via `extra-packages` on the thin caller. Listing one that is already present is a no-op, so over-specifying is safe.

One to watch: `archive` needs `libarchive-dev`, which the shared workflow's apt step does not install (it installs the geospatial set). pak installs system requirements itself, so this may just work — if it does not, dropping `archive` from the list costs 5 tests.

## Verification

This can only be verified by CI, since the packages are present locally. The check is whether the reported coverage moves toward the ~76% the suite achieves locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCsUDsBLinupG53MMooAfA