### PR TITLE
[diagnostic, do not merge] test-save.R .grd inside outputPath

### DIFF
--- a/inst/sampleModules/caribouMovement/caribouMovement.R
+++ b/inst/sampleModules/caribouMovement/caribouMovement.R
@@ -20,7 +20,7 @@ defineModule(sim, list(
   timeunit = "month",
   citation = list(),
   documentation = list(),
-  reqdPkgs = list("grid", "terra", "sf", "stats", "SpaDES.tools (>= 2.0.0)"),
+  reqdPkgs = list("grid", "terra", "stats", "SpaDES.tools (>= 2.0.0)"),
   parameters = rbind(
     defineParameter("stackName", "character", "landscape", NA, NA, "name of the RasterStack"),
     defineParameter("moveInitialTime", "numeric", start(sim) + 1, start(sim) + 1, end(sim),

--- a/tests/testthat/helper-initTests.R
+++ b/tests/testthat/helper-initTests.R
@@ -84,7 +84,7 @@ testInit <- function(libraries = character(), ask = FALSE, verbose,
 }
 
 sampleModReqdPkgs <- c("terra", "SpaDES.tools", "RColorBrewer", # randomLandscapes & fireSpread
-                       "sf", "CircStats") # caribouMovement
+                       "CircStats") # caribouMovement
 
 testCode <- '
       defineModule(sim, list(

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -174,6 +174,13 @@ test_that("saveSimList works correctly", {
   outputPath <- checkPath(file.path(tmpdir, "outputs"), create = TRUE)
   cachePath <- checkPath(file.path(tmpdir, "cache"), create = TRUE)
 
+  ## DIAGNOSTIC (#397): tmpfile[] lands at tmpdir root, which is outside every
+  ## named sim path, so the .grd backing files have no anchor to be recorded
+  ## against. Move them inside outputPath -- a supported location -- to find out
+  ## whether the Windows failure is that unsupported scenario or something else.
+  tmpfile[1] <- file.path(outputPath, basename(tmpfile[1]))
+  tmpfile[7] <- file.path(outputPath, basename(tmpfile[7]))
+
   linkOrCopy(dir(mapPath, full.names = TRUE), file.path(modulePath, dir(mapPath)))
   linkOrCopy(dir(modules, recursive = TRUE, full.names = TRUE),
              file.path(modulePath, dir(modules, recursive = TRUE)))

--- a/tests/testthat/test-simList.R
+++ b/tests/testthat/test-simList.R
@@ -172,7 +172,7 @@ test_that("simList object initializes correctly (1)", {
   expect_equal("second", attr(mySim@simtimes$current, "unit"))
 
   ### required packages
-  pkgs <- c("grid", "methods", "terra", "reproducible", "RColorBrewer", "sf",
+  pkgs <- c("grid", "methods", "terra", "reproducible", "RColorBrewer",
             "SpaDES.core", "SpaDES.tools", "stats")
   expect_equal(sort(packages(mySim, clean = TRUE)), sort(pkgs))
 


### PR DESCRIPTION
Draft, diagnostic only — **do not merge**.

#394 turns 4 Windows legs red on `test-save.R:223`/`:233` (#397). This branch is #394 plus one change: `tmpfile[1]`/`tmpfile[7]` (the two `.grd` files) are moved from `tmpdir` root into `outputPath`.

Why: `testInit(tmpFileExt = ...)` puts `tmpfile[]` directly in `tmpdir`, while the sim's `modulePath`/`inputPath`/`outputPath`/`cachePath` are all *subdirectories* of `tmpdir`. So the `.grd` backing files sit outside every named sim path and have no anchor to be recorded against. The test then loads with `projectPath = tmpCache`, a different directory.

If Windows goes green here, the failure is the unsupported "outside every named path" case (#389) and the product bug is narrow and well-defined. If Windows stays red, it is something else in the `.grd` round trip and this theory is wrong.

Passes locally on Linux either way.