### PR TITLE
fix(codecheck): count in-place updates of sim objects as writes

### DIFF
--- a/R/codecheck-api.R
+++ b/R/codecheck-api.R
@@ -22,8 +22,8 @@
 #' structured tibble of findings, optionally printed as grouped tables.
 #'
 #' This is the v2 implementation, selectable at `simInit()` time via
-#' `options(spades.codeCheckEngine = "v2")` (the default). The legacy v1
-#' checker is still available via `options(spades.codeCheckEngine = "v1")`.
+#' `options(spades.codeCheckEngine = "v2")`. The legacy v1 checker is the
+#' default; set the option to opt in to v2.
 #'
 #' @section Silencing findings:
 #' Each finding in the printed report is tagged with its **rule id** in

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -158,9 +158,6 @@
 ## Is `node` (an expr) the LHS of an assignment? An expr is an LHS iff its
 ## parent is also an expr whose first expr child is `node` AND whose second
 ## child is one of LEFT_ASSIGN / RIGHT_ASSIGN / EQ_ASSIGN.
-##
-## Note: for `sim$x[1] <- v` we treat the inner `sim$x` as a get (it's read
-## then [<- is applied), matching the spirit of v1's behavior.
 .cc_isLhsOfAssign <- function(node) {
   parent <- xml2::xml_parent(node)
   if (xml2::xml_name(parent) != "expr") return(FALSE)
@@ -178,6 +175,65 @@
   ## look for an assignment op as a sibling of the expr children
   assignOps <- c("LEFT_ASSIGN", "EQ_ASSIGN", "RIGHT_ASSIGN")
   any(xml2::xml_name(kids) %in% assignOps)
+}
+
+## Is `node` the target of an assignment reached through one or more extraction
+## operations -- `sim$x[] <- v`, `sim$x[i, j] <- v`, `sim$x$y <- v`,
+## `sim[["x"]][[1]] <- v`? These are replacement-function calls, so `sim$x` is
+## read *and* rewritten; the caller records both.
+.cc_isLhsThroughSubset <- function(node) {
+  extractOps <- c("OP-LEFT-BRACKET", "LBB", "OP-DOLLAR", "OP-AT")
+  cur <- node
+  repeat {
+    parent <- xml2::xml_parent(cur)
+    if (inherits(parent, "xml_missing")) return(FALSE)
+    pName <- xml2::xml_name(parent)
+    if (length(pName) != 1L || is.na(pName) || pName != "expr") return(FALSE)
+    kids <- xml2::xml_children(parent)
+    ## parent must be an extraction, with `cur` as the object being extracted
+    ## from (i.e. the first expr child)
+    if (!any(xml2::xml_name(kids) %in% extractOps)) return(FALSE)
+    exprKids <- kids[xml2::xml_name(kids) == "expr"]
+    if (length(exprKids) == 0) return(FALSE)
+    if (!identical(xml2::xml_path(cur), xml2::xml_path(exprKids[[1]]))) return(FALSE)
+    if (.cc_isLhsOfAssign(parent)) return(TRUE)
+    cur <- parent
+  }
+}
+
+## Is `node` the target of a data.table modify-by-reference, i.e. does it sit
+## directly in front of a `[` whose arguments use `:=`? `sim$x[, y := 1]` and
+## `sim$x[, \u0060:=\u0060(y = 1)]` rewrite `sim$x` even though there is no `<-`.
+.cc_isDataTableSetByRef <- function(node) {
+  parent <- xml2::xml_parent(node)
+  if (inherits(parent, "xml_missing")) return(FALSE)
+  pName <- xml2::xml_name(parent)
+  if (length(pName) != 1L || is.na(pName) || pName != "expr") return(FALSE)
+  kids <- xml2::xml_children(parent)
+  if (!any(xml2::xml_name(kids) == "OP-LEFT-BRACKET")) return(FALSE)
+  exprKids <- kids[xml2::xml_name(kids) == "expr"]
+  if (length(exprKids) == 0) return(FALSE)
+  if (!identical(xml2::xml_path(node), xml2::xml_path(exprKids[[1]]))) return(FALSE)
+  ## `:=` reaches the parser as a LEFT_ASSIGN token, or as a function call when
+  ## written in its backtick form
+  found <- xml2::xml_find_first(
+    parent,
+    paste0("expr/LEFT_ASSIGN[text()=':=']",
+           " | expr/expr/SYMBOL_FUNCTION_CALL[text()='`:=`']")
+  )
+  !inherits(found, "xml_missing")
+}
+
+## Classify a `sim$x` / `sim[["x"]]` access: a bare LHS is a write, an LHS
+## reached through an extraction or rewritten in place by data.table (see
+## above) is both a read and a write, and anything else is a read. Returns one
+## or two `kind` values.
+.cc_accessKinds <- function(node) {
+  if (.cc_isLhsOfAssign(node)) return("sim_assign")
+  if (.cc_isLhsThroughSubset(node) || .cc_isDataTableSetByRef(node)) {
+    return(c("sim_get", "sim_assign"))
+  }
+  "sim_get"
 }
 
 ## ---------------------------------------------------------------------------
