### PR TITLE
test: cover plotting-diagrams, memory and save/load helpers

### DIFF
--- a/TODO-coverage-batch-2.md
+++ b/TODO-coverage-batch-2.md
@@ -55,6 +55,18 @@ Filed as **#397**. Your call:
 
 I did not choose for you.
 
+## CI on #398
+
+One test of mine broke CI on the first push — the `archiveWrite`/`archiveExtract`
+round trip assumed the `archive::` branch, which is not taken when `archive` is
+missing or on Windows. Fixed in 98b657d5.
+
+Everything failing since is `test-downloadModule.R:95` returning HTTP 403, filed
+as **#399**. It rotates between matrix legs run to run, and every leg has now
+passed on at least one run. The reusable workflow does set `GITHUB_PAT`, but the
+test took its no-token branch, so the request is going out unauthenticated and
+hitting the shared 60/hr IP quota across ~12 concurrent legs.
+
 ## Verified bug, deliberately not fixed
 
 **`clearCacheEventsOnly(x = )` clears the wrong cache.** It reads the entries

--- a/TODO-coverage-batch-2.md
+++ b/TODO-coverage-batch-2.md
@@ -1,0 +1,137 @@
+# Overnight coverage work — 2026-08-25/26
+
+## Where things stand
+
+| | coverage |
+|---|---|
+| start of the coverage effort | 60.98% |
+| end of the previous batch (#390) | 76.00% |
+| **after tonight** | **80.97%** |
+
+Eleven new test files, ~150 tests. **No production code was changed** — you said
+any code change had to be 100% or not made at all, and every candidate fix
+either needed a decision from you or was in a destructive code path.
+
+Local suite: `0 failures, 1 skip` (the pre-existing igraph/GLPK skip).
+
+## The 8% you saw is real, but it is not on `development`
+
+`development` still reads 67.32% on codecov. What you were looking at is #394's
+branch.
+
+| branch | codecov |
+|---|---|
+| `development` | 67.32% |
+| **#394** `fix/declare-sf-suggests` | **75.64%** |
+| **#398** `test/coverage-batch-2` (tonight) | **70.87%** |
+
+#398 is measured against `development`, so most sample-module tests still skip
+there. #394 and #398 touch different files; landing both should put codecov near
+79%.
+
+## #394 is blocked — and it is not #394's fault
+
+Four of five Windows `R-CMD-check` legs fail on `test-save.R:223`. I re-ran them;
+it is deterministic, not a flake.
+
+It is **not** a regression. That test never runs on CI today:
+
+```
+development, windows-latest (release): [ FAIL 0 | WARN 0 | SKIP 65 | PASS 1203 ]
+  • {sf} is not installed (64): ... 'test-save.R:162:3' ...
+```
+
+`caribouMovement` declared `sf` in `reqdPkgs` while `sf` was never in
+`DESCRIPTION`, so `simInit()` could not load it on CI and every sample-module
+test skipped. Removing the stale `sf` un-skips 64 tests — and
+`saveSimList works correctly` turns out to have been broken on Windows all
+along: `.grd`-backed rasters do not survive the save/load round trip there.
+
+Filed as **#397**. Your call:
+
+1. `skip_on_os("windows")` on that one test, merge #394 now, fix separately.
+   Gets the +8% immediately but re-masks the bug.
+2. Fix the Windows round trip first.
+
+I did not choose for you.
+
+## Verified bug, deliberately not fixed
+
+**`clearCacheEventsOnly(x = )` clears the wrong cache.** It reads the entries
+from `x` but calls `clearCache()` without `x`, so the deletion happens in
+`getOption("reproducible.cachePath")`.
+
+Verified both ways: with the option pointed at `x`, 3 cached entries become 1
+(the two event entries removed, correctly). Without it, nothing is removed and
+nothing is said. The fix is `clearCache(x = x, cacheId = y, ...)` — one
+argument — but it makes a *delete* function start deleting somewhere new, so I
+left it alone. The tests pin the intended behaviour without asserting the
+broken path.
+
+## Other things found, all left alone
+
+1. **`moduleDiagram(type = )`** — `if (grep("plot", type, ...))` evaluates to
+   `if (integer(0))`, an error, so the `stop("type must be one of 'rgl', 'tk',
+   'Plot' or 'plot'")` below it is unreachable. Wants `grepl()`.
+2. **`archiveConvertFileExt()`** — `tools::file_ext("sim.tar.gz")` is `"gz"`, so
+   converting to zip yields `sim.tar.zip`. The `gsub` is also unanchored and
+   applied to the whole path, so a directory named `gz` gets rewritten too.
+   Neither is pinned by a test until it is decided what is right.
+3. **Leftover `browser()`** at `simulation-spades.R:2592`, inside
+   `allowSequentialCaching1()`. The condition also reads as though it meant
+   `length(nextEvent) > 1` rather than `length(nextEvent != ...) > 1`.
+4. **`moduleCoverage()`** opens with
+   `stop("This is a stub that is not intended for use")` — 32 lines of
+   unreachable code behind it, and it is not exported. Finish it or delete it.
+5. **`ongoingMemoryThisPid(interval = )`** takes an `interval` argument but the
+   loop sleeps by `getOption("spades.memoryUseInterval")`, ignoring it. Only the
+   loop bound uses the argument. The tests set the option rather than assert
+   this.
+6. **`saveSimList()` with module sources outside `projectPath`** — I could not
+   get a test to reach that branch reliably, and one attempt failed inside
+   `archive::archive_write_files()` with "`files` must be one or more readable
+   file paths" that I could not reproduce standalone. Dropped the test rather
+   than commit something I could not explain. The branch is still uncovered.
+
+## What got covered
+
+| file | before | after |
+|---|---|---|
+| `R/memory.R` | **0.0** | 91.9 |
+| `R/plotting-diagrams.R` | **0.0** | 88.8 |
+| `R/codecheck-rules.R` | 79.9 | 97.2 |
+| `R/module-template.R` | 79.9 | 90.1 |
+| `R/load.R` | 73.9 | 82.8 |
+| `R/saveLoadSimList.R` | 60.8 | 66.1 |
+| `R/module-define.R` | 83.0 | 86.8 |
+| `R/cache.R` | 81.8 | 83.9 |
+| `R/simList-accessors.R` | 84.5 | 87.2 |
+
+No file went down.
+
+New files:
+
+- `test-plotting-diagrams.R` — `ganttStatus`, `.sim2gantt`, all three
+  `eventDiagram` methods, `objectDiagram`, `moduleDiagram`, `moduleGraph`
+- `test-memory.R` — the `ps` sampler, `memoryUse()`, and the `future.callr`
+  setup/teardown around `spades()`
+- `test-saveLoadSimList-helpers.R` — archive naming, path relativisation, the
+  deep environment cloner, `.wrapAnchors`
+- `test-module-template-extras.R` — `openModules()` (with `.fileEdit` mocked),
+  `zipModule()`, `checkModulePath()`
+- `test-codecheck-rules.R` — the `.ccr_*` rules driven directly
+- `test-module-define-extras.R` — `defineParameter()` edge cases
+- `test-rasterToMemory.R` — `rasterToMemory` / `rasterCreate`, terra and raster
+- `test-outputs-rmDups.R` — `rmDups()`, including the AsIs columns
+- `test-clearCacheEventsOnly.R`
+- `test-parameters-accessor.R` — `parameters()`, `newObjectsCreated()`,
+  `inputArgs<-`
+
+## Still open from before
+
+- #388 `loadSimList()` module re-parse
+- #389 file-backed objects outside every named path (related to #397)
+- reproducible #575 (ETag / `preProcessCheckURLs`) still open
+- SpaDES.tools `release/2.1.3` prepped locally but never pushed
+- 3.2.0 release prep is stale — `development` has moved well past `52b83515`;
+  needs a fresh `--as-cran` and a `NEWS.md` section

--- a/tests/testthat/test-clearCacheEventsOnly.R
+++ b/tests/testthat/test-clearCacheEventsOnly.R
@@ -1,0 +1,90 @@
+## clearCacheEventsOnly(): drop only the cache entries belonging to module
+## events (`doEvent.*`) and `.inputObjects`, leaving every other cached call
+## alone.
+##
+## NOTE: the entries are *read* from `x`, but the clearing itself calls
+## reproducible::clearCache() without passing `x`, so it acts on
+## getOption("reproducible.cachePath"). The clearing tests below therefore point
+## that option at the same directory. See the note in the summary -- when the
+## two differ, the function reports what it would remove from one cache and then
+## removes from another.
+
+cacheAnEvent <- function(path) {
+  f <- function(x) x
+  for (nm in c("doEvent.myMod.init", ".inputObjects", "somethingElse"))
+    invisible(reproducible::Cache(f, nm, .functionName = nm,
+                                  cachePath = path, verbose = -1))
+  path
+}
+
+nCacheIds <- function(path) {
+  length(unique(reproducible::showCache(path, verbose = -1)$cacheId))
+}
+
+test_that("clearCacheEventsOnly returns nothing for an empty cache", {
+  skip_on_cran()
+  testInit()
+
+  d <- checkPath(file.path(tmpdir, "emptyCache"), create = TRUE)
+
+  out <- suppressMessages(clearCacheEventsOnly(ask = FALSE, x = d, dryRun = TRUE,
+                                               verbose = 0))
+
+  expect_type(out, "list")
+  expect_length(out, 0L)
+})
+
+test_that("clearCacheEventsOnly with dryRun reports the event entries and clears nothing", {
+  skip_on_cran()
+  testInit()
+
+  d <- cacheAnEvent(checkPath(file.path(tmpdir, "cacheDry"), create = TRUE))
+  expect_identical(nCacheIds(d), 3L)
+
+  msgs <- capture_messages(
+    clearCacheEventsOnly(ask = FALSE, x = d, dryRun = TRUE, verbose = 1)
+  )
+  msgs <- paste(msgs, collapse = "")
+
+  expect_match(msgs, "dryRun = TRUE, no clearing")
+  expect_match(msgs, "Would remove: doEvent.myMod.init", fixed = TRUE)
+  expect_match(msgs, "Would remove: .inputObjects", fixed = TRUE)
+  ## the unrelated cached call is not even mentioned
+  expect_false(grepl("somethingElse", msgs, fixed = TRUE))
+  ## and nothing was actually removed
+  expect_identical(nCacheIds(d), 3L)
+})
+
+test_that("clearCacheEventsOnly removes the event entries and keeps the others", {
+  skip_on_cran()
+  testInit()
+
+  d <- cacheAnEvent(checkPath(file.path(tmpdir, "cacheClear"), create = TRUE))
+  expect_identical(nCacheIds(d), 3L)
+
+  withr::local_options(list(reproducible.cachePath = d))
+  suppressMessages(clearCacheEventsOnly(ask = FALSE, x = d, dryRun = FALSE, verbose = 0))
+
+  ## only `somethingElse` survives
+  expect_identical(nCacheIds(d), 1L)
+  sc <- reproducible::showCache(d, verbose = -1)
+  fns <- sc$tagValue[grepl("function", sc$tagKey)]
+  expect_identical(unique(fns), "somethingElse")
+})
+
+test_that("clearCacheEventsOnly leaves a cache with no event entries alone", {
+  skip_on_cran()
+  testInit()
+
+  d <- checkPath(file.path(tmpdir, "cacheNoEvents"), create = TRUE)
+  f <- function(x) x
+  invisible(reproducible::Cache(f, 1, .functionName = "somethingElse",
+                                cachePath = d, verbose = -1))
+
+  withr::local_options(list(reproducible.cachePath = d))
+  out <- suppressMessages(clearCacheEventsOnly(ask = FALSE, x = d, dryRun = FALSE,
+                                               verbose = 0))
+
+  expect_length(out, 0L)
+  expect_identical(nCacheIds(d), 1L)
+})

--- a/tests/testthat/test-codecheck-rules.R
+++ b/tests/testthat/test-codecheck-rules.R
@@ -1,0 +1,226 @@
+## The individual `.ccr_*` rules. Each takes a `uses` data.frame (built here
+## with the .cc_use() constructor) plus a `meta` list, and returns a findings
+## data.frame -- so they can be driven directly, without parsing a module.
+
+ccUse <- SpaDES.core:::.cc_use
+ccNoUses <- SpaDES.core:::.cc_emptyUses
+
+## ---- must_return_sim ----------------------------------------------------
+
+test_that("must_return_sim flags a doEvent function that never returns sim", {
+  testInit()
+
+  env <- new.env()
+  env$doEvent.mod.init <- function(sim) sim
+  env$helper <- function() 1
+
+  f <- SpaDES.core:::.ccr_must_return_sim(ccNoUses(), list(module = "mod", moduleEnv = env))
+
+  expect_identical(NROW(f), 1L)
+  expect_identical(f$id, "must_return_sim")
+  expect_identical(f$severity, "error")
+  expect_identical(f$name, "doEvent.mod.init")
+  expect_match(f$message, "must end with")
+  ## only doEvent.* functions are subject to the rule
+  expect_false("helper" %in% f$name)
+})
+
+test_that("must_return_sim is quiet when the doEvent function does return sim", {
+  testInit()
+
+  env <- new.env()
+  env$doEvent.mod.init <- function(sim) sim
+
+  f <- SpaDES.core:::.ccr_must_return_sim(ccUse("return_sim", fn = "doEvent.mod.init"),
+                                          list(module = "mod", moduleEnv = env))
+
+  expect_identical(NROW(f), 0L)
+})
+
+test_that("must_return_sim is quiet when there is no module environment", {
+  testInit()
+
+  expect_identical(
+    NROW(SpaDES.core:::.ccr_must_return_sim(ccNoUses(),
+                                            list(module = "mod", moduleEnv = NULL))),
+    0L)
+})
+
+test_that("must_return_sim is quiet when the module defines no doEvent function", {
+  testInit()
+
+  env <- new.env()
+  env$helper <- function() 1
+
+  expect_identical(
+    NROW(SpaDES.core:::.ccr_must_return_sim(ccNoUses(),
+                                            list(module = "mod", moduleEnv = env))),
+    0L)
+})
+
+## ---- must_assign_to_sim -------------------------------------------------
+
+test_that("must_assign_to_sim flags a bare call that should have been assigned", {
+  testInit()
+
+  u <- ccUse("assign_to_sim", name = "scheduleEvent", fn = "doEvent.mod.init", line = 10L)
+
+  f <- SpaDES.core:::.ccr_must_assign_to_sim(u, list(module = "mod"))
+
+  expect_identical(NROW(f), 1L)
+  expect_identical(f$id, "must_assign_to_sim")
+  expect_identical(f$severity, "error")
+  expect_match(f$message, "must be assigned to sim")
+  expect_match(f$suggestion, "sim <- scheduleEvent", fixed = TRUE)
+  expect_identical(f$line, 10L)
+})
+
+test_that("must_assign_to_sim is quiet when there is nothing to flag", {
+  testInit()
+
+  expect_identical(NROW(SpaDES.core:::.ccr_must_assign_to_sim(ccNoUses(),
+                                                              list(module = "mod"))), 0L)
+})
+
+## ---- module_named_object ------------------------------------------------
+
+test_that("module_named_object flags sim$<moduleName> <- ...", {
+  testInit()
+
+  u <- ccUse("sim_assign", name = "mod", fn = "doEvent.mod.init", line = 3L)
+
+  f <- SpaDES.core:::.ccr_module_named_object(u, list(module = "mod"))
+
+  expect_identical(NROW(f), 1L)
+  expect_identical(f$id, "module_named_object")
+  expect_identical(f$severity, "error")
+  expect_match(f$message, "collides with module name")
+})
+
+test_that("module_named_object ignores assignments with any other name", {
+  testInit()
+
+  u <- ccUse("sim_assign", name = "somethingElse", fn = "doEvent.mod.init")
+
+  expect_identical(NROW(SpaDES.core:::.ccr_module_named_object(u, list(module = "mod"))), 0L)
+})
+
+## ---- clashing_fn --------------------------------------------------------
+
+test_that("clashing_fn flags a module function named Plot", {
+  testInit()
+
+  env <- new.env()
+  env$Plot <- function() 1
+
+  f <- SpaDES.core:::.ccr_clashing_fn(ccNoUses(), list(module = "mod", moduleEnv = env))
+
+  expect_identical(NROW(f), 1L)
+  expect_identical(f$id, "clashing_module_fn")
+  expect_identical(f$severity, "warning")
+  expect_match(f$message, "quickPlot::Plot")
+})
+
+test_that("clashing_fn is quiet for an ordinary module function", {
+  testInit()
+
+  env <- new.env()
+  env$myHelper <- function() 1
+
+  expect_identical(NROW(SpaDES.core:::.ccr_clashing_fn(ccNoUses(),
+                                                       list(module = "mod", moduleEnv = env))), 0L)
+})
+
+test_that("clashing_fn is quiet when there is no module environment", {
+  testInit()
+
+  expect_identical(NROW(SpaDES.core:::.ccr_clashing_fn(ccNoUses(),
+                                                       list(module = "mod", moduleEnv = NULL))), 0L)
+})
+
+## ---- param_used_other_module --------------------------------------------
+
+test_that("param_used_other_module notes a parameter read from an unknown module", {
+  testInit()
+
+  u <- ccUse("param", name = "alpha", module = "otherMod", fn = "doEvent.mod.init", line = 5L)
+
+  f <- SpaDES.core:::.ccr_param_used_other_module(
+    u, list(module = "mod", otherModuleParams = list()))
+
+  expect_identical(NROW(f), 1L)
+  expect_identical(f$id, "param_used_other_module")
+  expect_identical(f$severity, "note")
+  expect_match(f$message, "looked up in module 'otherMod'")
+})
+
+test_that("param_used_other_module is quiet when the sibling declares the parameter", {
+  testInit()
+
+  u <- ccUse("param", name = "alpha", module = "otherMod", fn = "doEvent.mod.init")
+
+  f <- SpaDES.core:::.ccr_param_used_other_module(
+    u, list(module = "mod", otherModuleParams = list(otherMod = "alpha")))
+
+  expect_identical(NROW(f), 0L)
+})
+
+test_that("param_used_other_module ignores parameters of the current module", {
+  testInit()
+
+  u <- ccUse("param", name = "alpha", module = "mod", fn = "doEvent.mod.init")
+
+  expect_identical(
+    NROW(SpaDES.core:::.ccr_param_used_other_module(u, list(module = "mod",
+                                                            otherModuleParams = list()))),
+    0L)
+})
+
+## ---- codetools ----------------------------------------------------------
+
+test_that("codetools reports what checkUsageEnv finds", {
+  testInit()
+  skip_if_not_installed("codetools")
+
+  env <- new.env()
+  env$bad <- function() { y <- 1; invisible(NULL) }
+
+  f <- SpaDES.core:::.ccr_codetools(ccNoUses(), list(module = "mod", moduleEnv = env))
+
+  expect_identical(NROW(f), 1L)
+  expect_identical(f$id, "codetools")
+  expect_identical(f$severity, "note")
+  expect_match(f$message, "local variable")
+})
+
+test_that("codetools is quiet for clean code", {
+  testInit()
+  skip_if_not_installed("codetools")
+
+  env <- new.env()
+  env$fine <- function(x) x + 1
+
+  expect_identical(NROW(SpaDES.core:::.ccr_codetools(ccNoUses(),
+                                                     list(module = "mod", moduleEnv = env))), 0L)
+})
+
+test_that("codetools is quiet when there is no module environment", {
+  testInit()
+
+  expect_identical(NROW(SpaDES.core:::.ccr_codetools(ccNoUses(),
+                                                     list(module = "mod", moduleEnv = NULL))), 0L)
+})
+
+test_that("codetools drops the noisy doEvent parameter complaints", {
+  testInit()
+  skip_if_not_installed("codetools")
+
+  ## doEvent functions take eventTime/eventType/priority that they rarely use;
+  ## those complaints are filtered out rather than reported every time
+  env <- new.env()
+  env$doEvent.mod.init <- function(sim, eventTime, eventType, priority) sim
+
+  f <- SpaDES.core:::.ccr_codetools(ccNoUses(), list(module = "mod", moduleEnv = env))
+
+  expect_false(any(grepl("doEvent.*: parameter", f$message)))
+})

--- a/tests/testthat/test-memory.R
+++ b/tests/testthat/test-memory.R
@@ -1,0 +1,226 @@
+## memory.R: the ps-based memory sampler and the memoryUse() summary.
+##
+## The sampler normally runs inside a future::callr subprocess, so the loop is
+## also driven directly here -- coverage in a subprocess is invisible to covr,
+## and more importantly the loop's exit conditions deserve a test of their own.
+
+## ---- small helpers -----------------------------------------------------
+
+test_that("isWindows agrees with .Platform", {
+  testInit()
+
+  expect_identical(SpaDES.core:::isWindows(), identical(.Platform$OS.type, "windows"))
+})
+
+test_that("stopFilename derives the sentinel name from the output file", {
+  testInit()
+
+  expect_identical(SpaDES.core:::stopFilename("/a/b/memoryUse.csv"),
+                   "/a/b/memoryUsedone.csv")
+})
+
+test_that("outputFilename embeds the pid", {
+  testInit()
+
+  f <- SpaDES.core:::outputFilename(4242)
+
+  expect_type(f, "character")
+  expect_match(basename(f), "memAvail_4242\\.txt$")
+})
+
+## ---- memoryUseThisSession ----------------------------------------------
+
+test_that("memoryUseThisSession reports this session's memory as an object_size", {
+  skip_on_cran()
+  testInit()
+
+  m <- SpaDES.core:::memoryUseThisSession()
+
+  expect_s3_class(m, "object_size")
+  expect_true(is.numeric(unclass(m)))
+  expect_gt(as.numeric(m), 0)
+})
+
+test_that("memoryUseThisSession defaults to the current pid", {
+  skip_on_cran()
+  testInit()
+
+  expect_equal(as.numeric(SpaDES.core:::memoryUseThisSession()),
+               as.numeric(SpaDES.core:::memoryUseThisSession(Sys.getpid())),
+               tolerance = 0.5)
+})
+
+## ---- ongoingMemoryThisPid ----------------------------------------------
+
+test_that("ongoingMemoryThisPid does nothing when the interval is 0", {
+  testInit()
+
+  f <- withr::local_tempfile(fileext = ".csv")
+
+  msgs <- capture_messages(
+    out <- SpaDES.core:::ongoingMemoryThisPid(seconds = 1, interval = 0, outputFile = f)
+  )
+
+  expect_match(paste(msgs, collapse = ""), "interval is 0")
+  expect_identical(out, f)
+  expect_false(file.exists(f))
+})
+
+test_that("ongoingMemoryThisPid samples memory into the output file", {
+  skip_on_cran()
+  testInit()
+
+  ## the loop sleeps by getOption("spades.memoryUseInterval"), not by `interval`
+  withr::local_options(list(spades.memoryUseInterval = 0.1))
+  f <- withr::local_tempfile(fileext = ".csv")
+
+  out <- SpaDES.core:::ongoingMemoryThisPid(seconds = 0.3, interval = 0.1, outputFile = f)
+
+  expect_identical(out, f)
+  expect_true(file.exists(f))
+
+  dt <- data.table::fread(f)
+  expect_true(NROW(dt) >= 1)
+  expect_setequal(names(dt), c("memory", "time"))
+  expect_true(all(dt$memory > 0))
+})
+
+test_that("ongoingMemoryThisPid stops when the sentinel file appears", {
+  skip_on_cran()
+  testInit()
+
+  withr::local_options(list(spades.memoryUseInterval = 0.1))
+  f <- withr::local_tempfile(fileext = ".csv")
+  ## the sentinel is already there, so the loop must not run a single pass
+  writeLines("x", SpaDES.core:::stopFilename(f))
+  withr::defer(unlink(SpaDES.core:::stopFilename(f)))
+
+  out <- SpaDES.core:::ongoingMemoryThisPid(seconds = 100, interval = 0.1, outputFile = f)
+
+  expect_identical(out, f)
+  expect_false(file.exists(f))
+})
+
+## ---- memoryUse ---------------------------------------------------------
+
+test_that("memoryUse says so when the sim carries no memory data", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  defineEvent(sim, "tick", moduleName = "mA", code = { sim })
+  sim <- scheduleEvent(sim, 0, "mA", "tick")
+  out <- suppressMessages(spades(sim))
+
+  msgs <- capture_messages(res <- memoryUse(out))
+
+  expect_null(res)
+  expect_match(paste(msgs, collapse = ""), "no data in the sim")
+})
+
+test_that("memoryUse summarises the maximum memory per module and event", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"))
+  defineEvent(sim, "tick", moduleName = "mA", code = {
+    sim <- scheduleEvent(sim, time(sim) + 1, "mA", "tick")
+  })
+  sim <- scheduleEvent(sim, 0, "mA", "tick")
+  out <- suppressMessages(spades(sim))
+
+  ## stand in for the sampler's output: one reading per completed event
+  cmp <- completed(out)
+  out@.xData$.memoryUse <- list(obj = data.table::data.table(
+    memory = seq(100, by = 10, length.out = NROW(cmp)),
+    time = cmp[[SpaDES.core:::._txtClockTime]]
+  ))
+
+  a <- memoryUse(out)
+
+  expect_s3_class(a, "data.table")
+  expect_setequal(names(a), c("moduleName", "eventType", "maxMemory"))
+  expect_true("mA" %in% a$moduleName)
+  ## one row per module/event combination that ran
+  expect_identical(NROW(a), NROW(unique(cmp[, c("moduleName", "eventType")])))
+})
+
+test_that("memoryUse with max = FALSE keeps one row per event time", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"))
+  defineEvent(sim, "tick", moduleName = "mA", code = {
+    sim <- scheduleEvent(sim, time(sim) + 1, "mA", "tick")
+  })
+  sim <- scheduleEvent(sim, 0, "mA", "tick")
+  out <- suppressMessages(spades(sim))
+
+  cmp <- completed(out)
+  out@.xData$.memoryUse <- list(obj = data.table::data.table(
+    memory = seq(100, by = 10, length.out = NROW(cmp)),
+    time = cmp[[SpaDES.core:::._txtClockTime]]
+  ))
+
+  a <- memoryUse(out, max = FALSE)
+
+  expect_setequal(names(a), c("moduleName", "eventType", "eventTime", "maxMemory"))
+  expect_identical(NROW(a), NROW(cmp))
+})
+
+## ---- setup / teardown around spades() ----------------------------------
+
+test_that("memoryUseSetup insists on a non-sequential future plan", {
+  skip_on_cran()
+  skip_if_not_installed("future")
+  skip_if_not_installed("future.callr")
+  testInit()
+
+  originalPlan <- future::plan()
+  withr::defer(future::plan(originalPlan))
+  future::plan("sequential")
+
+  ## note: future::plan(x) returns the *previous* plan, so the current one has
+  ## to be fetched separately for `originalFuturePlan` to really be sequential
+  withr::local_options(list(spades.futurePlan = NULL))
+
+  expect_error(
+    SpaDES.core:::memoryUseSetup(simInit(), originalFuturePlan = future::plan()),
+    "you must set a future::plan"
+  )
+})
+
+test_that("spades() records memory use when an interval is set", {
+  skip_on_cran()
+  skip_if_not_installed("future")
+  skip_if_not_installed("future.callr")
+  testInit()
+
+  originalPlan <- future::plan()
+  withr::defer(future::plan(originalPlan))
+  future::plan(future.callr::callr)
+
+  withr::local_options(list(spades.memoryUseInterval = 0.2,
+                            spades.futurePlan = "callr"))
+
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"),
+                 paths = list(outputPath = tmpdir))
+  defineEvent(sim, "tick", moduleName = "mA", code = {
+    Sys.sleep(0.3)
+    sim <- scheduleEvent(sim, time(sim) + 1, "mA", "tick")
+  })
+  sim <- scheduleEvent(sim, 0, "mA", "tick")
+
+  out <- suppressMessages(spades(sim))
+
+  ## the sampler's readings were folded back into the simList ...
+  expect_true(is.data.frame(out@.xData$.memoryUse$obj))
+  expect_true(NROW(out@.xData$.memoryUse$obj) > 0)
+  ## ... and the csv it wrote was cleaned up
+  expect_false(file.exists(out@.xData$.memoryUse$filename))
+
+  a <- memoryUse(out)
+  expect_s3_class(a, "data.table")
+  expect_true("mA" %in% a$moduleName)
+  expect_true(all(a$maxMemory > 0))
+})

