### PR TITLE
feat(loadSimList): add `reparse` to skip restoring module source code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # SpaDES.core 3.2.1.9001 (development version)
 
+## New features
+
+* `loadSimList()` gains `reparse`; `reparse = FALSE` skips restoring module source
+  code, which dominates the load time of a lazily saved `simList`. The result is
+  inspect-only: objects (including `mod`) are still bound lazily, but it cannot be
+  passed to `spades()`.
+
 ## Bug fixes
 
 * `saveSimList()`/`loadSimList()`: the warning for a file-backed object whose

--- a/R/saveLoadSimList.R
+++ b/R/saveLoadSimList.R
@@ -445,6 +445,16 @@ zipSimList <- function(sim, zipfile, ..., outputs = TRUE, inputs = TRUE, cache =
 #'   incorrect paths in `Filenames(sim)` if the the `file` being read in is from
 #'   a different computer, path, or drive. This could be the output from `unzipSimList`
 #'   (which is calls `loadSimList` internally, passing the unzipped filenames)
+#' @param reparse Logical. If `TRUE` (default), the module source code is
+#'   re-parsed on load, restoring the module functions that `saveSimList()`
+#'   does not carry -- without which the `simList` cannot be run. Set `FALSE`
+#'   to skip it when the `simList` is only going to be *inspected*: reparsing
+#'   dominates the cost of loading a lazily saved `simList` (on a 19-module
+#'   simulation, ~7 s of a ~9.5 s load), and none of the objects need it.
+#'   Lazy objects are unaffected either way -- both user objects and each
+#'   module's `mod` objects are still bound as promises. What a
+#'   `reparse = FALSE` `simList` lacks is the module code itself, so it cannot
+#'   be passed to [spades()], and module `mod`/`Par` active bindings are absent.
 #' @param tempPath A character string specifying the new base directory for the
 #'   temporary paths maintained in a `simList`.
 #' @inheritParams reproducible::Cache
@@ -460,7 +470,7 @@ zipSimList <- function(sim, zipfile, ..., outputs = TRUE, inputs = TRUE, cache =
 #' @importFrom reproducible linkOrCopy remapFilenames updateFilenameSlots .unwrap
 #' @importFrom tools file_ext
 loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
-                        paths = NULL, otherFiles = "",
+                        paths = NULL, otherFiles = "", reparse = TRUE,
                         verbose = getOption("reproducible.verbose")) {
   checkSimListExts(filename)
 
@@ -592,7 +602,8 @@ loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
   ## Restore the module functions. `saveSimList()` carries objects, metadata,
   ## paths and the event queue, but not the module code -- see .reparseModules()
   ## -- so without this a reloaded simList cannot be run.
-  tmpsim <- .reparseModules(tmpsim, modules(tmpsim), verbose = verbose)
+  if (isTRUE(reparse))
+    tmpsim <- .reparseModules(tmpsim, modules(tmpsim), verbose = verbose)
 
   ## Lazy loading: bind a promise per sidecar object, into @.xData for user
   ## objects and into .modObjs[[module]] for `mod` objects. Done after

--- a/man/loadSimList.Rd
+++ b/man/loadSimList.Rd
@@ -11,6 +11,7 @@ loadSimList(
   tempPath = tempdir(),
   paths = NULL,
   otherFiles = "",
+  reparse = TRUE,
   verbose = getOption("reproducible.verbose")
 )
 
@@ -35,6 +36,17 @@ existing file-backed \verb{Raster*} files that are the real paths for the possib
 incorrect paths in \code{Filenames(sim)} if the the \code{file} being read in is from
 a different computer, path, or drive. This could be the output from \code{unzipSimList}
 (which is calls \code{loadSimList} internally, passing the unzipped filenames)}
+
+\item{reparse}{Logical. If \code{TRUE} (default), the module source code is
+re-parsed on load, restoring the module functions that \code{saveSimList()}
+does not carry -- without which the \code{simList} cannot be run. Set \code{FALSE}
+to skip it when the \code{simList} is only going to be \emph{inspected}: reparsing
+dominates the cost of loading a lazily saved \code{simList} (on a 19-module
+simulation, ~7 s of a ~9.5 s load), and none of the objects need it.
+Lazy objects are unaffected either way -- both user objects and each
+module's \code{mod} objects are still bound as promises. What a
+\code{reparse = FALSE} \code{simList} lacks is the module code itself, so it cannot
+be passed to \code{\link[=spades]{spades()}}, and module \code{mod}/\code{Par} active bindings are absent.}
 
 \item{verbose}{Numeric, -1 silent (where possible), 0 being very quiet,
 1 showing more messaging, 2 being more messaging, etc.


### PR DESCRIPTION
`.reparseModules()` re-parses every module's source on load, restoring the functions `saveSimList()` doesn't carry. That's required to *run* a reloaded simList — and pure overhead when it's only going to be inspected. Once lazy saving removes the object reads, it's what's left.

Measured on a real 19-module simulation (a 4.6 GB run reloaded from a lazy save):

| | time |
|---|---|
| `reparse = TRUE` | 9.1 s |
| `reparse = FALSE` | **2.5 s** |

74% of the load. Both give the same 118 objects, all 118 still bound as **unforced promises**, `.modObjs` intact with all 19 module environments.

## Lazy binding does not depend on reparsing

The comment at the call site says `.attachLazyObjs()` runs after `.reparseModules()` so module environments exist. That ordering is about a module reaching its own `mod` at **run** time — not about binding the promises. `.attachLazyObjs()` reaches its target via `.lazyEnvFor()`, which creates `.modObjs[[module]]` itself when absent. Verified: with `reparse = FALSE`, `Biomass_core`'s `mod` objects are still present and still lazy.

## What you give up

The module code itself. A `reparse = FALSE` simList cannot be passed to `spades()`, and module `mod`/`Par` active bindings are absent. Documented on the argument.

Default stays `TRUE`, so nothing changes unless asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141xS4r9o76uEgTvzR8qdTP