### PR TITLE
chore: vendor isAre()/singularPlural() instead of borrowing Require's

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -418,3 +418,30 @@ noEventWarning <- function(sim) {
                      ._txtDotUseCache, ._txtDotUseCacheArgs, ._txtDotUseCloud,
                      ".useParallel") ## TODO: add others here, e.g. .studyAreaName?
 
+
+## Singular/plural message grammar ---------------------------------------------
+##
+## Vendored from Require rather than borrowed with getFromNamespace(): these are
+## two lines each, and copying them costs less than a cross-package dependency
+## on a private binding. Kept behaviourally identical to Require's, so messages
+## read the same across the SpaDES packages.
+
+#' Pick the singular or plural form for a message
+#'
+#' @param singPlur Length-2 character vector: the singular form, then the plural.
+#' @param l An object whose length is the count.
+#' @param v The count itself. Takes precedence over `l` when both are supplied.
+#'
+#' @return One element of `singPlur`.
+#'
+#' @keywords internal
+#' @rdname singularPlural
+singularPlural <- function(singPlur, l, v) {
+  singPlur[(if (!missing(v)) v > 1 else length(l) > 1) + 1]
+}
+
+#' @keywords internal
+#' @rdname singularPlural
+isAre <- function(l, v) {
+  singularPlural(c("is", "are"), l, v)
+}

--- a/R/reexports.R
+++ b/R/reexports.R
@@ -21,8 +21,7 @@ extractInequality <- getFromNamespace("extractInequality", "Require")
 GETWauthThenNonAuth <- getFromNamespace("GETWauthThenNonAuth", "Require")
 getGitCredsToken <- getFromNamespace("getGitCredsToken", "Require")
 trimRedundancies <- getFromNamespace("trimRedundancies", "Require")
-isAre <- getFromNamespace("isAre", "Require")
-singularPlural <- getFromNamespace("singularPlural", "Require")
+## isAre() and singularPlural() are vendored into R/helpers.R instead
 
 getDrv <- getFromNamespace("getDrv", "reproducible")
 isWindows <- getFromNamespace("isWindows", "reproducible")

--- a/tests/testthat/test-singularPlural.R
+++ b/tests/testthat/test-singularPlural.R
@@ -1,0 +1,60 @@
+## singularPlural()/isAre(): vendored from Require, so these pin the behaviour
+## the two copies have to keep sharing -- in particular that `v` wins when both
+## `l` and `v` are supplied, which in Require's original came about only because
+## the `v` assignment happened to come second.
+
+test_that("singularPlural picks by count v", {
+  testInit()
+
+  expect_identical(singularPlural(c("is", "are"), v = 1), "is")
+  expect_identical(singularPlural(c("is", "are"), v = 2), "are")
+})
+
+test_that("singularPlural treats a zero count as singular", {
+  testInit()
+
+  ## only > 1 is plural, matching Require
+  expect_identical(singularPlural(c("is", "are"), v = 0), "is")
+})
+
+test_that("singularPlural picks by the length of l", {
+  testInit()
+
+  expect_identical(singularPlural(c("is", "are"), l = 1), "is")
+  expect_identical(singularPlural(c("is", "are"), l = c(1, 2)), "are")
+  expect_identical(singularPlural(c("is", "are"), l = character(0)), "is")
+})
+
+test_that("singularPlural lets v win when both are given", {
+  testInit()
+
+  expect_identical(singularPlural(c("is", "are"), l = c(1, 2, 3), v = 1), "is")
+  expect_identical(singularPlural(c("is", "are"), l = 1, v = 5), "are")
+})
+
+test_that("isAre is singularPlural over is/are", {
+  testInit()
+
+  expect_identical(isAre(v = 1), "is")
+  expect_identical(isAre(v = 2), "are")
+  expect_identical(isAre(l = c("a", "b")), "are")
+})
+
+test_that("the vendored copies agree with Require's", {
+  testInit()
+  skip_if_not_installed("Require")
+
+  reqSP <- getFromNamespace("singularPlural", "Require")
+  reqIA <- getFromNamespace("isAre", "Require")
+
+  for (n in c(0, 1, 2, 5)) {
+    expect_identical(singularPlural(c("is", "are"), v = n),
+                     reqSP(c("is", "are"), v = n))
+    expect_identical(isAre(v = n), reqIA(v = n))
+  }
+  expect_identical(singularPlural(c("is", "are"), l = c(1, 2)),
+                   reqSP(c("is", "are"), l = c(1, 2)))
+  ## both supplied: v takes precedence in each
+  expect_identical(singularPlural(c("is", "are"), l = c(1, 2, 3), v = 1),
+                   reqSP(c("is", "are"), l = c(1, 2, 3), v = 1))
+})


### PR DESCRIPTION
Follow-up to the discussion on PredictiveEcology/Require#181 about helpers other packages reach into Require for.

`R/reexports.R` pulled these in with `getFromNamespace("isAre", "Require")` — a **private** binding. A rename in Require breaks SpaDES.core at load time, with nothing more useful than "object not found", and nothing pins a Require version to prevent it.

The set splits three ways:

| functions | disposition |
|---|---|
| `compareVersion2`, `extractInequality` | already exported by Require — the `getFromNamespace()` calls were never needed |
| `trimRedundancies`, `GETWauthThenNonAuth`, `getGitCredsToken` | now exported from Require (#181) |
| `isAre`, `singularPlural` | **vendored here** |

The last two are two lines each. Copying them costs less than maintaining a cross-package contract, whereas the version-specification parsers are genuinely Require's mission and belong in its public API.

## The simplification

```r
singularPlural <- function(singPlur, l, v) {
  singPlur[(if (!missing(v)) v > 1 else length(l) > 1) + 1]
}
```

replacing two conditional assignments. `v` still wins when both arguments are supplied — in Require's original that happened only because the `v` assignment came second, so it is now stated deliberately rather than by accident. The same simplification went into Require in #181.

## Tests

`tests/testthat/test-singularPlural.R`, 21 assertions: selection by `v`, by `length(l)`, zero treated as singular, `v` winning when both are given, and `isAre()` over the pair — plus a cross-check against Require's own copies so the two cannot drift silently.

Full suite: 0 failures, 1 skip (the pre-existing igraph/GLPK one).