--- a/tests/testthat/test-module-define-extras.R
+++ b/tests/testthat/test-module-define-extras.R
@@ -1,0 +1,68 @@
+## defineParameter() edge cases: the no-argument form used to build an empty
+## parameter table, and the min/max coercion that happens when neither is given.
+
+test_that("defineParameter with no arguments returns an empty parameter table", {
+  testInit()
+
+  p <- defineParameter()
+
+  expect_s3_class(p, "data.frame")
+  expect_identical(NROW(p), 0L)
+  expect_identical(names(p),
+                   c("paramName", "paramClass", "default", "min", "max", "paramDesc"))
+})
+
+test_that("defineParameter fills min and max with a typed NA when neither is given", {
+  testInit()
+
+  p <- defineParameter("alpha", "numeric", 1, desc = "a")
+
+  expect_true(is.na(p$min[[1]]))
+  expect_true(is.na(p$max[[1]]))
+  ## the NA takes the class of the parameter, not the default logical NA
+  expect_type(p$min[[1]], "double")
+  expect_type(p$max[[1]], "double")
+})
+
+test_that("defineParameter types the NA for each of the atomic classes", {
+  testInit()
+
+  expect_type(defineParameter("a", "character", "x", desc = "")$min[[1]], "character")
+  expect_type(defineParameter("a", "integer", 1L, desc = "")$min[[1]], "integer")
+  expect_type(defineParameter("a", "logical", TRUE, desc = "")$min[[1]], "logical")
+})
+
+test_that("defineParameter picks the class the default actually matches", {
+  testInit()
+
+  ## more than one class is allowed; the NA follows whichever one `default` is
+  p <- defineParameter("a", c("numeric", "character"), 1, desc = "")
+
+  expect_type(p$min[[1]], "double")
+})
+
+test_that("defineParameter falls back to the first class when the default matches none", {
+  testInit()
+
+  p <- defineParameter("a", c("integer", "character"), 1.5, desc = "")
+
+  expect_type(p$min[[1]], "integer")
+})
+
+test_that("defineParameter leaves min and max as plain NA for a non-atomic class", {
+  testInit()
+
+  p <- defineParameter("a", "list", list(1), desc = "")
+
+  expect_true(is.na(p$min[[1]]))
+  expect_type(p$min[[1]], "logical")
+})
+
+test_that("defineParameter keeps an explicitly supplied min and max", {
+  testInit()
+
+  p <- defineParameter("alpha", "numeric", 1, 0, 10, "a")
+
+  expect_identical(p$min[[1]], 0)
+  expect_identical(p$max[[1]], 10)
+})

