### PR TITLE
fix(outputs): stop rewriting filenames that already name a real file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # SpaDES.core 3.2.1.9001 (development version)
 
+## Bug fixes
+
+* `outputs<-` no longer renames a file that `registerOutputs()` recorded, and no
+  longer treats the time unit appearing anywhere in a *path* as meaning the
+  filename is already time-stamped. Both left `outputs(sim)$file` naming files that
+  do not exist.
+
 ## New features
 
 * `loadSimList()` gains `fetch`, letting a lazily saved `simList` keep its objects

--- a/R/simList-accessors.R
+++ b/R/simList-accessors.R
@@ -1405,15 +1405,32 @@ setReplaceMethod(
        }
        sim@outputs[["file"]][wh] <- paste0(sim@outputs[["file"]][wh], ".", fe[wh])
 
-       ## If the file name already has a time unit on it,
-       ## i.e., passed explicitly by user, then don't postpend again
        txtTimeA <- paste0(attr(sim@outputs[["saveTime"]], "unit"))
        txtTimeB <- paddedFloatToChar(
          sim@outputs[["saveTime"]],
          ceiling(log10(end(sim, sim@simtimes[["timeunit"]]) + 1))
        )
+
+       ## Only stamp rows whose file WE are naming.
+       ##
+       ## A row with `saved = TRUE` came from registerOutputs(): the module has
+       ## already written that file, under a name it chose. Renaming it here
+       ## leaves outputs(sim)$file pointing at a file that does not exist, and
+       ## downstream code that greps those paths then silently finds nothing.
+       alreadyOnDisk <- sim@outputs[["saved"]] %in% TRUE
+
+       ## "already has a time unit on it" has to be a real test. This used to be
+       ## grepl(txtTimeA, file) -- a bare substring search over the WHOLE path --
+       ## which was wrong in both directions: a name like "burnSummary.csv" got
+       ## stamped even when the module had written it unstamped, while any path
+       ## with the unit somewhere in a *directory* (".../1991-2020_yearly/")
+       ## counted as stamped and was skipped. Match "_<unit><number>" at the end
+       ## of the basename, which is what this function actually appends.
+       bn <- tools::file_path_sans_ext(basename(as.character(sim@outputs$file)))
+       alreadyStamped <- grepl(paste0("_", txtTimeA, "[-0-9.]+$"), bn)
+
        # Add time unit and saveTime to filename, without stripping extension
