### PR TITLE
fix(memory): restore the roxygen block to memoryUseThisSession()

### DIFF
--- a/R/memory.R
+++ b/R/memory.R
@@ -37,6 +37,13 @@ ongoingMemoryThisPid <- function(
   invisible(outputFile)
 }
 
+## Pull the leading numeric field out of a `ps` line. `ps` right-aligns its
+## columns, so the line may begin with spaces; trim before splitting or the
+## first field is "" and the value parses to NA.
+.rssField <- function(x) {
+  strsplit(trimws(x[1]), split = " +")[[1]][1]
+}
+
 #' Estimate memory used with `system("ps")`
 #'
 #' This will give a slightly different estimate than `pryr::mem_used`, which uses `gc()` internally.
@@ -50,13 +57,6 @@ ongoingMemoryThisPid <- function(
 #'
 #' @export
 #' @rdname memoryUse
-## Pull the leading numeric field out of a `ps` line. `ps` right-aligns its
-## columns, so the line may begin with spaces; trim before splitting or the
-## first field is "" and the value parses to NA.
-.rssField <- function(x) {
-  strsplit(trimws(x[1]), split = " +")[[1]][1]
-}
-
 memoryUseThisSession <- function(thisPid) {
   ps <- Sys.which("ps")
   if (missing(thisPid)) {


### PR DESCRIPTION
**Merge this first — it is why PRs #408–#412 are red.**

## What happened

`1630b914` (my memory-parsing fix, already merged) inserted `.rssField()` *between* the roxygen block and the function it documents:

```r
#' Estimate memory used with `system("ps")`
#' ...
#' @export
#' @rdname memoryUse
## Pull the leading numeric field out of a `ps` line. ...
.rssField <- function(x) { ... }        # <- block attached to THIS

memoryUseThisSession <- function(thisPid) {   # <- now undocumented, unexported
```

roxygen binds a block to the object that follows it. So `memoryUseThisSession()` silently lost its documentation and its export, and `.rssField()` — an internal helper that should never be exported — gained both.

That commit did not re-run `document()`, so the checked-in `NAMESPACE` and `man/memoryUse.Rd` still described the *intended* state and masked it entirely.

## Why it surfaced now

Every one of my six feature PRs ran `document()`, which regenerated the honest-but-broken output, giving each of them the same two `R CMD check` WARNINGs — on every platform, not just macOS:

```
❯ checking Rd cross-references ... WARNING
  Missing link(s) in Rd file 'SpaDES.core-package.Rd': 'memoryUseThisSession'

❯ checking Rd \usage sections ... WARNING
  Undocumented arguments in Rd file 'memoryUse.Rd': 'x'
  Documented arguments not in \usage in Rd file 'memoryUse.Rd': 'thisPid'
```

## The fix

Move `.rssField()` above the roxygen block, so the block reattaches to `memoryUseThisSession()`.

The strongest evidence this is right: **`document()` after this change produces no `NAMESPACE` or `man/` diff at all.** The regenerated files match what is already checked in, which means the committed files were correct for the intended code and only the attachment was wrong.

Verified: `memoryUseThisSession` exported again, `.rssField` not exported, `.rssField("   123 456 ")` still returns `123`. `test-memory.R` 10 passing.

## Note on the other PRs

Their `NAMESPACE` / `man/memoryUse.Rd` deltas were unrelated regenerated files my `document()` runs swept in — I should have caught that in review rather than committing whatever `document()` touched. I am stripping those deltas from each of the six so they are surgical, and they will go green independently of merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBeLp5Zbsby8Qn8jj2btX3