--- a/tests/testthat/test-module-template-extras.R
+++ b/tests/testthat/test-module-template-extras.R
@@ -1,0 +1,256 @@
+## module-template.R helpers that the existing tests do not reach: the file
+## opener, openModules()'s five methods, zipModule() and checkModulePath().
+##
+## openModules() ends by handing every file it found to .fileEdit(), which
+## launches an editor. That one call is mocked out so the file-selection logic
+## -- which is the part with the branches -- can be exercised headlessly.
+
+## ---- openIsRequested ----------------------------------------------------
+
+test_that("openIsRequested is TRUE for TRUE and for a matching suffix", {
+  testInit()
+
+  expect_true(SpaDES.core:::openIsRequested(TRUE, "r"))
+  expect_true(SpaDES.core:::openIsRequested("R", "r"))
+  expect_true(SpaDES.core:::openIsRequested("Rmd", "md"))
+})
+
+test_that("openIsRequested is FALSE for FALSE and for a non-matching suffix", {
+  testInit()
+
+  expect_false(SpaDES.core:::openIsRequested(FALSE, "r"))
+  expect_false(SpaDES.core:::openIsRequested("Rmd", "r"))
+})
+
+## ---- .fileEdit ----------------------------------------------------------
+
+test_that(".fileEdit shows the file and says so under RStudio", {
+  testInit()
+
+  f <- withr::local_tempfile(fileext = ".R")
+  writeLines("1 + 1", f)
+  withr::local_envvar(c(RSTUDIO = "1"))
+
+  msgs <- capture_messages(SpaDES.core:::.fileEdit(f))
+
+  expect_match(paste(msgs, collapse = ""), "Using RStudio")
+  expect_match(paste(msgs, collapse = ""), "file.edit(", fixed = TRUE)
+})
+
+test_that(".fileEdit strips a leading ./ from the path under RStudio", {
+  testInit()
+
+  d <- withr::local_tempdir()
+  writeLines("1 + 1", file.path(d, "a.R"))
+  owd <- setwd(d); withr::defer(setwd(owd))
+  withr::local_envvar(c(RSTUDIO = "1"))
+
+  msgs <- capture_messages(SpaDES.core:::.fileEdit("./a.R"))
+
+  expect_match(paste(msgs, collapse = ""), "file.edit('a.R')", fixed = TRUE)
+})
+
+## ---- openModules --------------------------------------------------------
+
+## a module tree with the shape openModules() expects: <path>/<mod>/<mod>.R
+modTree <- function(dir, mods = c("modA", "modB")) {
+  for (m in mods) {
+    dir.create(file.path(dir, m, "tests", "testthat"), recursive = TRUE,
+               showWarnings = FALSE)
+    writeLines("## module code", file.path(dir, m, paste0(m, ".R")))
+    writeLines("## a test", file.path(dir, m, "tests", "testthat", paste0("test-", m, ".R")))
+  }
+  dir
+}
+
+test_that("openModules opens every module's R file when asked for 'all'", {
+  skip_on_cran()
+  testInit()
+
+  d <- modTree(withr::local_tempdir())
+  opened <- character(0)
+
+  testthat::with_mocked_bindings(
+    .fileEdit = function(file) { opened <<- c(opened, file); invisible(NULL) },
+    .package = "SpaDES.core",
+    expect_null(openModules(name = "all", path = d))
+  )
+
+  expect_length(opened, 2L)
+  expect_true(all(grepl("mod[AB]/mod[AB]\\.R$", opened)))
+})
+
+test_that("openModules skips files under a module's tests directory", {
+  skip_on_cran()
+  testInit()
+
+  d <- modTree(withr::local_tempdir())
+  opened <- character(0)
+
+  testthat::with_mocked_bindings(
+    .fileEdit = function(file) { opened <<- c(opened, file); invisible(NULL) },
+    .package = "SpaDES.core",
+    openModules(name = "all", path = d)
+  )
+
+  expect_false(any(grepl("tests", opened)))
+})
+
+test_that("openModules opens just the named module", {
+  skip_on_cran()
+  testInit()
+
+  d <- modTree(withr::local_tempdir())
+  opened <- character(0)
+
+  testthat::with_mocked_bindings(
+    .fileEdit = function(file) { opened <<- c(opened, file); invisible(NULL) },
+    .package = "SpaDES.core",
+    openModules(name = "modA", path = d)
+  )
+
+  expect_length(opened, 1L)
+  expect_match(opened, "modA/modA\\.R$")
+})
+
+test_that("openModules refuses a mix of file types", {
+  skip_on_cran()
+  testInit()
+
+  d <- modTree(withr::local_tempdir())
+
+  expect_error(openModules(name = c("a.R", "b.Rmd"), path = d),
+               "Can only open one file type at a time")
+})
+
+test_that("openModules leaves the working directory where it found it", {
+  skip_on_cran()
+  testInit()
+
+  d <- modTree(withr::local_tempdir())
+  owd <- getwd()
+
+  testthat::with_mocked_bindings(
+    .fileEdit = function(file) invisible(NULL),
+    .package = "SpaDES.core",
+    openModules(name = "all", path = d)
+  )
+
+  expect_identical(getwd(), owd)
+})
+
+test_that("openModules defaults its path to the module path", {
+  skip_on_cran()
+  testInit()
+
+  d <- modTree(withr::local_tempdir())
+  withr::local_options(list(spades.modulePath = d))
+  opened <- character(0)
+
+  testthat::with_mocked_bindings(
+    .fileEdit = function(file) { opened <<- c(opened, file); invisible(NULL) },
+    .package = "SpaDES.core",
+    {
+      openModules(path = d)          # name missing
+      openModules(name = "modA")     # path missing
+    }
+  )
+
+  expect_true(length(opened) >= 3L)
+})
+
+test_that("openModules takes the modules and path from a simList", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  mp <- getSampleModules(tmpdir)
+  sim <- suppressMessages(simInit(
+    times = list(start = 0, end = 1, timeunit = "year"),
+    params = list(.globals = list(stackName = "landscape", burnStats = "npixelsburned")),
+    modules = list("randomLandscapes", "fireSpread"),
+    paths = list(modulePath = mp)))
+
+  opened <- character(0)
+  testthat::with_mocked_bindings(
+    .fileEdit = function(file) { opened <<- c(opened, file); invisible(NULL) },
+    .package = "SpaDES.core",
+    openModules(sim)
+  )
+
+  expect_true(any(grepl("randomLandscapes\\.R$", opened)))
+  expect_true(any(grepl("fireSpread\\.R$", opened)))
+})
+
+## ---- zipModule ----------------------------------------------------------
+
+test_that("zipModule bundles a module into a versioned zip inside the module dir", {
+  skip_on_cran()
+  testInit()
+
+  d <- withr::local_tempdir()
+  dir.create(file.path(d, "modA", "data"), recursive = TRUE)
+  writeLines("## code", file.path(d, "modA", "modA.R"))
+  writeLines("a", file.path(d, "modA", "data", "CHECKSUMS.txt"))
+  writeLines("payload", file.path(d, "modA", "data", "big.tif"))
+
+  suppressMessages(zipModule(name = "modA", path = d, version = "1.2.3", data = TRUE))
+
+  zf <- file.path(d, "modA", "modA_1.2.3.zip")
+  expect_true(file.exists(zf))
+  ## the zip was moved into the module directory, not left beside it
+  expect_false(file.exists(file.path(d, "modA_1.2.3.zip")))
+
+  contents <- unzip(zf, list = TRUE)$Name
+  expect_true(any(grepl("modA\\.R$", contents)))
+  expect_true(any(grepl("big\\.tif$", contents)))
+})
+
+test_that("zipModule with data = FALSE keeps CHECKSUMS.txt but drops the data files", {
+  skip_on_cran()
+  testInit()
+
+  d <- withr::local_tempdir()
+  dir.create(file.path(d, "modA", "data"), recursive = TRUE)
+  writeLines("## code", file.path(d, "modA", "modA.R"))
+  writeLines("a", file.path(d, "modA", "data", "CHECKSUMS.txt"))
+  writeLines("payload", file.path(d, "modA", "data", "big.tif"))
+
+  suppressMessages(zipModule(name = "modA", path = d, version = "1.2.3", data = FALSE))
+
+  contents <- unzip(file.path(d, "modA", "modA_1.2.3.zip"), list = TRUE)$Name
+  expect_true(any(grepl("CHECKSUMS\\.txt$", contents)))
+  expect_false(any(grepl("big\\.tif$", contents)))
+})
+
+test_that("zipModule leaves the working directory where it found it", {
+  skip_on_cran()
+  testInit()
+
+  d <- withr::local_tempdir()
+  dir.create(file.path(d, "modA"), recursive = TRUE)
+  writeLines("## code", file.path(d, "modA", "modA.R"))
+  owd <- getwd()
+
+  suppressMessages(zipModule(name = "modA", path = d, version = "0.0.1", data = TRUE))
+
+  expect_identical(getwd(), owd)
+})
+
+## ---- checkModulePath ----------------------------------------------------
+
+test_that("checkModulePath returns '.' when the module path is still the default", {
+  testInit()
+
+  withr::local_options(list(spades.modulePath = spadesOptions()[["spades.modulePath"]]))
+
+  expect_identical(SpaDES.core:::checkModulePath(), ".")
+})
+
+test_that("checkModulePath returns the module path once it has been set", {
+  testInit()
+
+  d <- withr::local_tempdir()
+  withr::local_options(list(spades.modulePath = d))
+
+  expect_identical(normPath(SpaDES.core:::checkModulePath()), normPath(d))
+})

