### PR TITLE
fix(saveSimList): anchor file-backed objects properly, and say so when we cannot

### DIFF
--- a/R/saveLoadSimList.R
+++ b/R/saveLoadSimList.R
@@ -230,6 +230,11 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
     sim <- get(simName, envir = tmpEnv)
   }
 
+  ## Say so now if any file-backed object cannot be anchored. Only when we are
+  ## actually bundling files -- with `files = FALSE` the user has opted into a
+  ## metadata-only save and is not expecting portability.
+  if (isTRUE(files)) .warnUnanchoredFiles(sim, projectPath = projectPath)
+
   ## Pre-wrap file-backed objects one-by-one so a single inaccessible backing file
   ## does not abort the entire save; failed objects are saved as NULL with a warning.
   sim <- .wrapResiliently(sim, projectPath = projectPath)
@@ -803,6 +808,44 @@ recoverDataTableFromQs <- function(sim) {
   anchors
 }
 
+## Warn, at save time, about file-backed objects that cannot be re-rooted on
+## load. A backing file that lies under none of the sim's named paths, nor
+## under `projectPath`, nor under the working directory, has no anchor: .wrap()
+## records its absolute path, nothing puts it into the archive, and
+## loadSimList() elsewhere gets either NULL or a path that exists only on the
+## machine that saved it. The failure otherwise surfaces far from its cause --
+## at load, on another machine, as a silent NULL. See #389.
+.warnUnanchoredFiles <- function(sim, projectPath = NULL) {
+  anchors <- unlist(c(.wrapAnchors(sim, projectPath), list(getwd = getwd())),
+                    use.names = FALSE)
+  anchors <- unique(normPath(anchors[nzchar(anchors) & !is.na(anchors)]))
+  if (!length(anchors)) return(invisible(NULL))
+
+  isAnchored <- function(f) any(vapply(anchors, function(a) fs::path_has_parent(f, a),
+                                       logical(1)))
+
+  unanchored <- list()
+  for (nm in ls(sim@.xData, all.names = FALSE)) {
+    fns <- tryCatch(Filenames(sim@.xData[[nm]]), error = function(e) character(0))
+    fns <- unique(fns[nzchar(fns) & !is.na(fns)])
+    if (!length(fns)) next
+    bad <- fns[!vapply(normPath(fns), isAnchored, logical(1))]
+    if (length(bad)) unanchored[[nm]] <- bad
+  }
+  if (!length(unanchored)) return(invisible(NULL))
+
+  warning("saveSimList: ", length(unanchored), " file-backed object(s) lie outside ",
+          "`projectPath` and every path in `paths(sim)`, so they cannot be ",
+          "re-rooted when this simList is loaded elsewhere:\n",
+          paste0("  ", names(unanchored), ": ",
+                 vapply(unanchored, function(x) paste(x, collapse = ", "), character(1)),
+                 collapse = "\n"),
+          "\n  They are saved by absolute path and are not bundled. Move them under ",
+          "`projectPath`, or add their directory to `paths(sim)`, to make this ",
+          "simList portable.", call. = FALSE)
+  invisible(names(unanchored))
+}
+
 ## Pre-wrap each file-backed object in sim@.xData individually so that one
 ## inaccessible backing file does not abort saveSimList. Failed objects are
 ## replaced with NULL and a warning is issued; the subsequent monolithic
