### PR TITLE
ci(citation): call the org reusable citation workflow

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -1,65 +1,29 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
-# The action runs when:
-# - A new release is published
-# - The DESCRIPTION or inst/CITATION are modified
-# - Can be run manually
-# For customizing the triggers, visit https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+## Thin caller -- the job itself lives in PredictiveEcology/actions.
+## https://github.com/PredictiveEcology/actions/blob/main/.github/workflows/citation.yaml
+##
+## Regenerates CITATION.cff when:
+## - a new release is published
+## - DESCRIPTION or inst/CITATION change on main
+## - run manually
+
+name: Update CITATION.cff
+
 on:
   release:
     types: [published]
   push:
-    branches: main
+    branches: [main]
     paths:
       - DESCRIPTION
       - inst/CITATION
   workflow_dispatch:
 
-name: Update CITATION.cff
-
 jobs:
-  update-citation-cff:
-    runs-on: macos-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          Ncpus: 2
-          r-version: 'release'
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::cffr
-            any::V8
-
-      - name: Update CITATION.cff
-        run: |
-
-          library(cffr)
-
-          # Customize with your own code
-          # See https://docs.ropensci.org/cffr/articles/cffr.html
-
-          # Write your own keys
-          mykeys <- list()
-
-          # Create your CITATION.cff file
-          cff_write(keys = mykeys)
-
-        shell: Rscript {0}
-
-      - name: Commit results
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CITATION.cff
-          git commit -m 'Update CITATION.cff' || echo "No changes to commit"
-          git push origin || echo "No changes to commit"
+  citation:
+    ## The called workflow splits `build` (contents: read, runs third-party R
+    ## code) from `commit` (contents: write, runs nothing but git). A called
+    ## workflow can only reduce what is granted here, so the write scope has to
+    ## be granted at the call site.
+    permissions:
+      contents: write
+    uses: PredictiveEcology/actions/.github/workflows/citation.yaml@main


### PR DESCRIPTION
Replaces the hand-rolled `Update CITATION.cff` job with a thin caller. **No overrides** — every default in the template suits this package.

This supersedes #430, which moved the same job to ubuntu by hand — the template does that and more.

### Why template this one

Four repos (`reproducible`, `SpaDES`, `SpaDES.core`, `SpaDES.tools`) carried near-identical copies of this job, and two things had gone per-repo that shouldn't have:

- **The `install-spatial-deps` pin.** A hand-rolled caller names that action directly, so the four had drifted to `@v0.1`, `@v0.2` and a raw SHA. Every tag `v0.1`–`v0.5` still adds the `ubuntugis-unstable` PPA (libgdal37), which is ABI-incompatible with the binaries in Posit's noble cache. The template reaches the action through `setup-r-deps`, so the pin is internal to `PredictiveEcology/actions` and moves once instead of in four PRs.
- **The privilege split.** Generating `CITATION.cff` installs and runs third-party R code; committing it needs a write-scoped token. The template runs those as separate jobs — `build` with `contents: read`, `commit` with `contents: write` and nothing but git. Until now only `SpaDES.tools` did this.

### Also dropped

- `master` from the push trigger — this repo has no `master` branch.
- the `setup-pandoc` step where present. `cff_write()` reads `DESCRIPTION` and `inst/CITATION` and writes YAML; nothing renders.

### Behaviour

Unchanged. The template still runs with `dependencies: "all"`, so `cff_write(dependencies = TRUE)` sees the same installed set and the generated `references:` list comes out the same.

### Ordering

**Blocked on PredictiveEcology/actions#35**, which adds the template. This PR will fail until that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZoicL7829pkb5ZbS5Ciww