--- a/tests/testthat/test-outputs-rmDups.R
+++ b/tests/testthat/test-outputs-rmDups.R
@@ -1,0 +1,68 @@
+## rmDups(): drops duplicated rows from sim@outputs. The `arguments` column is
+## an AsIs list, which data.table cannot uniquify on, so those columns are
+## handled by a second pass -- that pass is what these tests drive.
+
+outputsTable <- function(objectName, file, arguments = NULL) {
+  n <- length(objectName)
+  if (is.null(arguments)) arguments <- vector("list", n)
+  data.table::data.table(
+    objectName = objectName, saveTime = rep(1, n), file = file,
+    fun = rep("saveRDS", n), package = rep("base", n),
+    saved = rep(NA, n), arguments = I(arguments)
+  )
+}
+
+test_that("rmDups removes an exactly duplicated output row", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"))
+  sim@outputs <- outputsTable(c("a", "a", "b"), c("f1", "f1", "f2"))
+
+  out <- SpaDES.core:::rmDups(sim)
+
+  expect_identical(NROW(out@outputs), 2L)
+  expect_identical(out@outputs$objectName, c("a", "b"))
+})
+
+test_that("rmDups keeps rows that differ in the file they save to", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"))
+  sim@outputs <- outputsTable(c("a", "a"), c("f1", "f2"))
+
+  out <- SpaDES.core:::rmDups(sim)
+
+  expect_identical(NROW(out@outputs), 2L)
+})
+
+test_that("rmDups keeps rows whose AsIs arguments differ", {
+  skip_on_cran()
+  testInit()
+
+  ## everything data.table can compare is identical, so only the `arguments`
+  ## column distinguishes these two rows -- they must both survive
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"))
+  sim@outputs <- outputsTable(c("a", "a"), c("f1", "f1"),
+                              arguments = list(list(compress = TRUE),
+                                               list(compress = FALSE)))
+
+  out <- SpaDES.core:::rmDups(sim)
+
+  expect_identical(NROW(out@outputs), 2L)
+})
+
+test_that("rmDups leaves a table with no duplicates untouched", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"))
+  tbl <- outputsTable(c("a", "b", "c"), c("f1", "f2", "f3"))
+  sim@outputs <- tbl
+
+  out <- SpaDES.core:::rmDups(sim)
+
+  expect_identical(NROW(out@outputs), 3L)
+  expect_identical(out@outputs$objectName, c("a", "b", "c"))
+})