@@ -865,7 +908,15 @@ recoverDataTableFromQs <- function(sim) {
   ## the non-lazy remap loop — wrapped non-file objects have tags but no filenames).
   fns <- tryCatch(Filenames(obj), error = function(e) character(0))
   if (!length(fns) || all(nchar(fns) == 0L)) return(obj)
-  pths <- if (identical(projectPath, getwd())) simPaths else list(projectPath = projectPath)
+  ## Same anchor set as the non-lazy remap loop in loadSimList(): when
+  ## `projectPath` is not the working directory it is an ADDITIONAL anchor, not
+  ## a replacement. Using it alone dropped the sim's named paths, so a lazily
+  ## saved object anchored to e.g. outputPath had nothing to resolve against.
+  pths <- if (identical(projectPath, getwd())) {
+    simPaths
+  } else {
+    c(simPaths, list(projectPath = projectPath))
+  }
   newFiles <- remapFilenames(tags = tags, cachePath = NULL, paths = pths)
   if (is(obj, "list")) {
     newNames <- unique(newFiles$newName)
@@ -972,7 +1023,16 @@ relativizePaths <- function(paths, projectPath = NULL) {
   if (is.null(projectPath)) {
     projectPath <- fs::path_common(p[["modulePath"]]) |> unique() |> dirname()
   }
-  p[corePaths] <- getRelative(p[corePaths], projectPath)
+  ## fs::path_rel, not getRelative: absolutizePaths() inverts this with
+  ## fs::path_abs(start = projectPath), and only path_rel is its true inverse.
+  ## getRelative("<base>/outs", "<base>/proj") returns "outs" -- dropping the
+  ## fact that it is a SIBLING of projectPath -- which re-absolutizes to
+  ## "<base>/proj/outs". Any named path outside projectPath (an outputPath
+  ## elsewhere, say) therefore came back pointing at a directory that never
+  ## existed, and its file-backed objects loaded as NULL. path_rel gives
+  ## "../outs", which round-trips. For paths under projectPath the two agree.
+  p[corePaths] <- sapply(p[corePaths], function(x)
+    as.character(fs::path_rel(x, start = projectPath)))
   p[tmpPaths] <- makeRelative(p[tmpPaths], p[["scratchPath"]])
 
   ## TODO: recombine paths, e.g. modulePath1, modulePath2 into modulePath

--- a/tests/testthat/test-saveLoadSimList.R
+++ b/tests/testthat/test-saveLoadSimList.R
@@ -353,3 +353,89 @@ test_that("mode 1 (portable): a sim moved to a new location keeps its file-backe
   expect_true(inherits(out$r, "SpatRaster"))
   expect_equal(as.numeric(terra::values(out$r)), as.numeric(seq_len(400)))
 })
+
+## Anchoring of file-backed objects: which directories a backing file can be
+## re-rooted against on load, and saying so at save time when there are none.
+## See #389.
+
+simWithFileBacked <- function(base, objDir, pathsList) {
+  dir.create(objDir, recursive = TRUE, showWarnings = FALSE)
+  f <- file.path(objDir, "r.tif")
+  terra::writeRaster(terra::rast(nrows = 8, ncols = 8, vals = 1:64), f, overwrite = TRUE)
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"), paths = pathsList)
+  sim$r <- terra::rast(f)
+  sim
+}
+
+test_that("saveSimList warns when a file-backed object cannot be anchored", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit("terra")
+
+  proj <- file.path(tmpdir, "proj")
+  dir.create(proj, recursive = TRUE, showWarnings = FALSE)
+  pths <- list(outputPath = proj, cachePath = proj, inputPath = proj, modulePath = proj)
+
+  ## Under none of the named paths, nor projectPath, nor the working directory
+  ## -- nothing to re-root against. It has to sit outside `tmpdir`, because
+  ## testInit() makes `tmpdir` the working directory and getwd() is an anchor.
+  outside <- tempfile("unanchored")
+  on.exit(unlink(outside, recursive = TRUE), add = TRUE)
+  sim <- suppressMessages(simWithFileBacked(tmpdir, outside, pths))
+  expect_warning(suppressMessages(saveSimList(sim, file.path(proj, "s.rds"), projectPath = proj)),
+                 "cannot be re-rooted")
+})
+
+test_that("saveSimList does not warn for objects under projectPath", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit("terra")
+
+  proj <- file.path(tmpdir, "proj")
+  dir.create(proj, recursive = TRUE, showWarnings = FALSE)
+  pths <- list(outputPath = proj, cachePath = proj, inputPath = proj, modulePath = proj)
+
+  ## projectPath is itself an anchor, so anything beneath it re-roots
+  sim <- suppressMessages(simWithFileBacked(tmpdir, file.path(proj, "data"), pths))
+  expect_no_warning(suppressMessages(
+    saveSimList(sim, file.path(proj, "s.rds"), projectPath = proj)))
+})
+
+test_that("saveSimList(files = FALSE) does not warn about anchoring", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit("terra")
+
+  proj <- file.path(tmpdir, "proj")
+  dir.create(proj, recursive = TRUE, showWarnings = FALSE)
+  pths <- list(outputPath = proj, cachePath = proj, inputPath = proj, modulePath = proj)
+
+  ## metadata-only save: the user has opted out of bundling, so portability
+  ## is not being promised and the warning would be noise
+  outside <- tempfile("unanchored")
+  on.exit(unlink(outside, recursive = TRUE), add = TRUE)
+  sim <- suppressMessages(simWithFileBacked(tmpdir, outside, pths))
+  expect_no_warning(suppressMessages(
+    saveSimList(sim, file.path(proj, "s.rds"), projectPath = proj, files = FALSE)))
+})
+
+test_that("an object under a named path survives a save from another projectPath", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit("terra")
+
+  ## outputPath deliberately sits OUTSIDE projectPath, so the object can only
+  ## be re-rooted via the sim's named paths -- not via projectPath.
+  proj <- file.path(tmpdir, "proj")
+  outs <- file.path(tmpdir, "outs")
+  dir.create(proj, recursive = TRUE, showWarnings = FALSE)
+  pths <- list(outputPath = outs, cachePath = proj, inputPath = proj, modulePath = proj)
+
+  sim <- suppressMessages(simWithFileBacked(tmpdir, outs, pths))
+  f <- file.path(proj, "s.rds")
+  suppressWarnings(suppressMessages(saveSimList(sim, f, projectPath = proj)))
+
+  out <- suppressWarnings(suppressMessages(loadSimList(f, projectPath = proj)))
+  expect_false(is.null(out$r))
+  expect_identical(sum(terra::values(out$r)), sum(terra::values(sim$r)))
+})


