### PR TITLE
fix(loadSimList): re-parse module code so a reloaded simList can be run

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -287,11 +287,6 @@ setPaths <- function(cachePath, inputPath, modulePath, outputPath, rasterPath, s
 #' @examples
 #' findProjectPath()                 # the project the session is working in
 #' findProjectPath(tempdir())        # no markers above tempdir(); returns it
-## Whether rprojroot is available. A seam so the Suggests-absent path can be
-## tested without mocking base::requireNamespace(), which would replace it
-## process-wide for the duration of the block.
-.hasRprojroot <- function() requireNamespace("rprojroot", quietly = TRUE)
-
 findProjectPath <- function(path = getwd()) {
   ## NOTE: deliberately NOT using rprojroot::from_wd as one of the OR'd
   ## criteria. Its test function is `function(path) TRUE`, so it matches the
@@ -307,3 +302,8 @@ findProjectPath <- function(path = getwd()) {
     error = function(e) path
   )
 }
+
+## Whether rprojroot is available. A seam so the Suggests-absent path can be
+## tested without mocking base::requireNamespace(), which would replace it
+## process-wide for the duration of the block.
+.hasRprojroot <- function() requireNamespace("rprojroot", quietly = TRUE)

--- a/R/restart.R
+++ b/R/restart.R
@@ -202,46 +202,100 @@ restartSpades <- function(sim = NULL, module = NULL, numEvents = 1L, restart = T
   return(sim)
 }
 
-#' Re-parse (fixed) module source into a `simList`
+#' Re-parse module source into a `simList`
 #'
-#' Shared by [restartSpades()] and [restartSimInit()]: re-`parse()`s the named modules'
-#' source files and evaluates them into the `simList`'s module environments (picking up
-#' any fixes the developer made). Operates by side effect on `sim@.xData` (an
-#' environment), so the input `sim` is mutated in place.
+#' Re-`parse()`s the named modules' source files and evaluates them into the
+#' `simList`'s module environments. Shared by three callers, for two different
+#' reasons:
+#'
+#' * [restartSpades()] and [restartSimInit()] use it to pick up any fixes the
+#'   developer made to a module after an interrupted run;
+#' * [loadSimList()] uses it because `saveSimList()` does not carry the module
+#'   functions at all. `Copy(objects = 2)` -- the path `.wrap.simList()` takes
+#'   -- rebuilds each `.mods[[module]]` environment from scratch and copies
+#'   only `.modObjs` back into it, so without this a reloaded `simList` fails
+#'   with `object 'doEvent.<module>' not found`.
+#'
+#' Only the module's code is evaluated: the `defineModule()` item is skipped.
+#' Its metadata is already in the `simList` -- and for a loaded `simList` that
+#' metadata is *end-state*, so re-evaluating `defineModule()` would risk
+#' replacing it with the module's declared defaults. That is exactly why
+#' "just call `simInit()` again" is not an answer for [loadSimList()].
+#'
+#' Operates by side effect on `sim@.xData` (an environment), so the input
+#' `sim` is mutated in place.
 #'
 #' @param sim A `simList`.
 #' @param modules Character vector of (non-core) module names to re-parse.
+#' @param verbose Numeric verbosity. At `verbose > 0` each re-parsed module is
+#'   announced; a module whose source cannot be found always warns.
 #' @return `sim`, invisibly.
 #' @keywords internal
 #' @importFrom cli col_blue
-.reparseModules <- function(sim, modules) {
+.reparseModules <- function(sim, modules, verbose = getOption("reproducible.verbose")) {
+  modules <- unique(unlist(modules, use.names = FALSE))
+  if (!length(modules)) return(invisible(sim))
   names(modules) <- modules
   opt <- options("spades.moduleCodeChecks" = FALSE)
   on.exit(options(opt), add = TRUE)
-  lapply(modules, function(module) {
-    pp <- list()
+
+  notFound <- character()
+
+  for (module in modules) {
     moduleFolder <- file.path(modulePath(sim, module = module), module)
-    if (file.exists(file.path(moduleFolder, paste0(module, ".R")))) {
-      pp[[1]] <- parse(file.path(moduleFolder, paste0(module, ".R")))
-      subFiles <- dir(file.path(moduleFolder, "R"), full.names = TRUE)
-
-      doesntUseNamespacing <- !.isNamespaced(sim, module)
-
-      ## evaluate the rest of the parsed file
-      sim <- currentModuleTemporary(sim, module)
-      if (doesntUseNamespacing) {
-        evalWithActiveCode(pp[[1]], sim@.xData, sim = sim)
-      }
-
-      if (length(subFiles)) {
-        pp[seq_len(length(subFiles)) + 1] <- lapply(subFiles, function(ff) parse(ff))
-      }
-      lapply(pp, function(pp1)
-        evalWithActiveCode(pp1, sim@.xData[[dotMods]][[module]], sim = sim))
-      message(cli::col_blue("Reparsing ", module, " source code"))
+    mainFile <- file.path(moduleFolder, paste0(module, ".R"))
+    mainFile <- mainFile[file.exists(mainFile)]
+    if (!length(mainFile)) {
+      notFound <- c(notFound, module)
+      next
     }
-    invisible()
-  })
+    mainFile <- mainFile[1L]
+
+    ## Reuse the module environment as it stands. Deliberately NOT
+    ## newEnvsByModule(), which calls setupModObjsEnv() and would replace
+    ## .modObjs[[module]] with a fresh empty env -- wiping the `mod` state that
+    ## a restart is rewinding, and that saveSimList() exists to preserve.
+    if (!is.environment(sim@.xData[[dotMods]][[module]])) {
+      sim@.xData[[dotMods]][[module]] <- new.env(parent = asNamespace("SpaDES.core"))
+      attr(sim@.xData[[dotMods]][[module]], "name") <- module
+    }
+    modEnv <- sim@.xData[[dotMods]][[module]]
+
+    parsed <- .parseConditional(envir = NULL, filename = mainFile)
+    pp <- list(parsed[["parsedFile"]][!parsed[["defineModuleItem"]]])
+
+    doesntUseNamespacing <- !.isNamespaced(sim, module)
+
+    sim <- currentModuleTemporary(sim, module)
+    if (doesntUseNamespacing) {
+      evalWithActiveCode(pp[[1]], sim@.xData, sim = sim)
+    }
+
+    subFiles <- dir(file.path(moduleFolder, "R"), pattern = "([.]R$|[.]r$)",
+                    full.names = TRUE)
+    if (length(subFiles)) {
+      pp[seq_along(subFiles) + 1] <- lapply(subFiles, function(ff) parse(ff))
+    }
+    lapply(pp, function(pp1) evalWithActiveCode(pp1, modEnv, sim = sim))
+
+    ## These live in the module env too, so they go missing along with the
+    ## functions; the code-checking machinery expects them back.
+    if (!is.null(parsed[["._parsedData"]]))
+      modEnv[["._parsedData"]] <- parsed[["._parsedData"]]
+    modEnv[["._sourceFilename"]] <- basename(mainFile)
+
+    messageVerbose(cli::col_blue("Reparsing ", module, " source code"), verbose = verbose)
+  }
+
+  if (length(notFound)) {
+    warning("Could not find source code for module(s): ",
+            paste(notFound, collapse = ", "), ".\n",
+            "  The simList is loaded and can be inspected, but cannot be run. ",
+            "Supply the correct `modulePath` via `paths`, or save and load in ",
+            "an archive format, which bundles the module source.",
+            call. = FALSE)
+  }
+
   invisible(sim)
 }
 

--- a/R/saveLoadSimList.R
+++ b/R/saveLoadSimList.R
@@ -583,6 +583,11 @@ loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
   }
   makeSimListActiveBindings(tmpsim)
 
+  ## Restore the module functions. `saveSimList()` carries objects, metadata,
+  ## paths and the event queue, but not the module code -- see .reparseModules()
+  ## -- so without this a reloaded simList cannot be run.
+  tmpsim <- .reparseModules(tmpsim, modules(tmpsim), verbose = verbose)
+
   ## Lazy loading: if a sibling .rdx/.rdb pair exists, restore the user objects
   ## via lazyLoad() into a holding env, then bind delayedAssign wrappers on the
   ## simList so each access triggers the underlying lazy promise plus our

--- a/man/dot-reparseModules.Rd
+++ b/man/dot-reparseModules.Rd
@@ -2,22 +2,44 @@
 % Please edit documentation in R/restart.R
 \name{.reparseModules}
 \alias{.reparseModules}
-\title{Re-parse (fixed) module source into a \code{simList}}
+\title{Re-parse module source into a \code{simList}}
 \usage{
-.reparseModules(sim, modules)
+.reparseModules(sim, modules, verbose = getOption("reproducible.verbose"))
 }
 \arguments{
 \item{sim}{A \code{simList}.}
 
 \item{modules}{Character vector of (non-core) module names to re-parse.}
+
+\item{verbose}{Numeric verbosity. At \code{verbose > 0} each re-parsed module is
+announced; a module whose source cannot be found always warns.}
 }
 \value{
 \code{sim}, invisibly.
 }
 \description{
-Shared by \code{\link[=restartSpades]{restartSpades()}} and \code{\link[=restartSimInit]{restartSimInit()}}: re-\code{parse()}s the named modules'
-source files and evaluates them into the \code{simList}'s module environments (picking up
-any fixes the developer made). Operates by side effect on \code{sim@.xData} (an
-environment), so the input \code{sim} is mutated in place.
+Re-\code{parse()}s the named modules' source files and evaluates them into the
+\code{simList}'s module environments. Shared by three callers, for two different
+reasons:
+}
+\details{
+\itemize{
+\item \code{\link[=restartSpades]{restartSpades()}} and \code{\link[=restartSimInit]{restartSimInit()}} use it to pick up any fixes the
+developer made to a module after an interrupted run;
+\item \code{\link[=loadSimList]{loadSimList()}} uses it because \code{saveSimList()} does not carry the module
+functions at all. \code{Copy(objects = 2)} -- the path \code{.wrap.simList()} takes
+-- rebuilds each \code{.mods[[module]]} environment from scratch and copies
+only \code{.modObjs} back into it, so without this a reloaded \code{simList} fails
+with \verb{object 'doEvent.<module>' not found}.
+}
+
+Only the module's code is evaluated: the \code{defineModule()} item is skipped.
+Its metadata is already in the \code{simList} -- and for a loaded \code{simList} that
+metadata is \emph{end-state}, so re-evaluating \code{defineModule()} would risk
+replacing it with the module's declared defaults. That is exactly why
+"just call \code{simInit()} again" is not an answer for \code{\link[=loadSimList]{loadSimList()}}.
+
+Operates by side effect on \code{sim@.xData} (an environment), so the input
+\code{sim} is mutated in place.
 }
 \keyword{internal}

--- a/tests/testthat/test-saveLoadSimList.R
+++ b/tests/testthat/test-saveLoadSimList.R
@@ -353,3 +353,89 @@ test_that("mode 1 (portable): a sim moved to a new location keeps its file-backe
   expect_true(inherits(out$r, "SpatRaster"))
   expect_equal(as.numeric(terra::values(out$r)), as.numeric(seq_len(400)))
 })