--- a/tests/testthat/test-parameters-accessor.R
+++ b/tests/testthat/test-parameters-accessor.R
@@ -1,0 +1,151 @@
+## parameters(): the module *parameter definition* tables, in both the
+## data.frame and the nested-list shape. params() is the current values; this is
+## the declared metadata, and its two branches were untested.
+
+twoModuleSim <- function(tmpdir) {
+  suppressMessages(simInit(
+    times = list(start = 0, end = 1, timeunit = "year"),
+    params = list(.globals = list(stackName = "landscape",
+                                  burnStats = "npixelsburned")),
+    modules = list("randomLandscapes", "fireSpread"),
+    paths = list(modulePath = getSampleModules(tmpdir))))
+}
+
+test_that("parameters(asDF = TRUE) stacks every module's definitions into one frame", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  p <- parameters(twoModuleSim(tmpdir), asDF = TRUE)
+
+  expect_s3_class(p, "data.frame")
+  expect_identical(names(p),
+                   c("paramName", "paramClass", "default", "min", "max", "paramDesc"))
+  expect_gt(NROW(p), 0L)
+  ## parameters from both modules are present
+  expect_true(all(c("nx", "ny") %in% p$paramName))
+})
+
+test_that("parameters() defaults to a list of one entry per module", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  p <- parameters(twoModuleSim(tmpdir))
+
+  expect_type(p, "list")
+  expect_setequal(names(p), c("randomLandscapes", "fireSpread"))
+  ## each module's entry is itself named by parameter
+  expect_true(all(c("nx", "ny") %in% names(p[["randomLandscapes"]])))
+})
+
+test_that("parameters() and parameters(asDF = TRUE) describe the same parameters", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  sim <- twoModuleSim(tmpdir)
+
+  asList <- parameters(sim)
+  asDF <- parameters(sim, asDF = TRUE)
+
+  expect_setequal(unlist(lapply(asList, names), use.names = FALSE), asDF$paramName)
+})
+
+test_that("parameters() is empty for a sim with no modules", {
+  skip_on_cran()
+  testInit()
+
+  expect_null(parameters(simInit()))
+})
+
+test_that("inputs() converts loadTime into the sim's timeunit", {
+  skip_on_cran()
+  testInit()
+
+  f <- file.path(tmpdir, "in.rds")
+  saveRDS(1:3, f)
+
+  sim <- suppressMessages(simInit(
+    times = list(start = 0, end = 2, timeunit = "year"),
+    inputs = data.frame(file = f, objectName = "io", loadTime = 1)))
+
+  ii <- inputs(sim)
+
+  expect_s3_class(ii, "data.frame")
+  expect_identical(NROW(ii), 1L)
+  expect_identical(as.numeric(ii$loadTime), 1)
+  expect_identical(ii$objectName, "io")
+})
+
+## ---- newObjectsCreated --------------------------------------------------
+
+test_that("newObjectsCreated returns an empty table when nothing was recorded", {
+  skip_on_cran()
+  testInit()
+
+  d <- newObjectsCreated(simInit(times = list(start = 0, end = 2, timeunit = "year")))
+
+  expect_s3_class(d, "data.table")
+  expect_identical(NROW(d), 0L)
+  expect_true(all(c("newObjects", "eventTime", "moduleName", "eventType",
+                    "eventPriority") %in% names(d)))
+})
+
+test_that("newObjectsCreated returns and prints what was recorded", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 2, timeunit = "year"))
+  sim$._objectsCreated <- list(
+    data.table::data.table(newObjects = "b", eventTime = 1, moduleName = "m",
+                           eventType = "e", eventPriority = 1),
+    data.table::data.table(newObjects = "a", eventTime = 2, moduleName = "m",
+                           eventType = "e", eventPriority = 1))
+
+  printed <- capture.output(d <- newObjectsCreated(sim))
+
+  expect_identical(NROW(d), 2L)
+  ## the rows come back ordered by object name
+  expect_identical(d$newObjects, c("a", "b"))
+  expect_gt(length(printed), 0L)
+})
+
+## ---- inputArgs<- --------------------------------------------------------
+
+inputSim <- function(tmpdir) {
+  f <- file.path(tmpdir, "ia.rds")
+  saveRDS(1, f)
+  suppressMessages(simInit(times = list(start = 0, end = 2, timeunit = "year"),
+                           inputs = data.frame(file = f, objectName = "io")))
+}
+
+test_that("inputArgs<- accepts a list", {
+  skip_on_cran()
+  testInit()
+
+  sim <- inputSim(tmpdir)
+  inputArgs(sim) <- list(list(a = 1))
+
+  expect_type(inputArgs(sim), "list")
+  expect_identical(inputArgs(sim)[[1]], list(a = 1))
+})
+
+test_that("inputArgs<- NULL blanks one entry per input row", {
+  skip_on_cran()
+  testInit()
+
+  sim <- inputSim(tmpdir)
+  inputArgs(sim) <- list(list(a = 1))
+  inputArgs(sim) <- NULL
+
+  expect_length(inputArgs(sim), NROW(inputs(sim)))
+  expect_null(inputArgs(sim)[[1]])
+})
+
+test_that("inputArgs<- rejects anything that is not a list", {
+  skip_on_cran()
+  testInit()
+
+  sim <- inputSim(tmpdir)
+
+  expect_error({inputArgs(sim) <- "nope"},
+               "must be a list of named elements")
+})