-       wh <- !grepl(txtTimeA, sim@outputs$file)
+       wh <- !alreadyStamped & !alreadyOnDisk
        fns <- sim@outputs[["file"]][wh]
        sim@outputs[["file"]][wh] <- paste0(
          tools::file_path_sans_ext(fns),

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -459,3 +459,56 @@ test_that("registerOutputs", {
   expect_equal(NROW(outputs(sim)$file), 8)
   expect_true(all(file.exists(outputs(sim)$file)))
 })
+
+## ---------------------------------------------------------------------------
+## outputs<- appends "_<timeunit><saveTime>" to filenames it generates. Two ways
+## that used to go wrong, both silent:
+##
+##   * a row registered by registerOutputs() names a file the module has ALREADY
+##     written; renaming it left outputs(sim)$file pointing at nothing;
+##   * "already stamped?" was grepl(unit, file) over the WHOLE path, so any
+##     directory containing the unit (".../1991-2020_yearly/") suppressed the
+##     stamp, while a plain basename got stamped regardless.
+## ---------------------------------------------------------------------------
+
+test_that("outputs<- still stamps a filename it generates itself", {
+  td <- normPath(withr::local_tempdir())
+  sim <- suppressMessages(simInit(times = list(start = 0, end = 3020),
+                                  paths = list(outputPath = td)))
+  outputs(sim) <- data.frame(objectName = "cohortData", saveTime = 3020)
+  expect_identical(basename(outputs(sim)$file), "cohortData_year3020.rds")
+})
+
+test_that("outputs<- does not rename a file registerOutputs() already wrote", {
+  td <- normPath(withr::local_tempdir())
+  sim <- suppressMessages(simInit(times = list(start = 0, end = 3020),
+                                  paths = list(outputPath = td)))
+  f <- file.path(outputPath(sim), "fireSense_burnSummary.csv")
+  writeLines("a,b", f)
+  sim <- registerOutputs(f, sim)
+
+  ## the row must name the file that exists, not a synthesised one
+  expect_identical(basename(outputs(sim)$file), "fireSense_burnSummary.csv")
+  expect_true(all(file.exists(outputs(sim)$file)))
+})
+
+test_that("outputs<- does not double-stamp an already-stamped basename", {
+  td <- normPath(withr::local_tempdir())
+  sim <- suppressMessages(simInit(times = list(start = 0, end = 3020),
+                                  paths = list(outputPath = td)))
+  outputs(sim) <- data.frame(objectName = "burnMap", saveTime = 3020,
+                             file = file.path(td, "burnMap_year3020.tif"),
+                             fun = "writeRaster", package = "terra")
+  expect_identical(basename(outputs(sim)$file), "burnMap_year3020.tif")
+})
+
+test_that("the timeunit appearing in a DIRECTORY does not suppress the stamp", {
+  ## the old grepl(unit, <whole path>) test made this a false positive
+  td <- normPath(withr::local_tempdir())
+  d <- file.path(td, "1991-2020_yearly"); dir.create(d, recursive = TRUE)
+  sim <- suppressMessages(simInit(times = list(start = 0, end = 3020),
+                                  paths = list(outputPath = d)))
+  outputs(sim) <- data.frame(objectName = "cohortData", saveTime = 3020)
+  expect_true(grepl("year", dirname(outputs(sim)$file)))       # unit is in the dir
+  expect_identical(basename(outputs(sim)$file), "cohortData_year3020.rds")
+})


### PR DESCRIPTION
`outputs<-` appends `_<timeunit><saveTime>` to filenames. It did so in two cases where it shouldn't, and **both fail silently**: `outputs(sim)$file` ends up naming a file that doesn't exist, so downstream code grepping those paths just finds nothing.

## 1. It renamed files `registerOutputs()` had already written

A module that writes a file itself and then registers it is asserting *"this file exists, at this path"*:

```r
f_burnSummary <- file.path(outputPath(sim), "fireSense_burnSummary.csv")
data.table::fwrite(sim$burnSummary, file = f_burnSummary)
sim <- registerOutputs(f_burnSummary, sim)
```

The row came back as `fireSense_burnSummary_year3020.csv` — a file nothing ever wrote. Those rows carry `saved = TRUE` and are now left alone.

## 2. The "already stamped?" test was a substring search

```r
wh <- !grepl(txtTimeA, sim@outputs$file)     # txtTimeA is e.g. "year"
```

A bare search for the unit across the **whole path**, wrong in both directions:

| path | old | correct |
|---|---|---|
| `burnMap_year3020.tif` | skipped ✓ | skipped |
| `burnSummary.csv` | **stamped** ✗ | left alone (module wrote it plain) |
| `.../1991-2020_yearly/cohortData.rds` | **skipped** ✗ | stamped |

Now matches `_<unit><number>` at the end of the *basename* — which is exactly what this code appends.

## Found in the wild

In one real simList: **208 output rows, 27 naming files that were never written** — 2 `.csv` and 25 `.png`, every one a case where the module chose a plain name. The files were on disk under the names the modules used; only the bookkeeping was wrong. `burnSummaries.R:409` greps `outputs(sim)$file` for one of those `.csv` paths and silently found nothing.

## Verification

```
1. objectName, no file            -> cohortData_year3020.rds     (still stamped)
2. registerOutputs, saved=TRUE    -> fireSense_burnSummary.csv   (not renamed, exists)
3. basename already stamped       -> burnMap_year3020.tif        (not doubled)
4. unit in a DIRECTORY            -> cohortData_year3020.rds     (now stamped)
5. end-to-end spades()            -> recorded == on disk
```

Regression suite: `test-save.R`, `test-load.R`, `test-simList-accessors-sweep.R`, `test-saveLoadSimList.R`, `test-saveLoadLazy.R` — **190 pass, 0 fail**. Four new tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ovGxDFz633RChMs8gUoZn