### PR DESCRIPTION
Towards #389 — the two directions you asked for, plus one bug they uncovered.

## 1. `projectPath` as an anchor, everywhere it should be

`.remapFileBackedObj()` — the lazy-load path — *replaced* the sim's named paths with `projectPath` instead of adding to them:

```r
pths <- if (identical(projectPath, getwd())) simPaths else list(projectPath = projectPath)
```

The non-lazy remap loop in `loadSimList()` already treats `projectPath` as an **additional** anchor; the lazy helper was extracted from that loop before the fix and never caught up. So a lazily saved object anchored to a named path (an `outputPath`, say) had nothing to resolve against.

## 2. Fail loudly at save time

A backing file under none of the sim's named paths, nor `projectPath`, nor the working directory has no anchor: `.wrap()` records its absolute path, nothing bundles it, and `loadSimList()` elsewhere gets either `NULL` or a path that exists only on the machine that saved it. `.warnUnanchoredFiles()` now names those objects and their files *while saving*, next to the cause, instead of leaving it to surface as a silent `NULL` at load on another machine.

Only when `files = TRUE`. With `files = FALSE` the user has opted into a metadata-only save and is not promising portability, so the warning would be noise.

Note `getwd()` counts as an anchor, because reproducible appends it and files beneath it genuinely do re-root. The warning means "this cannot be re-rooted", not "this may not be what you want".

## 3. `relativizePaths()` and `absolutizePaths()` were not inverses

Writing a test for (2) turned up a case that *is* anchored and still broke: a named path lying **outside** `projectPath`. `relativizePaths()` used `getRelative(p, projectPath)` while `absolutizePaths()` inverts with `fs::path_abs(start = projectPath)`, and only `fs::path_rel` is that inverse:

```r
getRelative("/tmp/x/outs", "/tmp/x/proj")   #> "outs"
fs::path_rel("/tmp/x/outs", "/tmp/x/proj")  #> "../outs"
```

`"outs"` drops the fact that it is a *sibling*, so it re-absolutized to `/tmp/x/proj/outs` — a directory that never existed — and every file-backed object under that path loaded as `NULL`. With `path_rel` it round-trips. For paths under `projectPath` the two agree, so this only touches the broken case.

## What is verified

Saving with `projectPath` and an archive, deleting the original tree, and loading into a fresh directory now re-roots correctly for objects under `projectPath`, which is the portable case from the issue. Objects genuinely outside every anchor warn at save.

Four tests: warns for a genuinely unanchored object; does not warn for one under `projectPath`; does not warn under `files = FALSE`; and an object under a named path outside `projectPath` survives the round trip. The first has to put its file outside `tmpdir`, since `testInit()` makes `tmpdir` the working directory and `getwd()` is an anchor.

## Still open on #389, not addressed here

`saveSimList()` rewrites the target extension twice, so the file you ask for is not the file you get: `saveSimList(sim, "s.zip")` writes `s.tar.gz`, and `saveSimList(sim, "s.tar.gz")` errors outright with

```
Could not automatically determine the `filter` and `format` from `archive` ".../s.tar.tar.gz"
```

because `archiveConvertFileExt()` `gsub()`s the extension substring rather than replacing the extension, and does not understand double extensions. Separate bug; worth its own issue.

## Test status

Full suite: 1 failure, pre-existing on `development` (`test-simList-accessors-sweep.R:117`, `terra::time<-` masking `SpaDES.core`'s), and 1 pre-existing skip. Present identically on this branch and on `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qgJbsLzHkx937W7GQfED4