--- a/tests/testthat/test-plotting-diagrams.R
+++ b/tests/testthat/test-plotting-diagrams.R
@@ -1,0 +1,295 @@
+## Diagram helpers in plotting-diagrams.R: ganttStatus(), .sim2gantt(),
+## eventDiagram(), objectDiagram(), moduleDiagram() and moduleGraph().
+##
+## The Gantt-chart side only needs a completed event list, so those tests build a
+## cheap sim with defineEvent() rather than loading the sample modules. The
+## dependency-graph side needs real module metadata, so those use the sample
+## modules but stop at simInit() -- none of them needs the sim to have been run.
+
+ranSim <- function(end = 2) {
+  sim <- simInit(times = list(start = 0, end = end, timeunit = "year"))
+  defineEvent(sim, "init", moduleName = "mA", code = {
+    sim <- scheduleEvent(sim, time(sim), "mA", "grow")
+  })
+  defineEvent(sim, "grow", moduleName = "mA", code = {
+    sim <- scheduleEvent(sim, time(sim) + 1, "mA", "grow")
+  })
+  defineEvent(sim, "plot", moduleName = "mB", code = {
+    sim <- scheduleEvent(sim, time(sim) + 1, "mB", "plot")
+  })
+  sim <- scheduleEvent(sim, 0, "mA", "init")
+  sim <- scheduleEvent(sim, 0, "mB", "plot")
+  suppressMessages(spades(sim))
+}
+
+## ---- ganttStatus -------------------------------------------------------
+
+test_that("ganttStatus maps init, plot and everything else to mermaid statuses", {
+  testInit()
+
+  expect_identical(ganttStatus("init"), "done")
+  expect_identical(ganttStatus("plot"), "crit")
+  expect_identical(ganttStatus("grow"), "active")
+})
+
+test_that("ganttStatus is vectorised over the event types", {
+  testInit()
+
+  expect_identical(ganttStatus(c("init", "plot", "grow", "save")),
+                   c("done", "crit", "active", "active"))
+})
+
+## ---- .sim2gantt --------------------------------------------------------
+
+test_that(".sim2gantt returns one data.frame per module in the completed list", {
+  skip_on_cran()
+  testInit()
+
+  out <- ranSim()
+  ll <- SpaDES.core:::.sim2gantt(out, n = NROW(completed(out)),
+                                 startDate = "2000-01-01", width = 1000)
+
+  expect_type(ll, "list")
+  expect_setequal(names(ll), unique(completed(out)$moduleName))
+  expect_true(all(vapply(ll, is.data.frame, logical(1))))
+  expect_true(all(vapply(ll, function(d)
+    all(c("task", "status", "pos", "start", "end") %in% names(d)), logical(1))))
+})
+
+test_that(".sim2gantt dates the tasks from startDate and orders start before end", {
+  skip_on_cran()
+  testInit()
+
+  out <- ranSim()
+  ll <- SpaDES.core:::.sim2gantt(out, n = NROW(completed(out)),
+                                 startDate = "2000-01-01", width = 1000)
+  d <- ll[["mA"]]
+
+  expect_s3_class(d$start, "Date")
+  expect_s3_class(d$end, "Date")
+  expect_true(all(d$start >= as.Date("2000-01-01")))
+  expect_true(all(d$end > d$start))
+  ## the status column is ganttStatus() applied to the tasks
+  expect_identical(d$status, ganttStatus(d$task))
+})
+
+test_that(".sim2gantt honours n, keeping only the most recent events", {
+  skip_on_cran()
+  testInit()
+
+  out <- ranSim(end = 3)
+  ll <- SpaDES.core:::.sim2gantt(out, n = 2, startDate = "2000-01-01", width = 1000)
+
+  expect_identical(sum(vapply(ll, NROW, integer(1))), 2L)
+})
+
+## ---- eventDiagram ------------------------------------------------------
+
+test_that("eventDiagram builds a mermaid gantt chart from a completed sim", {
+  skip_on_cran()
+  skip_if_not_installed("DiagrammeR")
+  testInit()
+
+  out <- ranSim()
+  d <- eventDiagram(out, n = NROW(completed(out)), startDate = "2000-01-01")
+
+  expect_s3_class(d, "htmlwidget")
+  expect_match(d$x$diagram, "^gantt")
+  expect_match(d$x$diagram, "title SpaDES event diagram")
+  expect_match(d$x$diagram, "section  mA")
+})
+
+test_that("eventDiagram defaults n to the whole completed list", {
+  skip_on_cran()
+  skip_if_not_installed("DiagrammeR")
+  testInit()
+
+  out <- ranSim()
+  withN <- eventDiagram(out, n = NROW(completed(out)), startDate = "2000-01-01")
+  noN <- eventDiagram(out, startDate = "2000-01-01")
+
+  expect_identical(noN$x$diagram, withN$x$diagram)
+})
+
+test_that("eventDiagram defaults startDate to today", {
+  skip_on_cran()
+  skip_if_not_installed("DiagrammeR")
+  testInit()
+
+  out <- ranSim()
+  d <- eventDiagram(out)
+
+  expect_s3_class(d, "htmlwidget")
+  ## start(sim) is 0, so the origin is today's date
+  expect_match(d$x$diagram, format(Sys.Date(), "%Y-%m-%d"))
+})
+
+test_that("eventDiagram passes width and height through to mermaid", {
+  skip_on_cran()
+  skip_if_not_installed("DiagrammeR")
+  testInit()
+
+  out <- ranSim()
+  d <- eventDiagram(out, n = NROW(completed(out)), startDate = "2000-01-01",
+                    width = 500, height = 700)
+
+  expect_identical(d$width, 500)
+  expect_identical(d$height, 700)
+})
+
+test_that("eventDiagram drops the progress module from the chart", {
+  skip_on_cran()
+  skip_if_not_installed("DiagrammeR")
+  testInit()
+
+  out <- ranSim()
+  ## fake a progress event in the completed list
+  cmp <- completed(out)
+  cmp$moduleName[1] <- "progress"
+  out@completed <- as.environment(list2env(setNames(
+    lapply(seq_len(NROW(cmp)), function(i) as.list(cmp[i, ])), as.character(seq_len(NROW(cmp))))))
+
+  d <- eventDiagram(out, n = NROW(cmp), startDate = "2000-01-01")
+
+  expect_false(grepl("section  progress", d$x$diagram))
+})
+
+test_that("eventDiagram refuses a simulation that has not been run", {
+  skip_on_cran()
+  skip_if_not_installed("DiagrammeR")
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+
+  expect_error(eventDiagram(sim, n = 0, startDate = "2000-01-01"),
+               "hasn't been run")
+})
+
+## ---- objectDiagram -----------------------------------------------------
+
+test_that("objectDiagram builds a mermaid sequence diagram of the object deps", {
+  skip_on_cran()
+  skip_if_not_installed("DiagrammeR")
+  testInit(sampleModReqdPkgs)
+
+  sim <- suppressMessages(simInit(
+    times = list(start = 0, end = 1, timeunit = "year"),
+    params = list(.globals = list(stackName = "landscape", burnStats = "npixelsburned")),
+    modules = list("randomLandscapes", "fireSpread"),
+    paths = list(modulePath = getSampleModules(tmpdir))))
+
+  d <- objectDiagram(sim)
+
+  expect_s3_class(d, "htmlwidget")
+  expect_match(d$x$diagram, "^sequenceDiagram")
+  ## every edge of the dependency list appears as a mermaid message
+  dt <- depsEdgeList(sim, FALSE)
+  expect_match(d$x$diagram, paste(dt$from[1], "->>", dt$to[1], ":", dt$objName[1]),
+               fixed = TRUE)
+})
+
+test_that("objectDiagram accepts height and width", {
+  skip_on_cran()
+  skip_if_not_installed("DiagrammeR")
+  testInit(sampleModReqdPkgs)
+
+  sim <- suppressMessages(simInit(
+    times = list(start = 0, end = 1, timeunit = "year"),
+    params = list(.globals = list(stackName = "landscape", burnStats = "npixelsburned")),
+    modules = list("randomLandscapes", "fireSpread"),
+    paths = list(modulePath = getSampleModules(tmpdir))))
+
+  d <- objectDiagram(sim, height = 3000, width = 2000)
+
+  expect_identical(d$height, 3000)
+  expect_identical(d$width, 2000)
+})
+
+## ---- moduleDiagram -----------------------------------------------------
+
+test_that("moduleDiagram plots the module dependency graph", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  sim <- suppressMessages(simInit(
+    times = list(start = 0, end = 1, timeunit = "year"),
+    params = list(.globals = list(stackName = "landscape", burnStats = "npixelsburned")),
+    modules = list("randomLandscapes", "fireSpread"),
+    paths = list(modulePath = getSampleModules(tmpdir))))
+
+  grDevices::png(withr::local_tempfile(fileext = ".png"))
+  withr::defer(grDevices::dev.off())
+
+  expect_no_error(suppressMessages(moduleDiagram(sim)))
+})
+
+test_that("moduleDiagram accepts a supplied title", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  sim <- suppressMessages(simInit(
+    times = list(start = 0, end = 1, timeunit = "year"),
+    params = list(.globals = list(stackName = "landscape", burnStats = "npixelsburned")),
+    modules = list("randomLandscapes", "fireSpread"),
+    paths = list(modulePath = getSampleModules(tmpdir))))
+
+  grDevices::png(withr::local_tempfile(fileext = ".png"))
+  withr::defer(grDevices::dev.off())
+
+  expect_no_error(suppressMessages(moduleDiagram(sim, title = "custom")))
+})
+
+test_that("moduleDiagram's type method reaches base plot", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  sim <- suppressMessages(simInit(
+    times = list(start = 0, end = 1, timeunit = "year"),
+    params = list(.globals = list(stackName = "landscape", burnStats = "npixelsburned")),
+    modules = list("randomLandscapes", "fireSpread"),
+    paths = list(modulePath = getSampleModules(tmpdir))))
+
+  grDevices::png(withr::local_tempfile(fileext = ".png"))
+  withr::defer(grDevices::dev.off())
+
+  expect_no_error(suppressMessages(moduleDiagram(sim, type = "plot", showParents = FALSE)))
+})
+
+## ---- moduleGraph -------------------------------------------------------
+
+test_that("moduleGraph returns the graph and its communities", {
+  skip_on_cran()
+  testInit(sampleModReqdPkgs)
+
+  if (Sys.which("glpsol") == "") skip("GLPK not available")
+
+  sim <- suppressMessages(simInit(
+    times = list(start = 0, end = 1, timeunit = "year"),
+    params = list(.globals = list(stackName = "landscape", burnStats = "npixelsburned")),
+    modules = list("randomLandscapes", "fireSpread"),
+    paths = list(modulePath = getSampleModules(tmpdir))))
+
+  mg <- suppressMessages(moduleGraph(sim, plot = FALSE))
+
+  ## NULL when igraph lacks GLPK support even though glpsol is on the PATH
+  skip_if(is.null(mg), "igraph not compiled with GLPK support")
+
+  expect_type(mg, "list")
+  expect_setequal(names(mg), c("graph", "communities"))
+  expect_s3_class(mg$graph, "igraph")
+  expect_true(all(c("randomLandscapes", "fireSpread") %in% names(igraph::V(mg$graph))))
+})
+
+test_that("moduleGraph tells the user how to install GLPK when it is missing", {
+  testInit()
+
+  ## the sim is never touched: the missing-GLPK branch returns before it is used
+  withr::local_envvar(c(PATH = ""))
+  skip_if(Sys.which("glpsol") != "", "could not hide glpsol from Sys.which")
+  skip_if(!Sys.info()[["sysname"]] %in% c("Darwin", "Linux"), "message is unix-only")
+
+  msgs <- capture_messages(res <- moduleGraph(simInit(), plot = FALSE))
+
+  expect_null(res)
+  expect_match(paste(msgs, collapse = ""), "GLPK not found")
+})

--- a/tests/testthat/test-rasterToMemory.R
+++ b/tests/testthat/test-rasterToMemory.R
@@ -110,3 +110,50 @@ test_that("rasterCreate returns an empty raster with the same geometry", {
   expect_identical(as.vector(terra::ext(out)), as.vector(terra::ext(r)))
   expect_false(terra::hasValues(out))
 })
+
+## ---- the raster (as opposed to terra) branches ---------------------------
+
+test_that("rasterToMemory brings a file-backed RasterLayer into memory", {
+  skip_on_cran()
+  skip_if_not_installed("raster")
+  testInit()
+
+  f <- file.path(tmpdir, "rl.tif")
+  terra::writeRaster(terra::rast(nrows = 4, ncols = 4, vals = 1:16), f)
+  r <- raster::raster(f)
+  expect_false(raster::inMemory(r))
+
+  m <- rasterToMemory(r)
+
+  expect_s4_class(m, "RasterLayer")
+  expect_true(raster::inMemory(m))
+})
+
+test_that("rasterToMemory keeps a RasterStack a RasterStack", {
+  skip_on_cran()
+  skip_if_not_installed("raster")
+  testInit()
+
+  f <- file.path(tmpdir, "rs.tif")
+  terra::writeRaster(terra::rast(nrows = 4, ncols = 4, vals = 1:16), f)
+
+  m <- rasterToMemory(raster::stack(f))
+
+  expect_s4_class(m, "RasterStack")
+})
+
+test_that("rasterCreate rebuilds each Raster* subclass as itself", {
+  skip_on_cran()
+  skip_if_not_installed("raster")
+  testInit()
+
+  f <- file.path(tmpdir, "rc.tif")
+  terra::writeRaster(terra::rast(nrows = 4, ncols = 4, vals = 1:16), f)
+
+  expect_s4_class(rasterCreate(raster::raster(f)), "RasterLayer")
+  expect_s4_class(rasterCreate(raster::stack(f)), "RasterStack")
+
+  fb <- file.path(tmpdir, "rb.tif")
+  terra::writeRaster(c(terra::rast(f), terra::rast(f)), fb)
+  expect_s4_class(rasterCreate(raster::brick(fb)), "RasterBrick")
+})

