### PR TITLE
ci: pin the matrix to exact R versions, and test the declared floor

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,4 +19,14 @@ jobs:
       # Extra legs SpaDES.core tested pre-migration, on top of the reusable base
       # (release + oldrel-1 + ubuntu nosuggests): windows nosuggests, and
       # windows/ubuntu oldrel-2. Vignette compaction is the reusable default.
-      extra-config: '[{"config":{"os":"windows-latest","nosuggests":true,"r":"release"}},{"config":{"os":"windows-latest","nosuggests":false,"r":"oldrel-2"}},{"config":{"os":"ubuntu-latest","nosuggests":false,"r":"oldrel-2"}}]'
+      # Deep matrix legs pinned to exact R versions, not oldrel-N. The oldrel
+      # ladder is platform-dependent and not monotone: on ubuntu-latest
+      # oldrel-4 and oldrel-5 both resolve to 4.1.3 and R 4.2 is unreachable
+      # entirely; on ubuntu-22.04 oldrel-4 gives R 3.6.3. It also shifts every
+      # time R releases. DESCRIPTION declares R (>= 4.3), so 4.3 is the
+      # version this matrix has to prove -- oldrel-2 stopped at 4.4.
+      extra-config: |
+        [{"config": {"os": "windows-latest", "nosuggests": true,  "r": "release"}},
+         {"config": {"os": "windows-latest", "nosuggests": false, "r": "4.4"}},
+         {"config": {"os": "ubuntu-latest",  "nosuggests": false, "r": "4.4"}},
+         {"config": {"os": "ubuntu-latest",  "nosuggests": false, "r": "4.3"}}]


### PR DESCRIPTION
Pins the deep matrix legs to exact R versions instead of `oldrel-N`, and adds a leg at the floor `DESCRIPTION` actually declares.

### `oldrel-N` does not mean what the matrix assumes

Resolved against the exact platform string `setup-r` sends (`linux-ubuntu-<ver>`), via the same r-hub endpoint the action uses:

```
ubuntu-latest (noble)      ubuntu-22.04             macOS arm64
oldrel-1 -> 4.5.3          oldrel-1 -> 4.5.3        oldrel-1 -> 4.4.3
oldrel-2 -> 4.4.3          oldrel-2 -> 4.3.3  skip  oldrel-2 -> 4.3.3
oldrel-3 -> 4.3.3          oldrel-3 -> 4.2.3        oldrel-3 -> 4.3.3  dup
oldrel-4 -> 4.1.3  skips   oldrel-4 -> 3.6.3   !!   oldrel-4 -> 4.1.3
oldrel-5 -> 4.1.3  dup     oldrel-5 -> 4.1.3        oldrel-5 -> 4.1.3  dup
```

Only macOS x86_64 and Windows give the clean monotone ladder everyone assumes. There is no `oldrel-4` ceiling in r-lib/actions — `setup-r` passes the value straight to the resolver — but the mapping is not what the name implies, and it moves every time R releases.

### The floor was never tested

`DESCRIPTION` declares **R (>= 4.3)**. The base matrix stops at `oldrel-1` (**R 4.5**), and the existing `oldrel-2` leg reaches only 4.4. Exact versions resolve identically on all three OSes (`4.3` -> 4.3.3), and Posit ships noble `.deb`s down to 4.0.5.

### If a new leg fails

That is the finding, not a reason to drop the leg — it means the declared floor was never true. Either fix the package or raise `Depends:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)