### PR TITLE
fix(parseModule): don't force the mod active binding when copying .mods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-08-26
-Version: 3.2.0
+Version: 3.2.1.9000
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# SpaDES.core 3.2.1.9000 (development version)
+
+## Bug fixes
+
+* `loadSimList()` is now much faster for simulations that carry large module
+  objects (`mod`). Reparsing module source code copied the `.mods` environment
+  with `Copy()`, which forced each module's `mod` and `Par` active bindings;
+  forcing `mod` materializes `.modObjs[[currentModule(sim)]]`, so the entire
+  per-module object store was deep copied once per module environment, for every
+  parsed file of every module. It is now copied with `.cloneEnvDeep()`, which
+  re-attaches active bindings instead of evaluating them. On a `simList` holding
+  a 9.5 GB `mod` object, a single `.mods` copy went from 174 s to under 0.01 s,
+  and the whole `loadSimList()` call from 627 s to 152 s.
+
 # SpaDES.core 3.2.0
 
 ## New features

--- a/R/simulation-parseModule.R
+++ b/R/simulation-parseModule.R
@@ -617,7 +617,13 @@ evalWithActiveCode <- function(parsedModuleNoDefineModule, envir, parentFrame = 
 
   # This needs to be unconnected to main sim so that object sizes don't blow up
   simCopy <- Copy(sim, objects = FALSE)
-  simCopy$.mods <- Copy(sim$.mods)
+  ## NOT Copy(): it goes via as.list(all.names = TRUE), which *forces* the
+  ## `mod`/`Par` active bindings in each module env. `mod` resolves to
+  ## .modObjs[[currentModule(sim)]], so Copy() deep copies the whole per-module
+  ## object store once per module env, on every call -- GBs of data.table::copy()
+  ## per parsed file when reloading a large simList. .cloneEnvDeep() re-attaches
+  ## active bindings instead of evaluating them.
+  simCopy$.mods <- .cloneEnvDeep(sim$.mods)
   tmpEnvir$sim <- simCopy
 
   ll <- local({

--- a/tests/testthat/test-mod.R
+++ b/tests/testthat/test-mod.R
@@ -891,3 +891,40 @@ test_that("convertToPackage testing", {
   # pkgload::unload(testName2)
   #}
 })
+
+test_that("evalWithActiveCode does not force the mod active binding", {
+  ## Regression: evalWithActiveCode() used Copy(sim$.mods) to detach the module
+  ## environments from the caller's sim. Copy() on an environment goes via
+  ## as.list(all.names = TRUE), which *evaluates* active bindings, and forcing
+  ## `mod` returns .modObjs[[currentModule(sim)]] -- so the whole per-module
+  ## object store was deep copied, once per module environment, for every parsed
+  ## file of every module. Reloading a large simList spent minutes in
+  ## data.table::copy(). See .cloneEnvDeep().
+  testInit(smcc = FALSE, debug = FALSE)
+
+  newModule("testActiveBinding", tmpdir, open = FALSE)
+  mySim <- simInit(times = list(start = 0, end = 0),
+                   paths = list(modulePath = tmpdir),
+                   modules = "testActiveBinding")
+
+  bigObj <- 1:10
+  mySim@.xData[[".modObjs"]][["testActiveBinding"]]$big <- bigObj
+  mySim <- SpaDES.core:::currentModuleTemporary(mySim, "testActiveBinding")
+
+  modEnv <- mySim@.xData[[".mods"]][["testActiveBinding"]]
+  expect_true(bindingIsActive("mod", modEnv))
+
+  ## ask the module code itself whether its `mod` arrived as a live binding.
+  ## (The temp sim's own .modObjs are deliberately empty -- Copy(objects = FALSE)
+  ## -- which is precisely why forcing `mod` was wrong: it reached past the copy
+  ## and materialized the *caller's* store.)
+  code <- parse(text =
+    'stillActive <- bindingIsActive("mod", sim@.xData[[".mods"]][["testActiveBinding"]])')
+  SpaDES.core:::evalWithActiveCode(code, modEnv, sim = mySim)
+
+  ## with the old Copy(sim$.mods) this was FALSE: `mod` had been materialized
+  expect_true(modEnv$stillActive)
+
+  ## and the caller's store is untouched
+  expect_identical(mySim@.xData[[".modObjs"]][["testActiveBinding"]]$big, bigObj)
+})


### PR DESCRIPTION
## The bug

`evalWithActiveCode()` detached its temporary sim from the caller's with `Copy(sim$.mods)`.

`Copy()` on an environment goes through `as.list(envir, all.names = TRUE)`, which **evaluates active bindings**. Every `.mods[[module]]` carries `mod` and `Par` active bindings, and `mod` resolves via `activeModBindingFunction()` to `sim@.xData$.modObjs[[currentModule(sim)]]` — i.e. it reaches *past* the copy, off the caller's sim, and returns the entire per-module object store.

That store was then deep copied — once per module environment, on every call — and `evalWithActiveCode()` runs once per parsed file per module (~50–60× for a 19-module sim).

Note the binding keys off `currentModule(sim)`, not the environment it lives in, so a single `Copy(sim$.mods)` pulls the *same* store once for each of the 19 module envs.

## Impact

Found while reloading a `simList` whose `Biomass_speciesParameters` `mod` held an 8.7 GB `cohortDataFactorial` data.table. `Rprof` on `loadSimList()`:

| | self time | share |
|---|---|---|
| `data.table::copy` | 487.0 s | 76.9% |
| `readRDS` | 120.5 s | 19.0% |

All of that `data.table::copy` sits under `.reparseModules` → `evalWithActiveCode` → `Copy`.

## The fix

Use `.cloneEnvDeep()` — already in the package (`R/saveLoadSimList.R`), already used by `saveSimList()` for exactly this reason, and already tested for keeping active bindings active. It re-attaches active bindings rather than evaluating them.

## Measurements

Same simList, same machine:

```
Copy(sim$.mods), active bindings present   174.1 s     <- one call
Copy(.mods), active bindings removed         0.011 s
.cloneEnvDeep(sim$.mods)                     0.001 s

loadSimList()                              627 s -> 152 s
```

Confirmed `.mods` itself is objects-free as designed (174 functions + 26 small bindings = 3.3 MB serialized); the objects arrive **solely** through the forced binding. Also confirmed `Copy(sim, objects = FALSE)` on the preceding line correctly short-circuits (0.007 s) — that line was never the problem.

## Test

Adds a regression test to `test-mod.R` asserting `mod` reaches module code as a live binding. Verified it **fails** on the previous `Copy()` implementation and passes with the fix.

## Version

`development` was still at `3.2.0` with 51 commits since the release prep and no dev-version bump, so this sets `3.2.1.9000` and opens a matching NEWS section.

⚠️ Unrelated, for the record: `origin/main` is at **3.2.1** and carries `f6aabd22 fix(test): keep saveSimList test paths inside projectPath` which `development` does not have. Deliberately **not** addressed here — flagging it for the next release merge, per the "verify every main-only fix exists on development" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnaYmDRPjQ8Uu3Rq8HRDZW