### PR TITLE
ci(use_gha): emit a thin caller for the shared render-module-rmd workflow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # SpaDES.core 3.2.1.9001 (development version)
 
+## Continuous integration
+
+* `use_gha()` now writes a short workflow that calls the shared
+  `render-module-rmd` workflow in `PredictiveEcology/actions`, instead of a
+  77-line copy of the job itself. New modules therefore reference one thing that
+  can be updated centrally, rather than freezing four action versions into the
+  repository on the day it is created. A survey of the 74 module repositories
+  carrying the old file (PredictiveEcology/actions#36) found them split across
+  two generations that had drifted apart, pinning those actions at `v0`,
+  `v0.0.1` or `v0.2`; those pins are the main obstacle to retiring the old tags.
+  The shared workflow also fixes four things that were wrong in every generated
+  copy: the `[skip-ci]` guard read the oldest commit of a push and was absent
+  entirely on pull requests; there was no setting to cancel superseded runs; the
+  `apt-get` step had no update, retries or timeout; and the commit step ran on
+  pull requests, where it could not succeed and failed silently every time.
+
 ## Bug fixes
 
 * `outputs<-` no longer renames a file that `registerOutputs()` recorded, and no

--- a/inst/templates/render-module-rmd.yaml.template
+++ b/inst/templates/render-module-rmd.yaml.template
@@ -1,4 +1,13 @@
 {{=[[ ]]=}}
+## Thin caller. The job itself lives in PredictiveEcology/actions, so the pins
+## for install-spatial-deps, install-Require, install-SpaDES and install-Rmd-pkgs
+## live there too and move once, instead of being frozen into every module
+## repository on the day it was created.
+##
+## https://github.com/PredictiveEcology/actions/blob/main/.github/workflows/render-module-rmd.yaml
+
+name: Render module Rmd
+
 on:
   pull_request:
     branches:
@@ -14,64 +23,17 @@ on:
       - .github/workflows/render-module-rmd.yaml
       - [[name]].Rmd
       - [[name]].R
-
-name: Render module Rmd
+  workflow_dispatch:
 
 jobs:
-  render:
-    if: "!contains(github.event.commits[0].message, '[skip-ci]')"
-    name: Render module Rmd
-    runs-on: ubuntu-latest
-
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - name: Install other dependencies
-        run: |
-          sudo apt-get install -y \
-            libcurl4-openssl-dev \
-            libgit2-dev \
-            libglpk-dev \
-            libmagick++-dev \
-            libxml2-dev \
-            python3-gdal
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          Ncpus: 2
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-Rmd-pkgs@v0.2
-
-      - uses: PredictiveEcology/actions/install-Require@v0.2
-        with:
-          GitTag: 'development'
-
-      - uses: PredictiveEcology/actions/install-SpaDES@v0.2
-
-      - uses: PredictiveEcology/actions/install-Rmd-pkgs@v0.2
-
-      - name: Install module package dependencies
-        run: |
-          pkgs <- SpaDES.core::packages(modules = "[[name]]", paths = "..")[[1]]
-          Require::Require(pkgs[[1]])
-        shell: Rscript {0}
-
-      - name: Render module Rmd
-        run: |
-          rmarkdown::render("[[name]].Rmd", encoding = "UTF-8")
-        shell: Rscript {0}
-
-      - name: Commit results
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-          git commit [[name]].html -m 'Re-build [[name]].Rmd' || echo "No changes to commit"
-          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{github.ref}} || echo "No changes to commit"
+  render-module-rmd:
+    ## The called workflow splits `render` (contents: read, which installs and
+    ## then executes this module's own code) from `commit` (contents: write,
+    ## which runs nothing but git). A called workflow can only reduce what is
+    ## granted here, never widen it, so the write scope has to be granted at the
+    ## call site.
+    permissions:
+      contents: write
+    uses: PredictiveEcology/actions/.github/workflows/render-module-rmd.yaml@main
+    with:
+      module: [[name]]


### PR DESCRIPTION
Step 2 of PredictiveEcology/actions#36. Depends on PredictiveEcology/actions#37, which is merged.

`use_gha()` writes a **77-line copy** of the module render job into every new module. That copy is never regenerated, so whatever the template looked like on the day a module was created is what that module still has — including four pinned action versions.

This changes the template to emit **~28 lines** that call the shared workflow instead:

```yaml
jobs:
  render-module-rmd:
    permissions:
      contents: write
    uses: PredictiveEcology/actions/.github/workflows/render-module-rmd.yaml@main
    with:
      module: <moduleName>
```

### Why

The survey in PredictiveEcology/actions#36 found **74 module repositories** carrying this file across **96 repository/branch combinations**, frozen into two generations that had drifted apart:

| | combinations | shape |
| --- | --- | --- |
| older | 46 | `ubuntu-20.04`, `checkout@v2`, `setup-r@v1`, hand-written apt block |
| newer | 50 | `ubuntu-latest`, `checkout@v4`, four actions pinned at `@v0.2` / `@v0` / `@v0.0.1` |

Those pins are the main obstacle to retiring `v0.1`–`v0.5`, every one of which still adds the `ubuntugis-unstable` package repository — a version of GDAL incompatible with the R package binaries Posit builds.

### Bugs the shared workflow fixes

All four were in **every** generated copy:

- **`[skip-ci]` worked on neither event.** It read `github.event.commits[0].message` — `commits[0]` is the *oldest* commit in a push, so `[skip-ci]` on the tip was ignored; and `pull_request` payloads carry no `commits` field at all.
- **No `concurrency` setting**, so superseded runs were never cancelled.
- **The `apt-get` step had no `apt-get update`, no retries and no timeout.** This is the shape that left two LandWebUtils jobs sitting for 6h before being killed on 2026-08-19.
- **The commit step ran on `pull_request`**, where `github.ref` is `refs/pull/N/merge` and the push cannot succeed. It failed silently every time, swallowed by `|| echo "No changes to commit"`.

Rendering and committing are also now separate jobs, because rendering installs the module's whole dependency tree and then executes the module's own `.Rmd` — that should not share a job with a token that can push.

### One addition

`workflow_dispatch` is added to the triggers, matching the example caller merged in actions#37. The commit job is push-only, so a manual run renders without committing — handy for checking a module still builds.

### Testing

`tests/testthat/test-module-template.R:28-30` already asserts the generated file contains no unsubstituted `[[name]]`. I rendered the new template through `whisker::whisker.render(tpl, list(name = "myModule"))` and confirmed: no leftover placeholders, output parses as valid YAML, `module: myModule` and the `paths:` filter both substituted correctly. No test changes needed.

### Scope

This only affects **new** modules. The 74 existing repositories are step 3 of actions#36 and are unaffected by this PR — that is a separate, scriptable pass, and it is the step that actually frees the tags.

Worth doing before that bulk pass: point **one** module repository at the shared workflow by hand and let it run. The shared workflow has never executed — `self-test.yaml` cannot exercise a reusable workflow — so step 3 should not be the first time it runs on 74 repos at once.

### Open question carried over from actions#36

The old template called `install-Rmd-pkgs` **twice**, once before `install-Require` and once after `install-SpaDES`. I preserved that in the shared workflow rather than dropping something possibly load-bearing (installing SpaDES can move versions the first call settled). If you know that history and it is vestigial, say so and it is a one-line removal in `actions` — cheaper now than after 74 repositories inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZoicL7829pkb5ZbS5Ciww