@@ -201,10 +257,11 @@
     name <- xml2::xml_text(sym)
     pos <- .cc_pos(n)
     fn <- .cc_enclosingFn(n)
-    kind <- if (.cc_isLhsOfAssign(n)) "sim_assign" else "sim_get"
-    out[[length(out) + 1]] <- .cc_use(kind, name = name, fn = fn, file = file,
-                                      line = pos$line, col = pos$col,
-                                      resolved = TRUE)
+    for (kind in .cc_accessKinds(n)) {
+      out[[length(out) + 1]] <- .cc_use(kind, name = name, fn = fn, file = file,
+                                        line = pos$line, col = pos$col,
+                                        resolved = TRUE)
+    }
   }
 
   ## sim[["x"]]  (string literal)  AND  sim[[<expr>]]  (unresolved)
@@ -219,21 +276,25 @@
     str <- xml2::xml_find_first(indexExpr, "STR_CONST")
     pos <- .cc_pos(n)
     fn <- .cc_enclosingFn(n)
-    kind <- if (.cc_isLhsOfAssign(n)) "sim_assign" else "sim_get"
+    kinds <- .cc_accessKinds(n)
     if (length(str) > 0 && !is.na(xml2::xml_text(str))) {
       ## strip surrounding quotes that STR_CONST preserves
       raw <- xml2::xml_text(str)
       name <- gsub('^["\']|["\']$', "", raw)
-      out[[length(out) + 1]] <- .cc_use(kind, name = name, fn = fn, file = file,
-                                        line = pos$line, col = pos$col,
-                                        resolved = TRUE)
+      for (kind in kinds) {
+        out[[length(out) + 1]] <- .cc_use(kind, name = name, fn = fn, file = file,
+                                          line = pos$line, col = pos$col,
+                                          resolved = TRUE)
+      }
     } else {
       ## unresolved (e.g., sim[[Par$stackName]])
-      out[[length(out) + 1]] <- .cc_use(
-        kind, name = NA_character_, fn = fn, file = file,
-        line = pos$line, col = pos$col, resolved = FALSE,
-        extra = xml2::xml_text(indexExpr)
-      )
+      for (kind in kinds) {
+        out[[length(out) + 1]] <- .cc_use(
+          kind, name = NA_character_, fn = fn, file = file,
+          line = pos$line, col = pos$col, resolved = FALSE,
+          extra = xml2::xml_text(indexExpr)
+        )
+      }
     }
   }
 

--- a/R/codecheck-engine.R
+++ b/R/codecheck-engine.R
@@ -202,8 +202,8 @@
 }
 
 ## Is `node` the target of a data.table modify-by-reference, i.e. does it sit
-## directly in front of a `[` whose arguments use `:=`? `sim$x[, y := 1]` and
-## `sim$x[, \u0060:=\u0060(y = 1)]` rewrite `sim$x` even though there is no `<-`.
+## directly in front of a `[` whose arguments use `:=`? Both `sim$x[, y := 1]`
+## and its backtick-call form rewrite `sim$x` even though there is no `<-`.
 .cc_isDataTableSetByRef <- function(node) {
   parent <- xml2::xml_parent(node)
   if (inherits(parent, "xml_missing")) return(FALSE)

--- a/man/codeCheckModule.Rd
+++ b/man/codeCheckModule.Rd
@@ -42,8 +42,8 @@ structured tibble of findings, optionally printed as grouped tables.
 }
 \details{
 This is the v2 implementation, selectable at \code{simInit()} time via
-\code{options(spades.codeCheckEngine = "v2")} (the default). The legacy v1
-checker is still available via \code{options(spades.codeCheckEngine = "v1")}.
+\code{options(spades.codeCheckEngine = "v2")}. The legacy v1 checker is the
+default; set the option to opt in to v2.
 }
 \section{Silencing findings}{
 

--- a/tests/testthat/test-codecheck-helpers.R
+++ b/tests/testthat/test-codecheck-helpers.R
@@ -122,3 +122,61 @@ test_that(".cc_otherModuleParams is empty when the sim has only the current modu
 
   expect_length(ccOtherModuleParams(sim, currentModule = "randomLandscapes"), 0L)
 })