+
+## Module code does not survive saveSimList(): Copy(objects = 2) -- the path
+## .wrap.simList() takes -- rebuilds each .mods[[module]] env and copies only
+## .modObjs back into it. loadSimList() re-parses the source to restore it.
+## See #388.
+
+simWithModule <- function(tmpdir, end = 1) {
+  mp <- getSampleModules(tmpdir)
+  simInit(times = list(start = 0, end = end, timeunit = "year"),
+          modules = list("randomLandscapes"),
+          paths = list(modulePath = mp, outputPath = tmpdir,
+                       cachePath = tmpdir, inputPath = tmpdir))
+}
+
+test_that("loadSimList restores module functions so the simList can be run", {
+  skip_on_cran()
+  testInit()
+
+  sim <- suppressMessages(simWithModule(tmpdir))
+  expect_true("doEvent.randomLandscapes" %in% ls(sim$.mods$randomLandscapes))
+
+  f <- file.path(tmpdir, "sim.rds")
+  suppressMessages(saveSimList(sim, f))
+  out <- suppressMessages(loadSimList(f))
+
+  expect_true("doEvent.randomLandscapes" %in% ls(out$.mods$randomLandscapes))
+  expect_true(is.function(out$.mods$randomLandscapes$doEvent.randomLandscapes))
+  ## the module's own helpers come back too, not just the dispatcher
+  expect_true(all(c("Init", "makeNLM") %in% ls(out$.mods$randomLandscapes)))
+
+  ## the point of the exercise: a reloaded simList runs
+  expect_s4_class(suppressMessages(spades(out, .plotInitialTime = NA)), "simList")
+})
+
+test_that("loadSimList's re-parse leaves `mod` state alone", {
+  skip_on_cran()
+  testInit()
+
+  sim <- suppressMessages(simWithModule(tmpdir))
+  ## .modObjs is what the `mod` active binding reads through; re-parsing must
+  ## not call newEnvsByModule(), which would replace it with an empty env.
+  sim$.modObjs$randomLandscapes$carriedOver <- "keep me"
+
+  f <- file.path(tmpdir, "sim.rds")
+  suppressMessages(saveSimList(sim, f))
+  out <- suppressMessages(loadSimList(f))
+
+  expect_identical(out$.modObjs$randomLandscapes$carriedOver, "keep me")
+})
+
+test_that("loadSimList's re-parse does not overwrite end-state metadata", {
+  skip_on_cran()
+  testInit()
+
+  sim <- suppressMessages(simWithModule(tmpdir))
+  ## end-state that differs from what the module's defineModule() declares
+  end(sim) <- 7
+  sim <- scheduleEvent(sim, 3, "randomLandscapes", "someLaterEvent")
+  nEvents <- NROW(sim@events)
+
+  f <- file.path(tmpdir, "sim.rds")
+  suppressMessages(saveSimList(sim, f))
+  out <- suppressMessages(loadSimList(f))
+
+  expect_identical(as.numeric(end(out)), 7)
+  expect_identical(NROW(out@events), nEvents)
+  expect_identical(unlist(modules(out), use.names = FALSE), "randomLandscapes")
+})
+
+test_that("loadSimList warns, rather than errors, when module source is gone", {
+  skip_on_cran()
+  testInit()
+
+  sim <- suppressMessages(simWithModule(tmpdir))
+  f <- file.path(tmpdir, "sim.rds")
+  suppressMessages(saveSimList(sim, f))
+
+  ## the metadata-only use case: the module path no longer exists
+  unlink(file.path(modulePath(sim), "randomLandscapes"), recursive = TRUE)
+
+  expect_warning(out <- suppressMessages(loadSimList(f)), "Could not find source code")
+  expect_s4_class(out, "simList")
+  ## loaded and inspectable, just not runnable
+  expect_identical(unlist(modules(out), use.names = FALSE), "randomLandscapes")
+  expect_false("doEvent.randomLandscapes" %in% ls(out$.mods$randomLandscapes))
+})

