### PR TITLE
ci(citation): run the CITATION.cff job on ubuntu instead of macOS (development)

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -18,7 +18,12 @@ name: Update CITATION.cff
 
 jobs:
   update-citation-cff:
-    runs-on: macos-latest
+    ## ubuntu, not macOS. The only R code in this job is cff_write(), but
+    ## setup-r-dependencies installs this package's full dependency tree, and
+    ## terra is an Import. On macOS that is a ~3GB Homebrew GDAL install for a
+    ## job whose output is one YAML file; stock noble apt is far cheaper for
+    ## exactly the same result.
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -26,7 +31,10 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+      ## @main, not a tag: every tag v0.1-v0.5 still adds the ubuntugis-unstable
+      ## PPA, which installs libgdal37 and is ABI-incompatible with the binaries
+      ## in Posit's noble cache. That line was inert on macOS; here it is not.
+      - uses: PredictiveEcology/actions/install-spatial-deps@main
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Moves the `Update CITATION.cff` job from `macos-latest` to `ubuntu-latest`.

### Why

The only R code in the job is `cff_write(keys = mykeys)`. `cffr` imports cli, desc, jsonlite, jsonvalidate, tools, utils and yaml — nothing spatial is ever loaded or called. (`V8` is in `extra-packages` for `jsonvalidate`, i.e. `validate = TRUE`.)

The geospatial stack arrives indirectly: `setup-r-dependencies` installs the package's full dependency tree, and `cff_write(dependencies = TRUE)` — the default — then emits a `references:` entry for each dependency **that happens to be installed**. From `cffr`'s `R/utils-create.R`:

```r
av_deps <- deps[deps$package %in% c("R", instpack), ]
```

Dependencies that are not installed are silently dropped, not errors. So the spatial packages are being built solely to populate a metadata list.

That list is real — `reproducible`'s current `CITATION.cff` carries 39 `references:` entries — so this PR does **not** remove it. It just stops paying macOS Homebrew prices for it: a ~3GB GDAL install on every `DESCRIPTION` push and every release, for a job whose output is one YAML file. Stock noble apt produces the identical file.

### Also in this PR

`install-spatial-deps` is repointed from `@v0.2` to `@main`. Every tag `v0.1`–`v0.5` still runs `add-apt-repository ppa:ubuntugis/ubuntugis-unstable`, which installs libgdal37 and is ABI-incompatible with the binaries in Posit's noble cache; only `@main` dropped it (PredictiveEcology/actions#25). That line was inert on a macOS runner. On ubuntu it is not, so the move makes the pin load-bearing.

### Not done here

`dependencies: "hard"` and `cff_write(dependencies = FALSE)` would both remove the spatial install entirely, but each changes the contents of `CITATION.cff`. Deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZoicL7829pkb5ZbS5Ciww