--- a/tests/testthat/test-rasterToMemory.R
+++ b/tests/testthat/test-rasterToMemory.R
@@ -1,0 +1,112 @@
+## rasterToMemory() / rasterCreate(): pulling file-backed rasters into RAM.
+
+test_that("rasterToMemory brings a file-backed SpatRaster into memory", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit()
+
+  f <- file.path(tmpdir, "r.tif")
+  terra::writeRaster(terra::rast(nrows = 5, ncols = 5, vals = 1:25), f)
+  r <- terra::rast(f)
+  expect_true(any(nchar(Filenames(r)) > 0))
+
+  m <- rasterToMemory(r)
+
+  expect_s4_class(m, "SpatRaster")
+  expect_identical(nchar(Filenames(m)), 0L)
+  expect_identical(as.numeric(terra::values(m)), as.numeric(1:25))
+})
+
+test_that("rasterToMemory leaves an in-memory raster alone", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit()
+
+  r <- terra::rast(nrows = 2, ncols = 2, vals = 1:4)
+
+  m <- rasterToMemory(r)
+
+  expect_s4_class(m, "SpatRaster")
+  expect_identical(as.numeric(terra::values(m)), as.numeric(1:4))
+})
+
+test_that("rasterToMemory passes a non-raster, non-character object through", {
+  skip_on_cran()
+  testInit()
+
+  expect_identical(rasterToMemory(1:3), 1:3)
+  expect_identical(rasterToMemory(list(a = 1)[["a"]]), 1)
+})
+
+test_that("rasterToMemory reads a character path as a raster file", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit()
+
+  f <- file.path(tmpdir, "byName.tif")
+  terra::writeRaster(terra::rast(nrows = 3, ncols = 3, vals = 1:9), f)
+
+  m <- rasterToMemory(f)
+
+  expect_s4_class(m, "SpatRaster")
+  expect_identical(nchar(Filenames(m)), 0L)
+  expect_identical(as.numeric(terra::values(m)), as.numeric(1:9))
+})
+
+test_that("rasterToMemory maps over a list", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit()
+
+  f <- file.path(tmpdir, "inList.tif")
+  terra::writeRaster(terra::rast(nrows = 2, ncols = 2, vals = 1:4), f)
+
+  out <- rasterToMemory(list(r = terra::rast(f), n = 42))
+
+  expect_type(out, "list")
+  expect_identical(nchar(Filenames(out$r)), 0L)
+  expect_identical(out$n, 42)
+})
+
+test_that("rasterToMemory on a simList converts every raster it holds", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit()
+
+  f <- file.path(tmpdir, "r2.tif")
+  terra::writeRaster(terra::rast(nrows = 4, ncols = 4, vals = 1:16), f)
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim$ras <- terra::rast(f)
+  sim$notARaster <- 42
+
+  out <- rasterToMemory(sim)
+
+  expect_s4_class(out, "simList")
+  expect_identical(nchar(Filenames(out$ras)), 0L)
+  expect_identical(out$notARaster, 42)
+})
+
+test_that("rasterCreate passes a non-raster through unchanged", {
+  testInit()
+
+  expect_identical(rasterCreate(1:3), 1:3)
+  expect_identical(rasterCreate("a"), "a")
+})
+
+test_that("rasterCreate returns an empty raster with the same geometry", {
+  skip_on_cran()
+  skip_if_not_installed("terra")
+  testInit()
+
+  ## terra::rast(x) deliberately keeps only the geometry -- rasterToMemory()
+  ## assigns the values immediately afterwards, so this is the contract
+  r <- terra::rast(nrows = 3, ncols = 3, vals = 1:9)
+
+  out <- rasterCreate(r)
+
+  expect_s4_class(out, "SpatRaster")
+  expect_identical(dim(out), dim(r))
+  expect_identical(as.vector(terra::ext(out)), as.vector(terra::ext(r)))
+  expect_false(terra::hasValues(out))
+})

--- a/tests/testthat/test-saveLoadSimList-helpers.R
+++ b/tests/testthat/test-saveLoadSimList-helpers.R
@@ -1,0 +1,339 @@
+## The small, pure helpers behind saveSimList()/loadSimList(): archive name
+## handling, path relativisation, the deep environment cloner and the anchor
+## list offered to reproducible's .wrap()/.unwrap().
+
+## ---- archive name handling ---------------------------------------------
+
+test_that("checkArchiveAlternative returns the filename when it exists", {
+  testInit()
+
+  f <- withr::local_tempfile(fileext = ".qs2")
+  writeLines("x", f)
+
+  expect_identical(SpaDES.core:::checkArchiveAlternative(f), f)
+})
+
+test_that("checkArchiveAlternative finds a sibling archive when the file is missing", {
+  testInit()
+
+  d <- withr::local_tempdir()
+  writeLines("x", file.path(d, "mySim.tar.gz"))
+
+  out <- SpaDES.core:::checkArchiveAlternative(file.path(d, "mySim.qs2"))
+
+  expect_identical(normPath(out), normPath(file.path(d, "mySim.tar.gz")))
+})
+
+test_that("checkArchiveAlternative leaves the name alone when no archive is there", {
+  testInit()
+
+  d <- withr::local_tempdir()
+  missing <- file.path(d, "mySim.qs2")
+
+  expect_identical(SpaDES.core:::checkArchiveAlternative(missing), missing)
+})
+
+test_that("archiveConvertFileExt swaps the extension", {
+  testInit()
+
+  expect_identical(SpaDES.core:::archiveConvertFileExt("/a/b/sim.zip", "tar.gz"),
+                   "/a/b/sim.tar.gz")
+  expect_identical(SpaDES.core:::archiveConvertFileExt("/a/b/sim.qs2", "zip"),
+                   "/a/b/sim.zip")
+
+  ## NOTE: not asserted here -- converting "sim.tar.gz" to "zip" currently gives
+  ## "sim.tar.zip", because tools::file_ext() sees only the "gz". The gsub() is
+  ## also unanchored, so a directory named e.g. "gz" would be rewritten too.
+  ## Both look wrong, so neither is pinned down by a test until it is decided.
+})
+
+test_that("archiveConvertFileExt leaves a tar.gz name alone when converting to tar.gz", {
+  testInit()
+
+  ## gsub() on file_ext() would turn "sim.tar.gz" into "sim.tar.tar.gz"
+  expect_identical(SpaDES.core:::archiveConvertFileExt("/a/b/sim.tar.gz", "tar.gz"),
+                   "/a/b/sim.tar.gz")
+})
+
+test_that("checkSimListExts accepts the supported extensions and rejects others", {
+  testInit()
+
+  for (f in c("a.qs2", "a.rds", "a.zip", "a.tar", "a.tar.gz", "a.RDS"))
+    expect_silent(SpaDES.core:::checkSimListExts(f))
+
+  expect_error(SpaDES.core:::checkSimListExts("a.txt"))
+})
+
+test_that("archiveWrite and archiveExtract round-trip files relative to projectPath", {
+  skip_on_cran()
+  testInit()
+
+  proj <- withr::local_tempdir()
+  dir.create(file.path(proj, "outputs"))
+  writeLines("hello", file.path(proj, "outputs", "a.txt"))
+  writeLines("world", file.path(proj, "sim.qs2"))
+
+  arch <- file.path(withr::local_tempdir(), "bundle.tar.gz")
+  SpaDES.core:::archiveWrite(arch, c("sim.qs2", file.path("outputs", "a.txt")),
+                             verbose = -1, projectPath = proj)
+
+  arch <- SpaDES.core:::archiveConvertFileExt(arch, "tar.gz")
+  expect_true(file.exists(arch))
+  ## writing must not leave the session in projectPath
+  expect_false(identical(normPath(getwd()), normPath(proj)))
+
+  exdir <- withr::local_tempdir()
+  owd <- setwd(exdir); withr::defer(setwd(owd))
+  out <- SpaDES.core:::archiveExtract(arch, exdir = exdir)
+
+  expect_true(any(grepl("a\\.txt$", out)))
+  expect_true(any(grepl("sim\\.qs2$", out)))
+})
+
+## ---- deprecation text ---------------------------------------------------
+
+test_that("warnDeprecFileBacked returns the right text for each deprecated arg", {
+  testInit()
+
+  expect_match(SpaDES.core:::warnDeprecFileBacked("fileBackedDir"), "use projectPath")
+  expect_match(SpaDES.core:::warnDeprecFileBacked("fileBackend"), "file-backed objects are")
+})
+
+test_that("warnDeprecFileBacked errors on an unknown arg", {
+  testInit()
+
+  expect_error(SpaDES.core:::warnDeprecFileBacked("nonsense"),
+               "No deprecation warning with that arg")
+})
+
+test_that("unzipSimList is deprecated in favour of loadSimList", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim$a <- 1
+  f <- file.path(tmpdir, "sim.qs2")
+  suppressMessages(saveSimList(sim, f))
+
+  expect_warning(out <- suppressMessages(SpaDES.core:::unzipSimList(f)), "deprecated")
+  expect_s4_class(out, "simList")
+})
+
+## ---- path relativisation ------------------------------------------------
+
+test_that("relativizePaths makes the core paths relative to projectPath", {
+  testInit()
+
+  proj <- normPath(withr::local_tempdir())
+  paths <- list(cachePath = file.path(proj, "cache"),
+                inputPath = file.path(proj, "inputs"),
+                modulePath = file.path(proj, "modules"),
+                outputPath = file.path(proj, "outputs"),
+                rasterPath = file.path(proj, "scratch", "raster"),
+                scratchPath = file.path(proj, "scratch"),
+                terraPath = file.path(proj, "scratch", "terra"))
+
+  p <- SpaDES.core:::relativizePaths(paths, projectPath = proj)
+
+  expect_identical(unname(p[["modulePath"]]), "modules")
+  expect_identical(unname(p[["outputPath"]]), "outputs")
+  ## the tmp paths are relative to scratchPath, not to projectPath
+  expect_identical(unname(p[["rasterPath"]]), "raster")
+  expect_identical(unname(p[["terraPath"]]), "terra")
+})
+
+test_that("relativizePaths infers projectPath from modulePath when not given", {
+  testInit()
+
+  proj <- normPath(withr::local_tempdir())
+  paths <- list(cachePath = file.path(proj, "cache"),
+                inputPath = file.path(proj, "inputs"),
+                modulePath = file.path(proj, "modules"),
+                outputPath = file.path(proj, "outputs"),
+                rasterPath = file.path(proj, "scratch", "raster"),
+                scratchPath = file.path(proj, "scratch"),
+                terraPath = file.path(proj, "scratch", "terra"))
+
+  p <- SpaDES.core:::relativizePaths(paths)
+
+  expect_identical(unname(p[["modulePath"]]), "modules")
+})
+
+test_that("absolutizePaths undoes relativizePaths", {
+  testInit()
+
+  proj <- normPath(withr::local_tempdir())
+  scratch <- file.path(proj, "scratch")
+  paths <- list(cachePath = file.path(proj, "cache"),
+                inputPath = file.path(proj, "inputs"),
+                modulePath = file.path(proj, "modules"),
+                outputPath = file.path(proj, "outputs"),
+                rasterPath = file.path(scratch, "raster"),
+                scratchPath = scratch,
+                terraPath = file.path(scratch, "terra"))
+
+  rel <- SpaDES.core:::relativizePaths(paths, projectPath = proj)
+  back <- SpaDES.core:::absolutizePaths(rel, projectPath = proj, tempdir = scratch)
+
+  for (n in names(paths))
+    expect_identical(normPath(back[[n]]), normPath(paths[[n]]))
+})
+
+## ---- .cloneEnvDeep / .cloneSimEnvs --------------------------------------
+
+test_that(".cloneEnvDeep passes non-environments straight through", {
+  testInit()
+
+  expect_identical(SpaDES.core:::.cloneEnvDeep(1:3), 1:3)
+  expect_identical(SpaDES.core:::.cloneEnvDeep("a"), "a")
+})
+
+test_that(".cloneEnvDeep copies bindings into a new environment", {
+  testInit()
+
+  e <- new.env(parent = emptyenv())
+  e$a <- 1
+  e$b <- "two"
+
+  out <- SpaDES.core:::.cloneEnvDeep(e)
+
+  expect_false(identical(out, e))
+  expect_setequal(ls(out), c("a", "b"))
+  expect_identical(out$a, 1)
+  ## a real copy: changing one must not change the other
+  out$a <- 99
+  expect_identical(e$a, 1)
+})
+
+test_that(".cloneEnvDeep recurses into nested environments", {
+  testInit()
+
+  e <- new.env(parent = emptyenv())
+  e$inner <- new.env(parent = emptyenv())
+  e$inner$x <- 1
+
+  out <- SpaDES.core:::.cloneEnvDeep(e)
+
+  expect_false(identical(out$inner, e$inner))
+  expect_identical(out$inner$x, 1)
+  out$inner$x <- 42
+  expect_identical(e$inner$x, 1)
+})
+
+test_that(".cloneEnvDeep survives a cycle and preserves the sharing", {
+  testInit()
+
+  e <- new.env(parent = emptyenv())
+  e$self <- e
+  e$x <- 1
+
+  out <- SpaDES.core:::.cloneEnvDeep(e)
+
+  ## the cycle guard means the clone points at itself, not at the original
+  expect_identical(out$self, out)
+  expect_false(identical(out$self, e))
+})
+
+test_that(".cloneEnvDeep keeps active bindings active", {
+  testInit()
+
+  e <- new.env(parent = emptyenv())
+  makeActiveBinding("live", function() 7, e)
+
+  out <- SpaDES.core:::.cloneEnvDeep(e)
+
+  expect_true(bindingIsActive("live", out))
+  expect_identical(out$live, 7)
+})
+
+test_that(".cloneEnvDeep preserves attributes and the parent environment", {
+  testInit()
+
+  p <- new.env(parent = emptyenv())
+  e <- new.env(parent = p)
+  attr(e, "myAttr") <- "kept"
+
+  out <- SpaDES.core:::.cloneEnvDeep(e)
+
+  expect_identical(attr(out, "myAttr"), "kept")
+  expect_identical(parent.env(out), p)
+})
+
+test_that(".cloneSimEnvs detaches the sim's environments from the original", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim$a <- 1
+
+  out <- SpaDES.core:::.cloneSimEnvs(sim)
+
+  expect_false(identical(out@.xData, sim@.xData))
+  expect_identical(out@.envir, out@.xData)
+  expect_identical(out$a, 1)
+
+  out$a <- 99
+  expect_identical(sim$a, 1)
+})
+
+## ---- .wrapAnchors --------------------------------------------------------
+
+test_that(".wrapAnchors is just the sim's paths when no projectPath is given", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+
+  expect_identical(SpaDES.core:::.wrapAnchors(sim), paths(sim))
+})
+
+test_that(".wrapAnchors adds projectPath when it differs from the working directory", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  proj <- withr::local_tempdir()
+
+  anchors <- SpaDES.core:::.wrapAnchors(sim, projectPath = proj)
+
+  expect_true("projectPath" %in% names(anchors))
+  expect_identical(anchors[["projectPath"]], proj)
+})
+
+test_that(".wrapAnchors does not add projectPath when it is the working directory", {
+  skip_on_cran()
+  testInit()
+
+  ## reproducible always appends its own `getwd` anchor; adding a second anchor
+  ## for the same directory makes which one wins order-dependent
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+
+  anchors <- SpaDES.core:::.wrapAnchors(sim, projectPath = getwd())
+
+  expect_false("projectPath" %in% names(anchors))
+  expect_identical(anchors, paths(sim))
+})
+
+test_that(".wrapAnchors ignores an empty projectPath", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+
+  expect_identical(SpaDES.core:::.wrapAnchors(sim, projectPath = ""), paths(sim))
+})
+
+## ---- recoverDataTableFromQs ---------------------------------------------
+
+test_that("recoverDataTableFromQs is a no-op when nothing needs converting", {
+  skip_on_cran()
+  testInit()
+
+  sim <- simInit(times = list(start = 0, end = 1, timeunit = "year"))
+  sim$a <- data.table::data.table(x = 1:3)
+
+  out <- suppressMessages(SpaDES.core:::recoverDataTableFromQs(sim))
+
+  expect_s4_class(out, "simList")
+  expect_s3_class(out$a, "data.table")
+})

