### PR TITLE
fix: drop the "Error:" prefix from resilient wrap/unwrap warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Bug fixes
 
+* `saveSimList()`/`loadSimList()`: the warning for a file-backed object whose
+  backing file is inaccessible no longer prefixes the underlying message with
+  `Error:`, which read as a failure when the load in fact continued.
 * `loadSimList()` is now much faster for simulations that carry large module
   objects (`mod`). Reparsing module source code copied the `.mods` environment
   with `Copy()`, which forced each module's `mod` and `Par` active bindings;

--- a/R/saveLoadSimList.R
+++ b/R/saveLoadSimList.R
@@ -976,7 +976,7 @@ recoverDataTableFromQs <- function(sim) {
         error = function(e) {
           warning("saveSimList: could not wrap '", nm,
                   "' (backing file inaccessible); saving as NULL.\n",
-                  "  Error: ", conditionMessage(e), call. = FALSE)
+                  "  ", conditionMessage(e), call. = FALSE)
           NULL
         }
       )
@@ -1004,7 +1004,7 @@ recoverDataTableFromQs <- function(sim) {
         error = function(e) {
           warning("loadSimList: could not unwrap '", nm,
                   "' (backing file inaccessible); loading as NULL.\n",
-                  "  Error: ", conditionMessage(e), call. = FALSE)
+                  "  ", conditionMessage(e), call. = FALSE)
           NULL
         }
       )


### PR DESCRIPTION
A file-backed object whose backing file is gone is warned about, set to NULL, and the load continues — that is what the resilient pass is for. But the warning prefixed the underlying condition with `Error:`, so a handled, documented situation read as a failure.

Before:
```
loadSimList: could not unwrap 'currentClimateRasters' (backing file inaccessible); loading as NULL.
  Error: [rast] file does not exist: /mnt/shared_cache/cache/year1991__1179204.tif
```

After:
```
loadSimList: could not unwrap 'myRas' (backing file inaccessible); loading as NULL.
  [rast] file does not exist: /tmp/.../backing.tif
```

This came up on a real load of five simLists where four such warnings looked alarming but were the expected consequence of `saveSimList(cache = FALSE)` plus a since-cleared cache — nothing had gone wrong.

Changes both the save- and load-side messages: they are mirrors and the wording problem is identical in each. Verified by calling `.wrapResiliently()` / `.unwrapResiliently()` against a raster whose backing `.tif` was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141xS4r9o76uEgTvzR8qdTP