+
+## ---- sim access: reads vs writes -----------------------------------------
+
+## `.cc_collect_simAccess()` classifies each `sim$x` / `sim[["x"]]` node as a
+## read (`sim_get`), a write (`sim_assign`), or -- for in-place updates -- both.
+ccSimAccess <- function(text) {
+  SpaDES.core:::.cc_collect_simAccess(SpaDES.core:::.cc_parseFile(text = text))
+}
+
+ccKinds <- function(text, name) {
+  u <- ccSimAccess(text)
+  sort(u$kind[!is.na(u$name) & u$name == name])
+}
+
+test_that("a bare assignment to sim is a write only", {
+  testInit()
+
+  expect_identical(ccKinds("sim$x <- 1", "x"), "sim_assign")
+  expect_identical(ccKinds('sim[["x"]] <- 1', "x"), "sim_assign")
+})
+
+test_that("a plain read of sim is a read only", {
+  testInit()
+
+  expect_identical(ccKinds("y <- sim$x", "x"), "sim_get")
+  expect_identical(ccKinds('y <- sim[["x"]]', "x"), "sim_get")
+  ## reaching into an object does not write it, and does not record the column
+  expect_identical(ccKinds("y <- sim$x$col", "x"), "sim_get")
+  expect_false("col" %in% ccSimAccess("y <- sim$x$col")$name)
+})
+
+test_that("updating a sim object in place is both a read and a write", {
+  testInit()
+
+  ## these all call a replacement function, so `sim$x` is read then rewritten
+  for (code in c("sim$x[] <- 1", "sim$x[i, j] <- 1", "sim$x$col <- 1",
+                 "sim$x[[1]] <- 1", 'sim[["x"]][[1]] <- 1')) {
+    expect_identical(ccKinds(code, "x"), c("sim_assign", "sim_get"), info = code)
+  }
+})
+
+test_that("data.table modify-by-reference on a sim object is a write", {
+  testInit()
+
+  ## no `<-` at all, but `:=` rewrites sim$x in place
+  expect_identical(ccKinds("sim$x[, col := 1]", "x"), c("sim_assign", "sim_get"))
+  expect_identical(ccKinds("sim$x[cond, col := 1]", "x"), c("sim_assign", "sim_get"))
+  expect_identical(ccKinds("sim$x[, `:=`(col = 1)]", "x"), c("sim_assign", "sim_get"))
+})
+
+test_that("subsetting a sim object without assigning is still only a read", {
+  testInit()
+
+  expect_identical(ccKinds("y <- sim$x[1]", "x"), "sim_get")
+  expect_identical(ccKinds("y <- sim$x[, .N, by = col]", "x"), "sim_get")
+  ## an unrelated object being assigned through does not make sim$x a write
+  expect_identical(ccKinds("other[sim$x] <- 1", "x"), "sim_get")
+})

