### PR TITLE
feat(saveSimList): defer mod objects too, as one sidecar file per object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL:
     https://spades-core.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.core
 Date: 2026-08-26
-Version: 3.2.1.9000
+Version: 3.2.1.9001
 Authors@R: c(
     person("Alex M", "Chubaty", , "achubaty@for-cast.ca", role = c("aut"),
            comment = c(ORCID = "0000-0001-7146-8135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,36 @@
   a 9.5 GB `mod` object, a single `.mods` copy went from 174 s to under 0.01 s,
   and the whole `loadSimList()` call from 627 s to 152 s.
 
+* `saveSimList(lazy = TRUE)` no longer loses module (`mod`) objects.
+  `loadSimList()` deleted every `.modObjs` binding when it detected a lazy save,
+  on the assumption that they were per-module copies of file-backed objects that
+  `spades()` would rebuild. Any `mod` state a module was keeping was therefore
+  silently dropped on a lazy round trip.
+
+## New features
+
+* `saveSimList(lazy = TRUE)` now defers module (`mod`) objects as well as user
+  objects, and writes each object to its own file under a sibling
+  `<filename>_lazy/` directory instead of to a lazy-load database.
+  [loadSimList()] binds each as a promise, into `sim@.xData` or into
+  `.modObjs[[module]]` as appropriate, so a module reaches its `mod` objects
+  exactly as before but pays for them only on first access.
+
+  A lazy-load database cannot hold a value larger than 2 GB at all (`long
+  vectors not supported yet`), which ruled it out for `mod` objects; one file per
+  object also lets a reader take only what it touches. On a real 2.7 GB
+  simulation whose `mod` held an 8.7 GB `data.table`, the `simList` file itself
+  drops to a few MB, and reading `outputs()` and parameters from a reloaded run
+  no longer materializes any object.
+
+  Note that promises are forced by whole-environment operations -- `as.list()`,
+  `get()`, `mget()`, `eapply()`, and therefore anything that deep copies a
+  `simList`, such as `Copy()` -- but not by `ls()`, `exists()`, or reading
+  metadata such as `outputs()`.
+
+  The previous `<filename>_xData.rdx`/`.rdb` layout is gone; `lazy = TRUE` was
+  never released, so nothing on disk depends on it.
+
 # SpaDES.core 3.2.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# SpaDES.core 3.2.1.9000 (development version)
+# SpaDES.core 3.2.1.9001 (development version)
 
 ## Bug fixes
 

--- a/R/saveLoadSimList.R
+++ b/R/saveLoadSimList.R
@@ -93,12 +93,23 @@
 #'   `inputs` or `cache` are `TRUE`. Setting this to `FALSE` will turn off the
 #'   saving of files specified in `inputs(sim)`, `outputs(sim)` or the cache.
 #'
-#' @param lazy Logical. If `TRUE`, the user objects in `sim@.xData` are saved
-#'   into a sibling lazy-load DB (a `<filename>_xData.rdx`/`.rdb` pair built
-#'   by `tools:::makeLazyLoadDB()`) alongside the shell `simList` file,
-#'   rather than monolithically. [loadSimList()] detects this layout
-#'   automatically and restores the objects via [lazyLoad()], materializing
-#'   each one only on first access. Defaults to `FALSE`.
+#' @param lazy Logical. If `TRUE`, the objects are written one per file into a
+#'   sibling `<filename>_lazy/` directory instead of into the `simList` file
+#'   itself, and [loadSimList()] binds each as a promise that reads its file on
+#'   first access. This covers both the user objects in `sim@.xData` and every
+#'   module's `mod` objects (`sim@.xData$.modObjs`); `.mods` and the internal
+#'   dot-prefixed bindings stay in the file, being small and always needed. The
+#'   result is a `simList` file of a few MB that opens in seconds, from which
+#'   you pay only for the objects you actually touch.
+#'
+#'   One file per object rather than a single lazy-load database because a value
+#'   larger than 2 GB cannot be put in one at all (`long vectors not supported
+#'   yet`), and `mod` objects are routinely larger than that.
+#'
+#'   Note that promises are forced by whole-environment operations -- `as.list()`,
+#'   `get()`, `mget()`, `eapply()`, and so anything that deep-copies the
+#'   `simList`, such as [Copy()] -- but not by `ls()`, `exists()`, or reading
+#'   metadata such as [outputs()]. Defaults to `FALSE`.
 #' @param ... Additional arguments. See Details.
 #'
 #' @return
@@ -278,23 +289,11 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
 
   if (isTRUE(lazy)) {
     ext <- tools::file_ext(filename)
-    lazyBase <- paste0(tools::file_path_sans_ext(filename), "_xData")
-    lazyDbFiles <- paste0(lazyBase, c(".rdx", ".rdb"))
-
-    userObjNames <- ls(sim@.xData, all.names = FALSE)
-    if (length(userObjNames)) {
-      ## makeLazyLoadDB is internal to tools but stable; use getFromNamespace
-      ## to avoid the R CMD check NOTE for ::: usage.
-      ## Restrict to user objects: dot-prefixed internals (.mods, .modObjs, ...)
-      ## stay in @.xData and ride along in saveRDS(). Without `variables`,
-      ## makeLazyLoadDB defaults to all.names = TRUE and bundles each nested
-      ## env's bindings into a single serialized blob via its envhook --
-      ## .mods alone can exceed the 2 GB single-value lazyLoadDB limit.
-      utils::getFromNamespace("makeLazyLoadDB", "tools")(
-        sim@.xData, lazyBase, variables = userObjNames
-      )
-      rm(list = userObjNames, envir = sim@.xData)
-    }
+    ## Defer the user objects AND every module's `mod` objects to sidecar files;
+    ## see .writeLazyObjs(). What is left in `sim` is the shell: slots, `.mods`
+    ## and the dot-prefixed internals.
+    lazyDir <- .lazyDirName(filename)
+    lazyFiles <- .writeLazyObjs(sim, lazyDir, ext = ext)
 
     if (ext == "rds") {
       saveRDS(sim, file = filename)
@@ -329,7 +328,7 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
         srcFiles <- tmpSrcFiles
       }
 
-      lazyDbExisting <- lazyDbFiles[file.exists(lazyDbFiles)]
+      lazyExisting <- lazyFiles[file.exists(lazyFiles)]
       allFns <- c(fns, otherFns, srcFilesRel)
       if (!is.null(symlinks)) {
         for (p in names(symlinks)) {
@@ -338,10 +337,10 @@ saveSimList <- function(sim, filename, projectPath = getwd(),
       }
       allFns <- na.omit(allFns)
 
-      relFns <- makeRelative(c(fileToDelete, lazyDbExisting, allFns), projectPath) |> unname()
+      relFns <- makeRelative(c(fileToDelete, lazyExisting, allFns), projectPath) |> unname()
       archiveWrite(filename, relFns, verbose, projectPath = projectPath)
       unlink(fileToDelete)
-      unlink(lazyDbExisting)
+      unlink(lazyDir, recursive = TRUE)
     }
 
     messageVerbose("    ... saved!", verbose = verbose)
@@ -473,29 +472,27 @@ loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
     on.exit(unlink(td, recursive = TRUE), add = TRUE)
 
     baseNameNoExt <- tools::file_path_sans_ext(basename(filename[1]))
-    lazyBaseName <- paste0(baseNameNoExt, "_xData")
-    lazyDbBasenames <- paste0(lazyBaseName, c(".rdx", ".rdb"))
-    isLazyDb <- basename(filename[-1]) %in% lazyDbBasenames
+    lazyDirName <- paste0(baseNameNoExt, "_lazy")
+    isLazy <- grepl(paste0("(^|/)", lazyDirName, "/"), filename[-1])
 
-    filenameRel <- gsub(paste0(td, "/"), "", filename[-1][!isLazyDb])  ## TODO: WRONG!
+    filenameRel <- gsub(paste0(td, "/"), "", filename[-1][!isLazy])  ## TODO: WRONG!
     ## This will put the files to relative path of projectPath
     newFns <- file.path(projectPath, filenameRel)
-    linkOrCopy(filename[-1][!isLazyDb], newFns, verbose = verbose - 1)
+    linkOrCopy(filename[-1][!isLazy], newFns, verbose = verbose - 1)
 
-    ## Persist .rdb/.rdx beyond tempdir cleanup so lazy promises can resolve
-    lazyBase <- file.path(tempPath, lazyBaseName)
-    for (ex in c(".rdx", ".rdb")) {
-      srcs <- filename[-1][isLazyDb & basename(filename[-1]) == paste0(lazyBaseName, ex)]
-      if (length(srcs)) {
-        dst <- paste0(lazyBase, ex)
-        if (file.exists(dst)) unlink(dst)
-        file.copy(srcs[[1L]], dst)
-      }
+    ## Persist the sidecar objects beyond tempdir cleanup: the promises bound
+    ## below resolve long after this call returns, and `td` is unlinked on exit.
+    lazyDir <- file.path(tempPath, lazyDirName)
+    srcs <- filename[-1][isLazy]
+    if (length(srcs)) {
+      unlink(lazyDir, recursive = TRUE)
+      dir.create(lazyDir, recursive = TRUE, showWarnings = FALSE)
+      file.copy(srcs, file.path(lazyDir, basename(srcs)))
     }
   } else {
     # filenameRel <- gsub(paste0(projectPath, "/"), "", filename) ## TODO: WRONG!
     filenameRel <- getRelative(filename, projectPath)
-    lazyBase <- paste0(tools::file_path_sans_ext(filename[1]), "_xData")
+    lazyDir <- .lazyDirName(filename[1])
   }
 
   if (tolower(tools::file_ext(filename[1])) == "rds") {
@@ -572,21 +569,13 @@ loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
     }
   }
 
-  ## Detect lazy load before .unwrap so we can clear .modObjs (which holds per-module
-  ## copies of file-backed objects) from the shell simList. Those objects were NOT saved
-  ## as part of the shell — their backing files may not exist — and .unwrap would fail on
-  ## them. They are rebuilt by spades() on the next run, so it is safe to clear them here.
-  isLazyLoad <- file.exists(paste0(lazyBase, ".rdx"))
-
-  if (isLazyLoad) {
-    modObjsEnv <- tmpsim@.xData[[".modObjs"]]
-    if (is.environment(modObjsEnv)) {
-      nms <- ls(modObjsEnv, all.names = TRUE)
-      if (length(nms)) rm(list = nms, envir = modObjsEnv)
-    } else if (!is.null(modObjsEnv)) {
-      tmpsim@.xData[[".modObjs"]] <- NULL
-    }
-  }
+  ## A lazily saved simList carries its objects -- user objects and every module's
+  ## `mod` objects alike -- as sidecar files rather than in the shell. Nothing to
+  ## strip here: the shell has none of them, and each is bound as a promise below,
+  ## after the module environments exist. `.unwrap` therefore never runs eagerly
+  ## over them, so a `mod` object whose backing file is missing now fails on
+  ## access, in its own tryCatch, instead of aborting the load.
+  isLazyLoad <- file.exists(file.path(lazyDir, .lazyManifestName))
 
   tmpsim <- .unwrapResiliently(tmpsim, paths(tmpsim))
   tmpsim <- .unwrap(tmpsim, cachePath = NULL, paths = paths(tmpsim))
@@ -605,32 +594,13 @@ loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
   ## -- so without this a reloaded simList cannot be run.
   tmpsim <- .reparseModules(tmpsim, modules(tmpsim), verbose = verbose)
 
-  ## Lazy loading: if a sibling .rdx/.rdb pair exists, restore the user objects
-  ## via lazyLoad() into a holding env, then bind delayedAssign wrappers on the
-  ## simList so each access triggers the underlying lazy promise plus our
-  ## remap/unwrap pass.
+  ## Lazy loading: bind a promise per sidecar object, into @.xData for user
+  ## objects and into .modObjs[[module]] for `mod` objects. Done after
+  ## .reparseModules() so the module environments and their `mod` active
+  ## bindings are already in place -- a module then reaches its `mod` object
+  ## exactly as it would have before, and pays for it only on first access.
   if (isLazyLoad) {
-    lazyEnv <- new.env(parent = emptyenv())
-    tryCatch(lazyLoad(lazyBase, envir = lazyEnv),
-             error = function(e) warning("Could not attach lazy DB '", lazyBase,
-                                         "': ", conditionMessage(e), call. = FALSE))
-    simPaths <- paths(tmpsim)
-    for (nm in ls(lazyEnv, all.names = TRUE)) {
-      local({
-        .nm <- nm
-        .lazyEnv     <- lazyEnv
-        .projectPath <- projectPath
-        .simPaths    <- simPaths
-        delayedAssign(.nm, tryCatch({
-          obj <- get(.nm, envir = .lazyEnv)
-          obj <- .remapFileBackedObj(obj, .projectPath, .simPaths)
-          .unwrap(obj, cachePath = NULL, paths = .simPaths)
-        }, error = function(e) {
-          warning("Could not load lazy object '", .nm, "': ", conditionMessage(e), call. = FALSE)
-          NULL
-        }), eval.env = environment(), assign.env = envir(tmpsim))
-      })
-    }
+    tmpsim <- .attachLazyObjs(tmpsim, lazyDir, projectPath)
   }
 
   return(tmpsim)
@@ -805,6 +775,133 @@ recoverDataTableFromQs <- function(sim) {
   }
   attributes(out) <- attributes(env)
   out
+}
+
+## ---- lazy sidecar objects ------------------------------------------------
+##
+## `lazy = TRUE` defers the big objects: each is written to its own file under
+## `<filename sans ext>_lazy/`, and loadSimList() binds a promise (delayedAssign)
+## for it instead of reading it. Two reasons this is one-file-per-object rather
+## than tools::makeLazyLoadDB(): a single value larger than 2 GB cannot go into a
+## lazy load DB at all ("long vectors not supported yet: connections.c"), and
+## `mod` objects routinely are that large; and a file per object lets a reader
+## pay for exactly what it touches.
+##
+## Deferred: the user objects in `sim@.xData` (undotted) and every `mod` object
+## in `sim@.xData$.modObjs[[module]]`. `.mods` and the dot-prefixed internals
+## stay in the shell -- together a few MB, and always needed.
+##
+## NOTE: promises are forced by bulk environment operations -- `as.list()`,
+## `get()`, `mget()`, `eapply()` -- but not by `ls()` or `exists()`. So a whole
+## simList `Copy()` materializes everything, while reading metadata or touching
+## one object does not.
+
+.lazyDirName <- function(filename) paste0(tools::file_path_sans_ext(filename), "_lazy")
+
+.lazyManifestName <- "_manifest.rds"
+
+.saveOneLazy <- function(obj, file, ext) {
+  if (identical(tolower(ext), "qs2")) {
+    qs2::qs_save(obj, file = file, nthreads = getOption("spades.qsThreads", 1))
+  } else {
+    saveRDS(obj, file = file)
+  }
+}
+
+.readOneLazy <- function(file) {
+  if (identical(tolower(tools::file_ext(file)), "qs2")) {
+    qs2::qs_read(file, nthreads = getOption("spades.qsThreads", 1))
+  } else {
+    readRDS(file)
+  }
+}
+
+## The environment a manifest row belongs to. `where` is "" for objects that live
+## directly in sim@.xData, otherwise the module name whose .modObjs env holds it.
+## Creates the .modObjs env if it is not there (loading into a fresh shell).
+.lazyEnvFor <- function(sim, where) {
+  if (!nzchar(where)) return(sim@.xData)
+  if (!is.environment(sim@.xData[[dotObjs]]))
+    sim@.xData[[dotObjs]] <- new.env(parent = emptyenv())
+  if (!is.environment(sim@.xData[[dotObjs]][[where]]))
+    sim@.xData[[dotObjs]][[where]] <- new.env(parent = emptyenv())
+  sim@.xData[[dotObjs]][[where]]
+}
+
+## Everything that gets deferred, as a manifest.
+.lazyEntries <- function(sim) {
+  ents <- list()
+  userObjNames <- ls(sim@.xData, all.names = FALSE)
+  if (length(userObjNames))
+    ents[[length(ents) + 1]] <- data.frame(where = "", name = userObjNames)
+
+  modObjsEnv <- sim@.xData[[dotObjs]]
+  if (is.environment(modObjsEnv)) {
+    for (m in ls(modObjsEnv, all.names = TRUE)) {
+      e <- modObjsEnv[[m]]
+      if (!is.environment(e)) next
+      nms <- ls(e, all.names = TRUE)
+      if (length(nms))
+        ents[[length(ents) + 1]] <- data.frame(where = m, name = nms)
+    }
+  }
+  if (!length(ents)) return(data.frame(where = character(), name = character()))
+  do.call(rbind, ents)
+}
+
+## Write each deferred object to its own file and remove it from the simList, so
+## the shell that gets serialized carries only metadata. Returns the files
+## written (manifest included), for the archive.
+.writeLazyObjs <- function(sim, dir, ext = "rds") {
+  ents <- .lazyEntries(sim)
+  unlink(dir, recursive = TRUE)
+  if (!NROW(ents)) return(character())
+
+  dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  ## index keeps the name unique; the readable part is only for humans browsing
+  ## the directory -- the manifest is what load reads.
+  ents$file <- sprintf("%04d-%s.%s", seq_len(NROW(ents)),
+                       gsub("[^A-Za-z0-9._-]", "_", ents$name), ext)
+
+  for (i in seq_len(NROW(ents))) {
+    env <- .lazyEnvFor(sim, ents$where[i])
+    .saveOneLazy(get(ents$name[i], envir = env, inherits = FALSE),
+                 file.path(dir, ents$file[i]), ext)
+    rm(list = ents$name[i], envir = env)
+  }
+  saveRDS(ents, file.path(dir, .lazyManifestName))
+
+  file.path(dir, c(ents$file, .lazyManifestName))
+}
+
+## Bind a promise per manifest row. The body matches what loadSimList() does for
+## an eagerly loaded object -- remap file-backed paths, then unwrap -- so a lazy
+## object is indistinguishable from an eager one once touched.
+.attachLazyObjs <- function(sim, dir, projectPath) {
+  mf <- file.path(dir, .lazyManifestName)
+  if (!file.exists(mf)) return(sim)
+
+  ents <- readRDS(mf)
+  simPaths <- paths(sim)
+  for (i in seq_len(NROW(ents))) {
+    env <- .lazyEnvFor(sim, ents$where[i])
+    local({
+      .f  <- file.path(dir, ents$file[i])
+      .nm <- ents$name[i]
+      .pp <- projectPath
+      .sp <- simPaths
+      delayedAssign(.nm, tryCatch({
+        obj <- .readOneLazy(.f)
+        obj <- .remapFileBackedObj(obj, .pp, .sp)
+        .unwrap(obj, cachePath = NULL, paths = .sp)
+      }, error = function(e) {
+        warning("Could not load lazy object '", .nm, "' from '", .f, "': ",
+                conditionMessage(e), call. = FALSE)
+        NULL
+      }), eval.env = environment(), assign.env = env)
+    })
+  }
+  sim
 }
 
 ## Anchors offered to .wrap()/.unwrap() when deciding what a file-backed

--- a/tests/testthat/test-saveLoadLazy.R
+++ b/tests/testthat/test-saveLoadLazy.R
@@ -1,5 +1,5 @@
-## Round-trip tests for the lazy saveSimList / loadSimList path
-## (tools::makeLazyLoadDB on save, lazyLoad() on load).
+## Round-trip tests for the lazy saveSimList / loadSimList path: one sidecar
+## file per object under `<filename sans ext>_lazy/`, restored as promises.
 ## A minimal `new("simList")` keeps the test fast and isolates the
 ## lazy mechanism from simInit/spades plumbing.
 
@@ -17,14 +17,16 @@ test_that("lazy saveSimList/loadSimList round-trip restores user objects via pro
   sim@.xData[["c"]] <- list(x = 10, y = "z")
 
   filename <- file.path(td, "sim.rds")
-  lazyBase <- file.path(td, "sim_xData")
+  lazyDir <- file.path(td, "sim_lazy")
 
   saveSimList(sim, filename = filename, files = FALSE, lazy = TRUE,
               projectPath = td)
 
   expect_true(file.exists(filename))
-  expect_true(file.exists(paste0(lazyBase, ".rdx")))
-  expect_true(file.exists(paste0(lazyBase, ".rdb")))
+  expect_true(dir.exists(lazyDir))
+  expect_true(file.exists(file.path(lazyDir, "_manifest.rds")))
+  ## one file per object, plus the manifest
+  expect_length(dir(lazyDir), 4L)
 
   loaded <- loadSimList(filename, projectPath = td)
 
@@ -61,7 +63,7 @@ test_that("lazy round-trip materializes a file-backed terra SpatRaster on access
   filename <- file.path(td, "sim.rds")
   saveSimList(sim, filename = filename, files = FALSE, lazy = TRUE,
               projectPath = td)
-  expect_true(file.exists(paste0(file.path(td, "sim_xData"), ".rdx")))
+  expect_true(dir.exists(file.path(td, "sim_lazy")))
   expect_true(file.exists(rastFile))  # files = FALSE -> backing file untouched
 
   loaded <- loadSimList(filename, projectPath = td)
@@ -109,7 +111,7 @@ test_that("saveSimList does not mutate the caller's simList (Path-wrap leak)", {
   expect_identical(sim$nested$inner, "untouched")
 })
 
-test_that("lazy saveSimList omits the .rdx/.rdb when there are no user objects", {
+test_that("lazy saveSimList omits the sidecar directory when there is nothing to defer", {
   td <- normPath(withr::local_tempdir())
   simPaths <- list(cachePath = td, inputPath = td, outputPath = td,
                    modulePath = td, scratchPath = td, terraPath = td)
@@ -118,15 +120,138 @@ test_that("lazy saveSimList omits the .rdx/.rdb when there are no user objects",
   paths(sim) <- simPaths
 
   filename <- file.path(td, "empty.rds")
-  lazyBase <- file.path(td, "empty_xData")
+  lazyDir <- file.path(td, "empty_lazy")
 
   saveSimList(sim, filename = filename, files = FALSE, lazy = TRUE,
               projectPath = td)
 
   expect_true(file.exists(filename))
-  expect_false(file.exists(paste0(lazyBase, ".rdx")))
-  expect_false(file.exists(paste0(lazyBase, ".rdb")))
+  expect_false(dir.exists(lazyDir))
 
   loaded <- loadSimList(filename, projectPath = td)
   expect_s4_class(loaded, "simList")
+})
+
+test_that("lazy round-trip defers `mod` objects instead of discarding them", {
+  ## Regression: loadSimList() used to *delete* every .modObjs binding when it
+  ## saw a lazy save, because .modObjs was assumed to hold only per-module copies
+  ## of file-backed objects whose backing files might be gone. `mod` state was
+  ## therefore silently lost on every lazy round-trip -- while .reparseModules()
+  ## goes out of its way to preserve exactly that state.
+  skip_if_not_installed("rlang")
+
+  td <- normPath(withr::local_tempdir())
+  simPaths <- list(cachePath = td, inputPath = td, outputPath = td,
+                   modulePath = td, scratchPath = td, terraPath = td)
+
+  sim <- new("simList")
+  paths(sim) <- simPaths
+  sim@.xData[["userObj"]] <- 1:5
+  sim@.xData[[".mods"]] <- new.env(parent = emptyenv())
+  sim@.xData[[".modObjs"]] <- new.env(parent = emptyenv())
+  ## The objects live in .modObjs; .mods carries only the `mod`/`Par` active
+  ## bindings that point at them. Build both, as simInit() would -- but leave
+  ## `modules(sim)` empty so .reparseModules() has no module folders to find.
+  for (m in c("modA", "modB")) {
+    sim@.xData[[".mods"]][[m]] <- new.env(parent = asNamespace("SpaDES.core"))
+    sim@.xData[[".modObjs"]][[m]] <- new.env(parent = emptyenv())
+    SpaDES.core:::makeModActiveBinding(sim = sim, mod = m)
+    SpaDES.core:::makeParActiveBinding(sim = sim, mod = m)
+  }
+  sim@.xData[[".modObjs"]][["modA"]]$scratch <- data.frame(a = 1:100)
+  sim@.xData[[".modObjs"]][["modB"]]$other <- "kept"
+
+  filename <- file.path(td, "sim.rds")
+  ## suppressWarnings: .wrap.simList() unconditionally rm()s the `mod`/`Par`
+  ## bindings from each .mods env, but Copy(objects = 2) only re-creates them for
+  ## modules listed in modules(sim) -- empty here, since this fixture has no real
+  ## module folders for .reparseModules() to find. A real sim never warns.
+  suppressWarnings(
+    saveSimList(sim, filename = filename, files = FALSE, lazy = TRUE,
+                projectPath = td)
+  )
+
+  ## the shell itself must not carry them
+  shell <- readRDS(filename)
+  expect_length(ls(shell@.xData[[".modObjs"]][["modA"]], all.names = TRUE), 0L)
+  expect_false("userObj" %in% ls(shell@.xData, all.names = TRUE))
+
+  loaded <- loadSimList(filename, projectPath = td)
+
+  modAEnv <- loaded@.xData[[".modObjs"]][["modA"]]
+  modBEnv <- loaded@.xData[[".modObjs"]][["modB"]]
+
+  ## present, and still unforced
+  expect_true("scratch" %in% ls(modAEnv, all.names = TRUE))
+  expect_true(rlang::env_binding_are_lazy(modAEnv, "scratch"))
+  expect_true(rlang::env_binding_are_lazy(modBEnv, "other"))
+
+  ## and they resolve to what went in
+  expect_equal(modAEnv$scratch, data.frame(a = 1:100))
+  expect_identical(modBEnv$other, "kept")
+  expect_false(rlang::env_binding_are_lazy(modAEnv, "scratch"))
+
+  ## touching one module's object leaves the other's alone
+  expect_true(rlang::env_binding_are_lazy(loaded@.xData, "userObj"))
+})
+
+test_that("reading simList metadata does not force any lazy object", {
+  ## The point of the feature: reload a finished run, read outputs(sim) and
+  ## params, and pay nothing for the objects.
+  skip_if_not_installed("rlang")
+
+  td <- normPath(withr::local_tempdir())
+  simPaths <- list(cachePath = td, inputPath = td, outputPath = td,
+                   modulePath = td, scratchPath = td, terraPath = td)
+
+  sim <- new("simList")
+  paths(sim) <- simPaths
+  sim@.xData[["big1"]] <- 1:1000
+  sim@.xData[["big2"]] <- letters
+
+  filename <- file.path(td, "sim.rds")
+  saveSimList(sim, filename = filename, files = FALSE, lazy = TRUE, projectPath = td)
+  loaded <- loadSimList(filename, projectPath = td)
+
+  invisible(ls(loaded))
+  invisible(outputs(loaded))
+  invisible(paths(loaded))
+  invisible(exists("big1", envir = loaded@.xData, inherits = FALSE))
+
+  expect_true(all(rlang::env_binding_are_lazy(loaded@.xData, c("big1", "big2"))))
+})
+
+test_that("lazy handles a value too large for a lazy-load database", {
+  ## tools::makeLazyLoadDB cannot store a single value over 2 GB
+  ## ("long vectors not supported yet: connections.c"), which is why the
+  ## sidecar files exist at all -- `mod` objects are routinely larger.
+  skip_on_cran()
+  skip_on_ci()
+  skip_if_not(identical(Sys.getenv("R_SPADES_RUN_BIG_MEMORY_TESTS"), "true"),
+              "set R_SPADES_RUN_BIG_MEMORY_TESTS=true to run (needs ~8 GB RAM)")
+  skip_if_not_installed("rlang")
+
+  td <- normPath(withr::local_tempdir())
+  simPaths <- list(cachePath = td, inputPath = td, outputPath = td,
+                   modulePath = td, scratchPath = td, terraPath = td)
+
+  sim <- new("simList")
+  paths(sim) <- simPaths
+  sim@.xData[[".modObjs"]] <- new.env(parent = emptyenv())
+  sim@.xData[[".modObjs"]][["modA"]] <- new.env(parent = emptyenv())
+  sim@.xData[[".modObjs"]][["modA"]]$huge <- raw(2.5 * 1024^3)
+
+  filename <- file.path(td, "sim.rds")
+  ## the point: this neither errors nor truncates. tools::makeLazyLoadDB would
+  ## fail here with "long vectors not supported yet: connections.c".
+  suppressWarnings(
+    saveSimList(sim, filename = filename, files = FALSE, lazy = TRUE,
+                projectPath = td)
+  )
+  expect_true(dir.exists(file.path(td, "sim_lazy")))
+
+  loaded <- loadSimList(filename, projectPath = td)
+  modAEnv <- loaded@.xData[[".modObjs"]][["modA"]]
+  expect_true(rlang::env_binding_are_lazy(modAEnv, "huge"))
+  expect_equal(length(modAEnv$huge), 2.5 * 1024^3)
 })


### PR DESCRIPTION
> **Stacked on #415.** Based on `fix/evalWithActiveCode-forces-mod-binding` so the diff shows only this change; GitHub will retarget to `development` when #415 merges. It genuinely depends on #415 — see *Why it needs #415* below.

## The problem

`lazy = TRUE` moved only the **undotted** user objects in `sim@.xData` into a `<filename>_xData.rdx`/`.rdb` lazy-load database. Everything dot-prefixed stayed in the shell — `.modObjs` included, which is where the big things actually are.

On the simList that prompted this (2.71 GB on disk, **15.17 GB** serialized):

| | |
|---|---|
| `.modObjs` | **9.67 GB (64%)** — `mod$cohortDataFactorial` 8.70 GB, `mod$speciesTableFactorial` 0.84 GB |
| user objects | ~5.4 GB |
| `.mods` + internals | ~4 MB |

So lazy deferred a third of the file and left the rest eager.

Worse, `loadSimList()` then **deleted** every `.modObjs` binding when it detected a lazy save, on the assumption they were per-module copies of file-backed objects that `spades()` would rebuild. That 9.67 GB was written, read back, and thrown away — silently taking any `mod` state with it. Which directly contradicts `.reparseModules()`, which goes out of its way *not* to wipe "the `mod` state that `saveSimList()` exists to preserve".

## Why files and not a second lazy-load database

A lazy-load DB cannot hold a value over 2 GB at all:

```
1.5 GB single value: OK
2.5 GB single value: FAIL -- long vectors not supported yet: connections.c:6604
```

`mod` objects routinely exceed that — the one here is 8.7 GB. Per-object files also let a reader take only what it touches, and `cohortDatas` (a *user* object, 1.32 GB) was already at 66% of the same ceiling.

## What this does

Defers user objects **and** every module's `mod` objects, writing each to its own file under a sibling `<filename sans ext>_lazy/` directory with a `_manifest.rds`. `loadSimList()` binds a promise per manifest row — into `@.xData` for user objects, into `.modObjs[[module]]` for `mod` objects — using the same remap-then-unwrap body the eager path uses. Modules reach `mod$x` exactly as before.

To be precise about the two environments, since they are easy to conflate: **`.mods[[module]]`** holds the module's functions and the `mod`/`Par` **active bindings** (3.3 MB here); **`.modObjs[[module]]`** holds the **objects** (9.67 GB). Sidecars are written from `.modObjs` and promises are attached back into `.modObjs`; `.mods` is untouched in the shell, so its `mod` binding resolves as it always did and simply finds a promise.

Also drops the eager `.unwrap` over `.modObjs`: a `mod` object whose backing file is missing now fails on access inside its own `tryCatch` instead of aborting the load — which is what the deletion was working around.

## Measured, on the real simList

```
loadSimList, eager                 151.7 s
loadSimList, lazy                    4.3 s
shell .rds            2.71 GB  ->    0.45 MB     (138 sidecars, 2.71 GB total)
outputs() + params from reload       0   s       forcing nothing
forcing mod$cohortDataFactorial     82.2 s       276,321,276 x 5
```

Both `mod` objects survive the round trip as unforced promises.

## Why it needs #415

With the old `Copy(sim$.mods)`, `.reparseModules()` forces the `mod` active binding, which returns the `.modObjs` environment, which `Copy` then walks — forcing every promise during the load and defeating the feature entirely. #415 makes that copy re-attach bindings instead of evaluating them.

## Forcing semantics

Promises are forced by whole-environment operations — `as.list()`, `get()`, `mget()`, `eapply()`, hence anything that deep-copies a simList such as `Copy()` — but **not** by `ls()`, `exists()`, or reading metadata such as `outputs()`. Documented on the `lazy` parameter.

## Tests

`test-saveLoadLazy.R`: 37 pass. New coverage for `mod` objects deferring rather than being discarded; for metadata reads forcing nothing; and a 2.5 GB round trip (gated behind `R_SPADES_RUN_BIG_MEMORY_TESTS=true`, `skip_on_ci`) proving the case a lazy-load DB cannot represent.

Regression-checked under `pkgload::load_all()`: `test-mod.R` (178), `test-Copy.R`, `test-saveLoadSimList.R`, `test-saveLoadSimList-helpers.R`, `test-checkpoint.R`, `test-unwrapResiliently.R` — all clean.

## Compatibility and a follow-up

The `.rdx`/`.rdb` layout is removed outright rather than kept as a fallback — `lazy = TRUE` has never been in a release, so nothing on disk depends on it. **`SpaDES.project` needs PredictiveEcology/SpaDES.project#137 alongside this**: `outTar()` globbed for the old `.rdx`/`.rdb` and would otherwise ship archives containing a 0.45 MB shell and no objects.

Not addressed here: sidecars inherit the shell's extension, so `.rds` means gzip — that is why the lazy *save* took 637 s and why forcing `cohortDataFactorial` costs 82 s. `.qs2` or `compress = FALSE` would cut both at the cost of transfer size; that is a policy call worth making separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnaYmDRPjQ8Uu3Rq8HRDZW