--- a/tests/testthat/test-saveLoadSimList.R
+++ b/tests/testthat/test-saveLoadSimList.R
@@ -369,7 +369,7 @@ simWithModule <- function(tmpdir, end = 1) {
 
 test_that("loadSimList restores module functions so the simList can be run", {
   skip_on_cran()
-  testInit()
+  testInit(sampleModReqdPkgs)
 
   sim <- suppressMessages(simWithModule(tmpdir))
   expect_true("doEvent.randomLandscapes" %in% ls(sim$.mods$randomLandscapes))


### PR DESCRIPTION
Closes #388.

A `simList` saved with `saveSimList()` reloaded fine but could not be run:

```r
out <- loadSimList("s.rds")
ls(out$.mods$randomLandscapes)
#> "mod" "Par"
spades(out)
#> Error in get(moduleCall, envir = fnEnv) :
#>   object 'doEvent.randomLandscapes' not found
```

## Where the functions actually go

They are not lost in serialization, so nothing on the save side needed changing. `Copy.simList()` with `objects = 2` — the path `.wrap.simList()` takes, and therefore the path every `saveSimList()` takes — builds a fresh `.mods[[module]]` environment via `newEnvsByModule()` and then only ever copies `.modObjs` contents back into it. The module env's functions are never carried over.

## The fix

`loadSimList()` now re-parses each module's source into its module environment. Re-running `simInit()` is not an alternative: it produces initial-state objects, and a saved `simList` holds end-state objects — which is the entire point of saving it.

`restart.R` already had a `.reparseModules()` doing this job for `restartSpades()` and `restartSimInit()`, so this extends that rather than adding a second implementation:

- **Skip the `defineModule()` item** instead of evaluating the whole file. Its metadata is already in the `simList`, and for a loaded `simList` that metadata is *end-state* — re-evaluating `defineModule()` would risk replacing it with the module's declared defaults. Restart benefits too: re-running `defineModule()` there was wasted work whose errors were silently swallowed by `evalWithActiveCode()`'s active-code detection.
- **Warn when a module's source cannot be found**, rather than skipping in silence. The `simList` still loads and is inspectable — which keeps the metadata-only use case in #389 working — it just cannot be run.
- **Restore `._parsedData` / `._sourceFilename`**, which live in the module env too and so went missing with the functions; the code-checking machinery expects them back.

Deliberately does **not** call `newEnvsByModule()`, which calls `setupModObjsEnv()` and would replace `.modObjs[[module]]` with a fresh empty env — wiping the `mod` state that a restart is rewinding, and that `saveSimList()` exists to preserve. There is a test for that.

## Tests

Four, starting from the reproducer in the issue: functions restored and `spades(out)` runs; `mod` state preserved; end-state metadata not overwritten; missing source warns instead of erroring. As the issue notes, there was previously no test anywhere in the package that called `loadSimList()` with modules, which is presumably why this went unnoticed.

## Unrelated fix that could not be avoided

`.hasRprojroot()` sat between `findProjectPath()`'s roxygen block and the function, so roxygen attached that block — including `@export` — to the helper. Regenerating documentation on `development` today drops `export(findProjectPath)` from `NAMESPACE` and retitles `man/findProjectPath.Rd`. This commit has to regenerate documentation, so the helper is moved below the function it follows. Same shape as PredictiveEcology/SpaDES.tools#111.

## Test status

Full suite: 1 failure, pre-existing on `development` (`test-simList-accessors-sweep.R:117`, `terra::time<-` masking `SpaDES.core`'s), and 1 pre-existing skip. Present identically on this branch and on `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qgJbsLzHkx937W7GQfED4