--- a/tests/testthat/test-saveLoadSimList-helpers.R
+++ b/tests/testthat/test-saveLoadSimList-helpers.R
@@ -66,6 +66,12 @@ test_that("checkSimListExts accepts the supported extensions and rejects others"
 
 test_that("archiveWrite and archiveExtract round-trip files relative to projectPath", {
   skip_on_cran()
+  ## archiveWrite()/archiveExtract() only take the archive:: path when that
+  ## package is available and we are not on Windows; otherwise they shell out to
+  ## zip()/unzip(), which needs an external zip binary and writes a differently
+  ## named file. Only the archive:: path is exercised here.
+  skip_if_not_installed("archive")
+  skip_on_os("windows")
   testInit()
 
   proj <- withr::local_tempdir()


### PR DESCRIPTION
Second batch of coverage work (follows #390). **No production code is changed** — new test files plus a summary doc.

Local suite with these in: `0 failures, 1 skip` (the pre-existing igraph/GLPK skip).

## Coverage

`covr::package_coverage(type = "tests")`:

| | coverage |
|---|---|
| before this branch | 76.00% |
| **after** | **80.97%** (+4.98) |

No file regressed.

| file | before | after |
|---|---|---|
| `R/memory.R` | **0.0** | 91.9 |
| `R/plotting-diagrams.R` | **0.0** | 88.8 |
| `R/codecheck-rules.R` | 79.9 | 97.2 |
| `R/module-template.R` | 79.9 | 90.1 |
| `R/load.R` | 73.9 | 82.8 |
| `R/simList-accessors.R` | 84.5 | 87.2 |
| `R/saveLoadSimList.R` | 60.8 | 66.1 |
| `R/module-define.R` | 83.0 | 86.8 |
| `R/cache.R` | 81.8 | 83.9 |

## What is covered

- **`test-plotting-diagrams.R`** — `ganttStatus`, `.sim2gantt`, all three `eventDiagram` methods, `objectDiagram`, `moduleDiagram`, `moduleGraph`. The Gantt side builds a cheap sim with `defineEvent()`; the graph side needs real module metadata but stops at `simInit()`. `moduleGraph` is guarded on `glpsol` and on igraph actually having GLPK support.
- **`test-memory.R`** — the `ps` sampler, `memoryUse()` summaries, and the `future.callr` setup/teardown around `spades()`. `ongoingMemoryThisPid()` normally runs in a subprocess where covr cannot see it, so it is also driven directly.
- **`test-saveLoadSimList-helpers.R`** — archive naming, `relativizePaths`/`absolutizePaths` round trip, the deep environment cloner (cycles, active bindings, attributes), `.wrapAnchors`.
- **`test-module-template-extras.R`** — `openModules()`'s five methods with `.fileEdit` mocked so nothing launches an editor, plus `zipModule()` and `checkModulePath()`.
- **`test-codecheck-rules.R`** — the `.ccr_*` rules driven directly with hand-built `uses`/`meta`.
- **`test-parameters-accessor.R`** — both shapes of `parameters()`, `newObjectsCreated()`, `inputArgs<-`.
- **`test-module-define-extras.R`**, **`test-rasterToMemory.R`** (terra *and* raster branches), **`test-outputs-rmDups.R`**, **`test-clearCacheEventsOnly.R`**.

`TODO-coverage-batch-2.md` is the write-up; drop it before merge if you would rather it not live in the repo.

## Note on CI numbers

Until #394 merges, sample-module tests still skip on CI (`sf` missing — see #387), so codecov here reads **70.87%** rather than the local 80.97%. #394 and this PR touch different files; both landed should put codecov near 79%.

## Things found but deliberately not changed

1. **`clearCacheEventsOnly(x = )` clears the wrong cache.** It reads entries from `x` but calls `clearCache()` without `x`, so deletion happens in `getOption("reproducible.cachePath")`. Verified: with the option pointed at `x`, 3 entries become 1 (correctly); without, nothing is removed and nothing is said. One-argument fix, but it is a delete function. The tests pin the intended behaviour without asserting the broken path.
2. **`moduleDiagram(type = )`** — `if (grep("plot", type, ...))` gives `if (integer(0))`, an error, so the `stop("type must be one of ...")` below is unreachable. Wants `grepl()`.
3. **`archiveConvertFileExt()`** — `tools::file_ext("sim.tar.gz")` is `"gz"`, so converting to zip gives `sim.tar.zip`; the `gsub` is also unanchored over the whole path, so a directory named `gz` gets rewritten.
4. **Leftover `browser()`** at `simulation-spades.R:2592`, in a condition that also reads as though it meant `length(nextEvent) > 1`.
5. **`moduleCoverage()`** opens with `stop("This is a stub that is not intended for use")` — 32 unreachable lines behind it, not exported.
6. **`saveSimList()` with module sources outside `projectPath`** is still uncovered — I could not reach that branch reliably and dropped the attempt rather than commit a test I could not explain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LFjKX43acsipg5vNf6afS