### PR TITLE
feat(loadSimList): add `fetch` so lazy objects can live elsewhere

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## New features
 
+* `loadSimList()` gains `fetch`, letting a lazily saved `simList` keep its objects
+  somewhere other than a local directory. The function is called with the path of an
+  absent sidecar object and must place the bytes there; `$`, `[[` and `get()` are
+  unchanged, and an object is transferred only when something touches it.
 * `$`-completion on a lazily saved `simList` no longer materialises every object:
   a new `.DollarNames.simList` method supplies completion types so RStudio does
   not evaluate each member to choose an icon.

--- a/R/saveLoadSimList.R
+++ b/R/saveLoadSimList.R
@@ -455,6 +455,16 @@ zipSimList <- function(sim, zipfile, ..., outputs = TRUE, inputs = TRUE, cache =
 #'   module's `mod` objects are still bound as promises. What a
 #'   `parse = FALSE` `simList` lacks is the module code itself, so it cannot
 #'   be passed to [spades()], and module `mod`/`Par` active bindings are absent.
+#' @param fetch Optional function of one argument, used only for a lazily saved
+#'   `simList`. It is called with the path of a sidecar object that is not
+#'   present, and must place that object's bytes there; the promise then reads
+#'   it normally. This lets the objects live somewhere other than a local
+#'   directory -- for example fetched from remote storage on first access --
+#'   without changing how they are used: `$`, `[[` and [get()] behave exactly
+#'   as before, and each object is transferred only if something touches it.
+#'   Because `fetch` is called only when the file is absent, whatever it writes
+#'   also serves as the cache. Default `NULL`, i.e. read from `filename`'s
+#'   sibling `_lazy/` directory as usual.
 #' @param tempPath A character string specifying the new base directory for the
 #'   temporary paths maintained in a `simList`.
 #' @inheritParams reproducible::Cache
@@ -471,6 +481,7 @@ zipSimList <- function(sim, zipfile, ..., outputs = TRUE, inputs = TRUE, cache =
 #' @importFrom tools file_ext
 loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
                         paths = NULL, otherFiles = "", parse = TRUE,
+                        fetch = NULL,
                         verbose = getOption("reproducible.verbose")) {
   checkSimListExts(filename)
 
@@ -611,7 +622,7 @@ loadSimList <- function(filename, projectPath = getwd(), tempPath = tempdir(),
   ## bindings are already in place -- a module then reaches its `mod` object
   ## exactly as it would have before, and pays for it only on first access.
   if (isLazyLoad) {
-    tmpsim <- .attachLazyObjs(tmpsim, lazyDir, projectPath)
+    tmpsim <- .attachLazyObjs(tmpsim, lazyDir, projectPath, fetch = fetch)
   }
 
   return(tmpsim)
@@ -819,7 +830,12 @@ recoverDataTableFromQs <- function(sim) {
   }
 }
 
-.readOneLazy <- function(file) {
+.readOneLazy <- function(file, fetch = NULL) {
+  ## `fetch` lets the sidecar live somewhere other than a local directory: it is
+  ## called with the expected path and must put the bytes there. Because it is
+  ## only called when the file is absent, whatever it writes doubles as the
+  ## cache -- a second access to the same object is an ordinary local read.
+  if (!file.exists(file) && is.function(fetch)) fetch(file)
   if (identical(tolower(tools::file_ext(file)), "qs2")) {
     qs2::qs_read(file, nthreads = getOption("spades.qsThreads", 1))
   } else {
@@ -888,7 +904,7 @@ recoverDataTableFromQs <- function(sim) {
 ## Bind a promise per manifest row. The body matches what loadSimList() does for
 ## an eagerly loaded object -- remap file-backed paths, then unwrap -- so a lazy
 ## object is indistinguishable from an eager one once touched.
-.attachLazyObjs <- function(sim, dir, projectPath) {
+.attachLazyObjs <- function(sim, dir, projectPath, fetch = NULL) {
   mf <- file.path(dir, .lazyManifestName)
   if (!file.exists(mf)) return(sim)
 
@@ -901,8 +917,9 @@ recoverDataTableFromQs <- function(sim) {
       .nm <- ents$name[i]
       .pp <- projectPath
       .sp <- simPaths
+      .fetch <- fetch
       delayedAssign(.nm, tryCatch({
-        obj <- .readOneLazy(.f)
+        obj <- .readOneLazy(.f, fetch = .fetch)
         obj <- .remapFileBackedObj(obj, .pp, .sp)
         .unwrap(obj, cachePath = NULL, paths = .sp)
       }, error = function(e) {

--- a/man/loadSimList.Rd
+++ b/man/loadSimList.Rd
@@ -12,6 +12,7 @@ loadSimList(
   paths = NULL,
   otherFiles = "",
   parse = TRUE,
+  fetch = NULL,
   verbose = getOption("reproducible.verbose")
 )
 
@@ -47,6 +48,17 @@ Lazy objects are unaffected either way -- both user objects and each
 module's \code{mod} objects are still bound as promises. What a
 \code{parse = FALSE} \code{simList} lacks is the module code itself, so it cannot
 be passed to \code{\link[=spades]{spades()}}, and module \code{mod}/\code{Par} active bindings are absent.}
+
+\item{fetch}{Optional function of one argument, used only for a lazily saved
+\code{simList}. It is called with the path of a sidecar object that is not
+present, and must place that object's bytes there; the promise then reads
+it normally. This lets the objects live somewhere other than a local
+directory -- for example fetched from remote storage on first access --
+without changing how they are used: \code{$}, \code{[[} and \code{\link[=get]{get()}} behave exactly
+as before, and each object is transferred only if something touches it.
+Because \code{fetch} is called only when the file is absent, whatever it writes
+also serves as the cache. Default \code{NULL}, i.e. read from \code{filename}'s
+sibling \verb{_lazy/} directory as usual.}
 
 \item{verbose}{Numeric, -1 silent (where possible), 0 being very quiet,
 1 showing more messaging, 2 being more messaging, etc.

--- a/tests/testthat/test-saveLoadLazy.R
+++ b/tests/testthat/test-saveLoadLazy.R
@@ -325,3 +325,81 @@ test_that(".DollarNames.simList adds `types` only when something is lazy", {
   invisible(as.list(s@.xData))
   expect_null(attr(utils::.DollarNames(s, pattern = ""), "types"))
 })
+
+## ---------------------------------------------------------------------------
+## loadSimList(fetch = ): the sidecar objects need not be local. `fetch` is
+## called with the expected path when an object is absent and must put the
+## bytes there. The point is that nothing else changes -- `$`, `[[` and get()
+## behave as always, and an object is transferred only if something touches it.
+## ---------------------------------------------------------------------------
+
+test_that("fetch is called per object, only on access, and only once", {
+  skip_if_not_installed("rlang")
+  td <- normPath(withr::local_tempdir())
+  simPaths <- list(cachePath = td, inputPath = td, outputPath = td,
+                   modulePath = td, scratchPath = td, terraPath = td)
+  sim <- new("simList"); paths(sim) <- simPaths
+  sim@.xData[["aa"]] <- 1:5
+  sim@.xData[["bb"]] <- letters[1:3]
+  sim@.xData[["cc"]] <- list(z = 1)
+
+  filename <- file.path(td, "sim.rds")
+  suppressMessages(saveSimList(sim, filename = filename, lazy = TRUE))
+  lazyDir <- file.path(td, "sim_lazy")
+
+  ## move the objects out of reach, leaving only the manifest
+  store <- file.path(td, "store"); dir.create(store)
+  objs <- setdiff(dir(lazyDir), .lazyManifestName)
+  file.rename(file.path(lazyDir, objs), file.path(store, objs))
+  expect_identical(dir(lazyDir), .lazyManifestName)
+
+  seen <- character(0)
+  myFetch <- function(path) {
+    seen <<- c(seen, basename(path))
+    file.copy(file.path(store, basename(path)), path)
+  }
+
+  s <- suppressMessages(loadSimList(filename, fetch = myFetch))
+  ## binding promises must not fetch anything
+  expect_length(seen, 0L)
+  expect_true(all(rlang::env_binding_are_lazy(s@.xData, c("aa", "bb", "cc"))))
+
+  expect_identical(s$bb, letters[1:3])
+  expect_length(seen, 1L)                                   # exactly one object
+  expect_true(all(rlang::env_binding_are_lazy(s@.xData, c("aa", "cc"))))
+
+  ## whatever fetch wrote is the cache: a second access must not re-fetch
+  invisible(s$bb)
+  expect_length(seen, 1L)
+
+  expect_identical(s$aa, 1:5)
+  expect_length(seen, 2L)                                   # `cc` never touched
+})
+
+test_that("fetch defaults to NULL and local lazy loading is unchanged", {
+  skip_if_not_installed("rlang")
+  td <- normPath(withr::local_tempdir())
+  simPaths <- list(cachePath = td, inputPath = td, outputPath = td,
+                   modulePath = td, scratchPath = td, terraPath = td)
+  sim <- new("simList"); paths(sim) <- simPaths
+  sim@.xData[["aa"]] <- 1:5
+  filename <- file.path(td, "sim.rds")
+  suppressMessages(saveSimList(sim, filename = filename, lazy = TRUE))
+
+  s <- suppressMessages(loadSimList(filename))
+  expect_true(rlang::env_binding_are_lazy(s@.xData, "aa"))
+  expect_identical(s$aa, 1:5)
+})
+
+test_that(".readOneLazy only calls fetch when the file is missing", {
+  td <- normPath(withr::local_tempdir())
+  f <- file.path(td, "obj.rds"); saveRDS(1:3, f)
+  called <- FALSE
+  expect_identical(.readOneLazy(f, fetch = function(p) called <<- TRUE), 1:3)
+  expect_false(called)                       # present -> fetch not called
+
+  unlink(f)
+  got <- .readOneLazy(f, fetch = function(p) { called <<- TRUE; saveRDS(1:3, p) })
+  expect_true(called)
+  expect_identical(got, 1:3)
+})


### PR DESCRIPTION
A lazily saved `simList` reads each object from a sibling `_lazy/` directory. `fetch` makes that source pluggable: it's called with the path of an object that isn't present and must put the bytes there; the promise then reads it normally.

**The point is that nothing else changes.** `$`, `[[` and `get()` behave exactly as before — no new function to learn just to reach an object — and an object is transferred only if something touches it.

## The seam is one line

```r
.readOneLazy <- function(file, fetch = NULL) {
  if (!file.exists(file) && is.function(fetch)) fetch(file)
  ...
}
```

Because `fetch` is only called when the file is absent, **whatever it writes is the cache** — a second access is an ordinary local read, no extra bookkeeping.

Default `NULL`, so local lazy loading is untouched.

## Behaviour

```
after load    | fetched: 0            | lazy: TRUE,TRUE,TRUE
after s$bb    | fetched: 0002-bb.rds  | others still lazy: TRUE,TRUE
second access | extra fetches: 0      (cached)
total fetched: 2 of 3                 <- never-touched object never transferred
```

## Why

These sidecars can be pulled out of a tar on remote storage by HTTP range request. On one real simList, the summary modules consuming it need **16 of 139 objects — 51 MB of 2035 MB**; the 1.57 GB `cohortDataFactorial` is never read. With `fetch`, the other 98% never moves, and the analysis code is unchanged.

SpaDES.core stays free of any knowledge of the remote — the caller supplies the closure. The Drive side lives in SpaDES.project.

## Tests

Three added to `test-saveLoadLazy.R`: fetch called per object and only on access; the write doubling as cache so a second access doesn't re-fetch; `.readOneLazy()` not calling fetch when the file is present; and the `fetch = NULL` path unchanged. 57 assertions pass in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141xS4r9o76uEgTvzR8qdTP