--- a/tests/testthat/test-codecheck-helpers.R
+++ b/tests/testthat/test-codecheck-helpers.R
@@ -138,6 +138,7 @@ ccKinds <- function(text, name) {
 
 test_that("a bare assignment to sim is a write only", {
   testInit()
+  skip_if_not_installed("xmlparsedata")
 
   expect_identical(ccKinds("sim$x <- 1", "x"), "sim_assign")
   expect_identical(ccKinds('sim[["x"]] <- 1', "x"), "sim_assign")
@@ -145,6 +146,7 @@ test_that("a bare assignment to sim is a write only", {
 
 test_that("a plain read of sim is a read only", {
   testInit()
+  skip_if_not_installed("xmlparsedata")
 
   expect_identical(ccKinds("y <- sim$x", "x"), "sim_get")
   expect_identical(ccKinds('y <- sim[["x"]]', "x"), "sim_get")
@@ -155,6 +157,7 @@ test_that("a plain read of sim is a read only", {
 
 test_that("updating a sim object in place is both a read and a write", {
   testInit()
+  skip_if_not_installed("xmlparsedata")
 
   ## these all call a replacement function, so `sim$x` is read then rewritten
   for (code in c("sim$x[] <- 1", "sim$x[i, j] <- 1", "sim$x$col <- 1",
@@ -165,6 +168,7 @@ test_that("updating a sim object in place is both a read and a write", {
 
 test_that("data.table modify-by-reference on a sim object is a write", {
   testInit()
+  skip_if_not_installed("xmlparsedata")
 
   ## no `<-` at all, but `:=` rewrites sim$x in place
   expect_identical(ccKinds("sim$x[, col := 1]", "x"), c("sim_assign", "sim_get"))
@@ -174,6 +178,7 @@ test_that("data.table modify-by-reference on a sim object is a write", {
 
 test_that("subsetting a sim object without assigning is still only a read", {
   testInit()
+  skip_if_not_installed("xmlparsedata")
 
   expect_identical(ccKinds("y <- sim$x[1]", "x"), "sim_get")
   expect_identical(ccKinds("y <- sim$x[, .N, by = col]", "x"), "sim_get")


### PR DESCRIPTION
Closes #223.

## Problem

The v2 collector classified every `sim$x` node reached through a subset as a **read**, so a declared output updated in place was reported as unused:

```r
sim$fireReturnInterval[] <- 2
sim$sppEquiv[, LandMine := 3]
```

```
[warn] 'fireReturnInterval' is declared in metadata outputObjects but is not used in module code [out_declared_unused]
[warn] 'sppEquiv' is declared in metadata outputObjects but is not used in module code [out_declared_unused]
```

Both are the false positives reported in #223 (and in the linked LandMine/LandWeb_preamble issues).

## Cause

`.cc_isLhsOfAssign()` (`R/codecheck-engine.R`) requires the `sim$x` node to be the assignment's *first* `expr` child. For `sim$x[] <- v` the parent expr is the `[` subset, so it returns `FALSE` and the use is recorded as `sim_get`.

`sim$x[, y := 1]` is a second, distinct case: data.table rewrites by reference and there is no `<-` in the expression at all.

## Fix

- `.cc_isLhsThroughSubset()` walks up through `[` / `[[` / `$` / `@` extraction parents (requiring the node to be the object being extracted from at each level) before testing for the assignment operator.
- `.cc_isDataTableSetByRef()` recognises `:=` in a `[` call, in both the operator form (`dt[, a := 1]`, which reaches the parser as a `LEFT_ASSIGN` token) and the backtick-call form (``dt[, `:=`(a = 1)]``).
- `.cc_accessKinds()` folds these together. A bare LHS stays a write; an in-place update is recorded as **both** `sim_get` and `sim_assign`, which is what actually happens — the replacement function reads the object and writes it back.

Recording both keeps `in_declared_unused` satisfied by the read while letting `out_declared_unused` see the write.

## Effect

On a module exercising all the shapes from #223, both false positives are gone. The one finding that remains is a true one: `sim$ROSTable$ros <- 1` where `ROSTable` is declared only as an input now correctly reports `out_used_undeclared` — the module does mutate it.

## Tests

Five new tests in `tests/testthat/test-codecheck-helpers.R` (17 assertions) covering bare writes, plain reads, the five in-place update shapes, the three `:=` shapes, and the negative cases (subsetting without assigning; `other[sim$x] <- 1`).

```
test-codecheck.R             pass= 77 fail=0 skip=0
test-codecheck-rules.R       pass= 40 fail=0 skip=0
test-codecheck-report.R      pass= 27 fail=0 skip=0
test-codecheck-helpers.R     pass= 26 fail=0 skip=4
```

(The 4 skips are pre-existing `On CRAN` skips.)

## Also in here

`R/codecheck-api.R` claimed `options(spades.codeCheckEngine = "v2")` was "the default", but `R/options.R` sets `"v1"` (and `?spadesOptions` documents `"v1"`). Corrected the roxygen.

## Not included

No NEWS entry — `development` has no unreleased section and `DESCRIPTION` is still at the released `3.2.0`, so I left the version/NEWS decision to you. Happy to add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBeLp5Zbsby8Qn8jj2btX3
