### PR TITLE
fix(memory): stop ps column padding turning memory readings into NA

### DIFF
--- a/R/memory.R
+++ b/R/memory.R
@@ -50,6 +50,13 @@ ongoingMemoryThisPid <- function(
 #'
 #' @export
 #' @rdname memoryUse
+## Pull the leading numeric field out of a `ps` line. `ps` right-aligns its
+## columns, so the line may begin with spaces; trim before splitting or the
+## first field is "" and the value parses to NA.
+.rssField <- function(x) {
+  strsplit(trimws(x[1]), split = " +")[[1]][1]
+}
+
 memoryUseThisSession <- function(thisPid) {
   ps <- Sys.which("ps")
   if (missing(thisPid)) {
@@ -57,13 +64,20 @@ memoryUseThisSession <- function(thisPid) {
   }
   needTasklist <- isWindows()
   if (nzchar(ps) && !needTasklist) {
+    ## `-p` asks ps for this process directly and `rss=` drops the header, so
+    ## there is exactly one field to read. The previous
+    ## `ps -eo rss,pid | grep <pid>` had two failure modes: `grep` matched the
+    ## pid anywhere in the line (so pid 2 matched every line containing a "2"),
+    ## and ps right-aligns rss in a fixed-width column, so a value narrower than
+    ## the column left the line starting with spaces -- `strsplit(x, " +")[[1]][1]`
+    ## was then "" and the memory reading came back NA.
     aa <- try(
-      suppressWarnings(system(paste(ps, "-eo rss,pid | grep", thisPid), intern = TRUE)),
+      suppressWarnings(system2(ps, c("-o", "rss=", "-p", thisPid), stdout = TRUE, stderr = FALSE)),
       silent = TRUE
     )
-    needTasklist <- !is.null(attr(aa, "status"))
+    needTasklist <- inherits(aa, "try-error") || !is.null(attr(aa, "status")) || !length(aa)
     if (!needTasklist) {
-      aa2 <- try(strsplit(aa, split = " +")[[1]][1], silent = TRUE)
+      aa2 <- try(.rssField(aa), silent = TRUE)
     }
   }
 

--- a/tests/testthat/test-memory.R
+++ b/tests/testthat/test-memory.R
@@ -28,6 +28,18 @@ test_that("outputFilename embeds the pid", {
   expect_match(basename(f), "memAvail_4242\\.txt$")
 })
 
+test_that(".rssField tolerates ps's right-aligned columns", {
+  testInit()
+
+  ## `ps` pads rss into a fixed-width column, so a value narrower than the
+  ## column leaves the line starting with spaces. Splitting on " +" without
+  ## trimming first returned "" and every reading parsed to NA -- which is why
+  ## memoryUse() silently produced NA on macOS, and for any small process.
+  expect_identical(SpaDES.core:::.rssField("    0       2"), "0")
+  expect_identical(SpaDES.core:::.rssField(" 3884 3597561"), "3884")
+  expect_identical(SpaDES.core:::.rssField("62064 3597570"), "62064")
+})
+
 ## ---- memoryUseThisSession ----------------------------------------------
 
 test_that("memoryUseThisSession reports this session's memory as an object_size", {


### PR DESCRIPTION
## The bug

`memoryUseThisSession()` ran `ps -eo rss,pid | grep <pid>` and took the first
whitespace-delimited field:

```r
aa  <- system(paste(ps, "-eo rss,pid | grep", thisPid), intern = TRUE)
aa2 <- strsplit(aa, split = " +")[[1]][1]
```

`ps` right-aligns `rss` in a fixed-width column, so a value narrower than the
column leaves the line starting with spaces. `strsplit(x, " +")[[1]][1]` is then
`""`, and the reading parses to `NA`:

```
" 3884 3597561"  -> field1 = ""      -> NA
"62064 3597570"  -> field1 = "62064" -> 62064
```

**This is not macOS-specific**, though macOS hits it most. On Linux `procps`
gives `rss` a minimum width of 5, and an R session is always >= 10 MB, so it
fills the field by luck. Reproduced on Linux against any process under 10 MB —
pid 2 returned `NA`; it now returns `0`.

An interactive macOS user sees this as `memoryUse()` silently returning `NA`
rather than erroring. It is also intermittent, which is why `macOS-latest` in CI
passed run 33219457367 and failed 33234766411 with `R/memory.R` untouched.

## Second defect, same line

`grep <pid>` was an unanchored match on the whole line, so it matched the pid
anywhere — `grep 2` matches every row containing a `2`, and the parse then took
whichever line came first.

## The fix

`ps -o rss= -p <pid>` asks for that one process directly (portable across
macOS/Linux), `rss=` suppresses the header, and the value is trimmed before
splitting. No shell pipeline, no substring collisions, no column padding.

## Tests

The three macOS CI failures in `test-memory.R` all funnel through this function
and now pass (`FAIL 0 | SKIP 0 | PASS 36` with `NOT_CRAN=true`).

The new `.rssField()` test is pure string parsing — no system calls — so it runs
on CRAN rather than being `skip_on_cran()`d like the rest of the file. That
matters: every existing test that would have caught this is skipped on CRAN.

## Not included

Unrelated to the 3.2.1 CRAN submission, which is in the pre-test queue. All the
affected tests are `skip_on_cran()`, so this never influenced a CRAN result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBeLp5Zbsby8Qn8jj2btX3