### PR TITLE
fix(loadSimList): warn, don't fail, when module code needs a missing package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -73,8 +73,8 @@
 
 * A `simList` saved with `saveSimList()` can now be run after `loadSimList()`.
   Module functions were lost in the round trip, so a reloaded simulation could be
-  inspected but not run. If the module source cannot be found, loading now warns
-  instead of failing. (#388)
+  inspected but not run. If the module source cannot be found, or needs a package
+  that is not installed, loading now warns instead of failing. (#388)
 
 * `saveSimList(projectPath = )` no longer fails for a simulation holding
   file-backed objects. Such objects are also re-rooted correctly on load when they

--- a/R/restart.R
+++ b/R/restart.R
@@ -228,7 +228,8 @@ restartSpades <- function(sim = NULL, module = NULL, numEvents = 1L, restart = T
 #' @param sim A `simList`.
 #' @param modules Character vector of (non-core) module names to re-parse.
 #' @param verbose Numeric verbosity. At `verbose > 0` each re-parsed module is
-#'   announced; a module whose source cannot be found always warns.
+#'   announced; a module whose source cannot be found, or whose code cannot be
+#'   evaluated (e.g., a package it loads is not installed), always warns.
 #' @return `sim`, invisibly.
 #' @keywords internal
 #' @importFrom cli col_blue
@@ -240,6 +241,7 @@ restartSpades <- function(sim = NULL, module = NULL, numEvents = 1L, restart = T
   on.exit(options(opt), add = TRUE)
 
   notFound <- character()
+  failed <- character()
 
   for (module in modules) {
     moduleFolder <- file.path(modulePath(sim, module = module), module)
@@ -267,16 +269,26 @@ restartSpades <- function(sim = NULL, module = NULL, numEvents = 1L, restart = T
     doesntUseNamespacing <- !.isNamespaced(sim, module)
 
     sim <- currentModuleTemporary(sim, module)
-    if (doesntUseNamespacing) {
-      evalWithActiveCode(pp[[1]], sim@.xData, sim = sim)
-    }
 
     subFiles <- dir(file.path(moduleFolder, "R"), pattern = "([.]R$|[.]r$)",
                     full.names = TRUE)
     if (length(subFiles)) {
       pp[seq_along(subFiles) + 1] <- lapply(subFiles, function(ff) parse(ff))
     }
-    lapply(pp, function(pp1) evalWithActiveCode(pp1, modEnv, sim = sim))
+
+    ## Top-level module code may need packages that are not installed here,
+    ## e.g., a simList saved on another machine; that must not abort the load.
+    err <- tryCatch({
+      if (doesntUseNamespacing) {
+        evalWithActiveCode(pp[[1]], sim@.xData, sim = sim)
+      }
+      lapply(pp, function(pp1) evalWithActiveCode(pp1, modEnv, sim = sim))
+      NULL
+    }, error = function(e) conditionMessage(e))
+    if (!is.null(err)) {
+      failed[module] <- err
+      next
+    }
 
     ## These live in the module env too, so they go missing along with the
     ## functions; the code-checking machinery expects them back.
@@ -293,6 +305,13 @@ restartSpades <- function(sim = NULL, module = NULL, numEvents = 1L, restart = T
             "  The simList is loaded and can be inspected, but cannot be run. ",
             "Supply the correct `modulePath` via `paths`, or save and load in ",
             "an archive format, which bundles the module source.",
+            call. = FALSE)
+  }
+  if (length(failed)) {
+    warning("Could not re-parse module(s): ",
+            paste0(names(failed), " (", failed, ")", collapse = "; "), ".\n",
+            "  The simList is loaded and can be inspected, but cannot be run ",
+            "until this is resolved, e.g., by installing the missing package(s).",
             call. = FALSE)
   }
 

--- a/man/dot-reparseModules.Rd
+++ b/man/dot-reparseModules.Rd
@@ -12,7 +12,8 @@
 \item{modules}{Character vector of (non-core) module names to re-parse.}
 
 \item{verbose}{Numeric verbosity. At \code{verbose > 0} each re-parsed module is
-announced; a module whose source cannot be found always warns.}
+announced; a module whose source cannot be found, or whose code cannot be
+evaluated (e.g., a package it loads is not installed), always warns.}
 }
 \value{
 \code{sim}, invisibly.

--- a/tests/testthat/test-saveLoadSimList.R
+++ b/tests/testthat/test-saveLoadSimList.R
@@ -440,6 +440,24 @@ test_that("loadSimList warns, rather than errors, when module source is gone", {
   expect_false("doEvent.randomLandscapes" %in% ls(out$.mods$randomLandscapes))
 })
 
+test_that("loadSimList warns, rather than errors, when module code needs a missing package", {
+  skip_on_cran()
+  testInit()
+
+  sim <- suppressMessages(simWithModule(tmpdir))
+  f <- file.path(tmpdir, "sim.rds")
+  suppressMessages(saveSimList(sim, f))
+
+  ## e.g., a simList saved on a machine that had this package installed
+  cat("\nlibrary(notAPackageSpaDES)\n",
+      file = file.path(modulePath(sim), "randomLandscapes", "randomLandscapes.R"),
+      append = TRUE)
+
+  expect_warning(out <- suppressMessages(loadSimList(f)), "Could not re-parse")
+  expect_s4_class(out, "simList")
+  expect_identical(unlist(modules(out), use.names = FALSE), "randomLandscapes")
+})
+
 ## Anchoring of file-backed objects: which directories a backing file can be
 ## re-rooted against on load, and saying so at save time when there are none.
 ## See #389.


### PR DESCRIPTION
## Problem

#395 made `loadSimList()` re-parse module code via `.reparseModules()` so a reloaded simList can be run. But `evalWithActiveCode()` re-evaluates top-level "active" code without error handling, so a module that loads a package not installed on this machine (e.g., a simList saved elsewhere) aborted the whole load:

```
Error in loadNamespace(...) : there is no package called 'EnvStats'
```

## Fix

`.reparseModules()` now catches a per-module eval failure and collects it alongside the existing "source not found" case, warning once at the end:

```
Could not re-parse module(s): <mod> (there is no package called 'EnvStats').
  The simList is loaded and can be inspected, but cannot be run until this is resolved, e.g., by installing the missing package(s).
```

The simList is returned as before. Nothing is installed on the user's behalf.

## Tests

New test appends `library(notAPackageSpaDES)` to a module after saving, expects the warning and a valid `simList`. `test-saveLoadSimList.R` and `test-mod.R` (restart paths sharing `.reparseModules`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTf8Jt3ELmPK2yYH2Cu1Af
